### PR TITLE
Add missing bml_scale Fortran interfaces

### DIFF
--- a/src/Fortran-interface/bml_scale_m.F90
+++ b/src/Fortran-interface/bml_scale_m.F90
@@ -9,7 +9,10 @@ module bml_scale_m
 
   !> Scale a matrix.
   interface bml_scale
-     module procedure scale_one
+     module procedure scale_one_single_real
+     module procedure scale_one_double_real
+     module procedure scale_one_single_complex
+     module procedure scale_one_double_complex
      module procedure scale_two_single_real
      module procedure scale_two_double_real
      module procedure scale_two_single_complex
@@ -26,14 +29,59 @@ contains
   !!
   !! \param alpha The factor
   !! \param a The matrix
-  subroutine scale_one(alpha, a)
+  subroutine scale_one_single_real(alpha, a)
+
+    real(C_FLOAT), target, intent(in) :: alpha
+    type(bml_matrix_t), intent(inout) :: a
+
+    call bml_scale_inplace_C(c_loc(alpha), a%ptr)
+
+  end subroutine scale_one_single_real
+
+  !> Scale a bml matrix.
+  !!
+  !! \f$ A \leftarrow \alpha A \f$
+  !!
+  !! \param alpha The factor
+  !! \param a The matrix
+  subroutine scale_one_double_real(alpha, a)
 
     real(C_DOUBLE), target, intent(in) :: alpha
     type(bml_matrix_t), intent(inout) :: a
 
     call bml_scale_inplace_C(c_loc(alpha), a%ptr)
 
-  end subroutine scale_one
+  end subroutine scale_one_double_real
+
+  !> Scale a bml matrix.
+  !!
+  !! \f$ A \leftarrow \alpha A \f$
+  !!
+  !! \param alpha The factor
+  !! \param a The matrix
+  subroutine scale_one_single_complex(alpha, a)
+
+    complex(C_FLOAT_COMPLEX), target, intent(in) :: alpha
+    type(bml_matrix_t), intent(inout) :: a
+
+    call bml_scale_inplace_C(c_loc(alpha), a%ptr)
+
+  end subroutine scale_one_single_complex
+
+  !> Scale a bml matrix.
+  !!
+  !! \f$ A \leftarrow \alpha A \f$
+  !!
+  !! \param alpha The factor
+  !! \param a The matrix
+  subroutine scale_one_double_complex(alpha, a)
+
+    complex(C_DOUBLE_COMPLEX), target, intent(in) :: alpha
+    type(bml_matrix_t), intent(inout) :: a
+
+    call bml_scale_inplace_C(c_loc(alpha), a%ptr)
+
+  end subroutine scale_one_double_complex
 
   !> Scale a bml matrix.
   !!
@@ -49,8 +97,6 @@ contains
     real(C_FLOAT), target, intent(in) :: alpha
     type(bml_matrix_t), intent(in) :: a
     type(bml_matrix_t), intent(inout) :: c
-
-    integer :: prec_a, prec_c
 
     call bml_scale_C(c_loc(alpha), a%ptr, c%ptr)
 
@@ -71,8 +117,6 @@ contains
     type(bml_matrix_t), intent(in) :: a
     type(bml_matrix_t), intent(inout) :: c
 
-    integer :: prec_a, prec_c
-
     call bml_scale_C(c_loc(alpha), a%ptr, c%ptr)
 
   end subroutine scale_two_double_real
@@ -92,8 +136,6 @@ contains
     type(bml_matrix_t), intent(in) :: a
     type(bml_matrix_t), intent(inout) :: c
 
-    integer :: prec_a, prec_c
-
     call bml_scale_C(c_loc(alpha), a%ptr, c%ptr)
 
   end subroutine scale_two_single_complex
@@ -112,8 +154,6 @@ contains
     complex(C_DOUBLE_COMPLEX), target, intent(in) :: alpha
     type(bml_matrix_t), intent(in) :: a
     type(bml_matrix_t), intent(inout) :: c
-
-    integer :: prec_a, prec_c
 
     call bml_scale_C(c_loc(alpha), a%ptr, c%ptr)
 


### PR DESCRIPTION
With change b93a366260afdd0ac0b0be4a5970e51173c9b7ed type matching scale
factors where introduced to the `bml_scale` APIs. However, only the
`bml_scale_two` Fortran interface was adapted but not the
`bml_scale_one` interfaces. This change adds the necessary APIs.