### PR TITLE
bml_import does not copy M

### DIFF
--- a/src/Fortran-interface/bml_convert_m.F90
+++ b/src/Fortran-interface/bml_convert_m.F90
@@ -56,7 +56,7 @@ contains
       distrib_mode_ = bml_dmode_sequential
     endif
 
-    if(present(threshold)) then
+    if (present(threshold)) then
        threshold_ = threshold
     else
        threshold_ = 0
@@ -69,12 +69,12 @@ contains
         write(*, *) "missing parameter m; number of non-zeros per row"
         error stop
       end if
+    end if
+
+    if (present(m)) then
+      m_ = m
     else
-      if (present(m)) then
-        m_ = m
-      else
-        m_ = n_
-      end if
+      m_ = n_
     end if
 
     call bml_deallocate(a)
@@ -129,12 +129,12 @@ contains
         write(*, *) "missing parameter m; number of non-zeros per row"
         error stop
       end if
+    end if
+
+    if (present(m)) then
+      m_ = m
     else
-      if (present(m)) then
-        m_ = m
-      else
-        m_ = n_
-      end if
+      m_ = n_
     end if
 
     call bml_deallocate(a)
@@ -176,7 +176,7 @@ contains
       distrib_mode_ = bml_dmode_sequential
     endif
 
-    if(present(threshold)) then
+    if (present(threshold)) then
        threshold_ = threshold
     else
        threshold_ = 0
@@ -189,12 +189,12 @@ contains
         write(*, *) "missing parameter m; number of non-zeros per row"
         error stop
       end if
+    end if
+
+    if (present(m)) then
+      m_ = m
     else
-      if (present(m)) then
-        m_ = m
-      else
-        m_ = n_
-      end if
+      m_ = n_
     end if
 
     call bml_deallocate(a)
@@ -236,7 +236,7 @@ contains
       distrib_mode_ = bml_dmode_sequential
     endif
 
-    if(present(threshold)) then
+    if (present(threshold)) then
        threshold_ = threshold
     else
        threshold_ = 0
@@ -249,12 +249,12 @@ contains
         write(*, *) "missing parameter m; number of non-zeros per row"
         error stop
       end if
+    end if
+
+    if (present(m)) then
+      m_ = m
     else
-      if (present(m)) then
-        m_ = m
-      else
-        m_ = n_
-      end if
+      m_ = n_
     end if
 
     call bml_deallocate(a)


### PR DESCRIPTION
The code added in eb87291d7bcbc0b6c61b0a6f41ec22e07a92f025 is supposed
to insist on an M value for non-dense matrices and replace the default
of `m = 0` with `m = n`. However, due to incorrect logic this change
ended up setting `m` only for dense matrices and ignoring it otherwise.
The resulting bml matrix was incorrect.