### PR TITLE
Make Travis-CI check indentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
     - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
     - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
     - BML_OPENMP=no  VERBOSE_MAKEFILE=yes COMMAND=docs
-    - BML_OPENMP=no  VERBOSE_MAKEFILE=yes COMMAND=indent
+    - BML_OPENMP=no  VERBOSE_MAKEFILE=yes COMMAND=check_indent
 
 before_script:
     - pip install codecov


### PR DESCRIPTION
The indentation of the .c and .h files should be verified by Travis-CI.
We used the command `indent` which simply indents all files instead of
the command `check_indent` which verifies that the indentation of those
files is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/92)
<!-- Reviewable:end -->
