### PR TITLE
Replace min/max reductions for <gcc-4.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,20 @@ addons:
             - cmake
             - cmake-data
             - doxygen
+            - g++-4.6
             - g++-4.7
             - g++-4.8
             - g++-4.9
             - g++-5
             - g++-6
+            - gcc-4.6
             - gcc-4.7
             - gcc-4.8
             - gcc-4.9
             - gcc-5
             - gcc-6
             - gfortran
+            - gfortran-4.6
             - gfortran-4.7
             - gfortran-4.8
             - gfortran-4.9
@@ -44,6 +47,8 @@ env:
     global:
         - secure: "W/BwWphH/Kc1JyF4ch94Egtb2ps2r8O44F1dm68gpYeD09dosgO7WnK4HPBMO7qAKpR+ZWvaPyFhokz+3ruE2ipl9SXFQ8ozJe9TjaEeY2TrkSembClnGdRgXUZXfXyLvvmvRhQ8I1OzwZ63k99PrKRYKiZUA7Pz2NMn8WrLlWBTxMtMkL4Kv8IPoJ7zA4FLhEfT/SUo9nB27/bHWWoCy/2CSyiMC4p1c1soJTIyPKB3BdlRvFhg3P1QZeHME6J4J8DFj+Yedc9n/WPcR4GdoUQfgDdbPe81CH4uV2z2HBi3x4TwHUCFwdDhBcElWBOpFtwnneVvNRdglEj65MNjtNSrShQOkhgPt8XpuITxaNAo03bC3yK8FXt2cRKvXDaOMrDK1J3W+nLOM5qga6XY/v7MvZV82Sxlhw3vPOkIHZdU6NJZAQ5Dl2gVnVxTOmOe8g5aNqQiaJqbRueAJwCgVnlHaB8QTP99T1d6kPbdXdJfIgucNoFmQVov9wgt+FrN/7WNrOiFFjecGiarcvuXUqzNb5V7b03acHHnrZZMBfueEyrWsGRq+fS/PmhIK2LzPlsbmq+qMwo69dO2jD7HHqMbqYQ/3hPq7z5hAKO1jOd/UI3QaGrmhLMeFWxqOt3qEYZcVmpjNc0cY70EDQpO9kkBTuTLe6C4li8+OTSk6dE="
     matrix:
+        - CC=gcc-4.6 CXX=g++-4.6 FC=gfortran-4.6 GCOV=gcov-4.6 BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
+        - CC=gcc-4.6 CXX=g++-4.6 FC=gfortran-4.6 GCOV=gcov-4.6 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
         - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
         - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
         - CC=gcc-4.8 CXX=g++-4.8 FC=gfortran-4.8 GCOV=gcov-4.8 BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing

--- a/examples/openmp_reductions/Makefile
+++ b/examples/openmp_reductions/Makefile
@@ -1,0 +1,2 @@
+min_max_reduction: openmp_min_max_reductions.c
+	$(CC) -fopenmp -O3 -o $@ $^

--- a/examples/openmp_reductions/openmp_min_max_reductions.c
+++ b/examples/openmp_reductions/openmp_min_max_reductions.c
@@ -1,0 +1,114 @@
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+long int get_reduction_old(const int max_n)
+{
+    long int emax = 0;
+
+    printf("using < OpenMP-3.1\n");
+
+    /* Start a parallel section. All threads are started.
+     */
+#pragma omp parallel
+    {
+        /* The thread local variable. This is used to find the max within the
+         * thread.
+         */
+        int _max = 0;
+
+#pragma omp master
+        printf("running on %d threads\n", omp_get_num_threads());
+
+        /* Run the for loop across the thread pool. The local max is updated
+         * appropriately per thread.
+         */
+#pragma omp for nowait
+        for(int i = 0; i < max_n; i++)
+        {
+            _max = i;
+        }
+
+        /* The 'critical' section specifies that only one thread at a time can
+         * enter it. We use it to update the global max. The 'nowait' clause
+         * in the for loop ensures that we don't block unecessarily already
+         * earlier on the for loop.
+         */
+#pragma omp critical
+        if (_max > emax)
+        {
+            emax = _max;
+        }
+    }
+
+    return emax;
+}
+
+long int get_reduction_new(const int max_n)
+{
+    long int emax = 0;
+
+    printf("using >= OpenMP-3.1\n");
+
+#pragma omp parallel
+    {
+#pragma omp master
+        printf("running on %d threads\n", omp_get_num_threads());
+    }
+
+#pragma omp parallel for reduction(max:emax)
+    for(int i = 0; i < max_n; i++)
+    {
+        emax = i;
+    }
+
+    return emax;
+}
+
+int main(int argc, char **argv)
+{
+    short use_max_reduction = 0;
+    long int emax;
+    long int max_n = 1000;
+
+    const char *shortopt = "nN:";
+    char ch;
+    while ((ch = getopt(argc, argv, shortopt)) != -1)
+    {
+        switch(ch)
+        {
+            case 'n':
+                use_max_reduction = 1;
+                break;
+
+            case 'N':
+                max_n = strtol(optarg, NULL, 10);
+                break;
+
+            default:
+                printf("error parsing command line\n");
+                return -1;
+                break;
+        }
+    }
+
+    if (use_max_reduction)
+    {
+        emax = get_reduction_new(max_n);
+    }
+    else
+    {
+        emax = get_reduction_old(max_n);
+    }
+
+    printf("emax = %ld\n", emax);
+
+    if (emax != max_n - 1)
+    {
+        printf("incorrect max reduction\n");
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -12,6 +12,7 @@
 #include "bml_types_dense.h"
 
 #include <complex.h>
+#include <float.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -63,8 +64,8 @@ void *TYPED_FUNC(
 
     int myRank = bml_getMyRank();
 
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 
@@ -137,8 +138,8 @@ void *TYPED_FUNC(
     int N = A->N;
     REAL_T *A_matrix = A->matrix;
 
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 

--- a/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
@@ -11,9 +11,10 @@
 #include "bml_types_ellpack.h"
 
 #include <complex.h>
+#include <float.h>
 #include <math.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _OPENMP
@@ -57,8 +58,9 @@ void *TYPED_FUNC(
     const bml_matrix_ellpack_t * A)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 
@@ -157,8 +159,9 @@ void *TYPED_FUNC(
     const int nrows)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 

--- a/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
@@ -78,55 +78,57 @@ void *TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#pragma omp parallel for default(none) \
+#pragma omp parallel \
+    default(none) \
     shared(N, M, A_nnz, A_index, A_value) \
     shared(A_localRowMin, A_localRowMax, myRank) \
     shared(rad, dval) \
-    private(absham, radius, dvalue) \
-    reduction(max:emax) \
-    reduction(min:emin)
-    //for (int i = 0; i < N; i++)
-    for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
+    shared(emin, emax) \
+    private(absham, radius, dvalue)
     {
-        radius = 0.0;
-        dvalue = 0.0;
+        double _emin = emin;
+        double _emax = emax;
 
-        for (int j = 0; j < A_nnz[i]; j++)
+#pragma omp for nowait
+        for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
         {
-            if (i == A_index[ROWMAJOR(i, j, N, M)])
-                dvalue = A_value[ROWMAJOR(i, j, N, M)];
-            else
+            radius = 0.0;
+            dvalue = 0.0;
+
+            for (int j = 0; j < A_nnz[i]; j++)
             {
-                absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
-                radius += (double) absham;
+                if (i == A_index[ROWMAJOR(i, j, N, M)])
+                    dvalue = A_value[ROWMAJOR(i, j, N, M)];
+                else
+                {
+                    absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
+                    radius += (double) absham;
+                }
+
             }
 
+            dval[i] = dvalue;
+            rad[i] = radius;
+
+            if (REAL_PART(dval[i] + rad[i]) > _emax)
+                _emax = REAL_PART(dval[i] + rad[i]);
+            if (REAL_PART(dval[i] - rad[i]) < _emin)
+                _emin = REAL_PART(dval[i] - rad[i]);
         }
 
-        dval[i] = dvalue;
-        rad[i] = radius;
+#pragma omp critical
+        {
+            if (_emax > emax)
+            {
+                emax = _emax;
+            }
 
-/*
-        emax =
-            (emax >
-             REAL_PART(dvalue + radius) ? emax : REAL_PART(dvalue + radius));
-        emin =
-            (emin <
-             REAL_PART(dvalue - radius) ? emin : REAL_PART(dvalue - radius));
-
-*/
+            if (_emin < emin)
+            {
+                emin = _emin;
+            }
+        }
     }
-    //for (int i = 0; i < N; i++)
-    for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
-    {
-        if (REAL_PART(dval[i] + rad[i]) > emax)
-            emax = REAL_PART(dval[i] + rad[i]);
-        if (REAL_PART(dval[i] - rad[i]) < emin)
-            emin = REAL_PART(dval[i] - rad[i]);
-
-    }
-
-    //printf("%d: emin = %e emax = %e\n", myRank, emin, emax);
 
 #ifdef DO_MPI
     if (bml_getNRanks() > 1 && A->distribution_mode == distributed)
@@ -138,8 +140,6 @@ void *TYPED_FUNC(
 
     eval[0] = emin;
     eval[1] = emax;
-
-    //printf("Global %d: emin = %e emax = %e\n", myRank, emin, emax);
 
     return eval;
 }
@@ -175,41 +175,55 @@ void *TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#pragma omp parallel for default(none) \
+#pragma omp parallel \
+    default(none) \
     shared(N, M, A_nnz, A_index, A_value) \
     shared(rad, dval) \
-    private(absham, radius, dvalue) \
-    reduction(max:emax) \
-    reduction(min:emin)
-    for (int i = 0; i < nrows; i++)
+    shared(emin, emax) \
+    private(absham, radius, dvalue)
     {
-        radius = 0.0;
-        dvalue = 0.0;
+        double _emin = emin;
+        double _emax = emax;
 
-        for (int j = 0; j < A_nnz[i]; j++)
+#pragma omp for nowait
+        for (int i = 0; i < nrows; i++)
         {
-            if (i == A_index[ROWMAJOR(i, j, N, M)])
-                dvalue = A_value[ROWMAJOR(i, j, N, M)];
-            else
+            radius = 0.0;
+            dvalue = 0.0;
+
+            for (int j = 0; j < A_nnz[i]; j++)
             {
-                absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
-                radius += (double) absham;
+                if (i == A_index[ROWMAJOR(i, j, N, M)])
+                    dvalue = A_value[ROWMAJOR(i, j, N, M)];
+                else
+                {
+                    absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
+                    radius += (double) absham;
+                }
+
             }
 
+            dval[i] = dvalue;
+            rad[i] = radius;
+
+            if (REAL_PART(dval[i] + rad[i]) > _emax)
+                _emax = REAL_PART(dval[i] + rad[i]);
+            if (REAL_PART(dval[i] - rad[i]) < _emin)
+                _emin = REAL_PART(dval[i] - rad[i]);
         }
 
-        dval[i] = dvalue;
-        rad[i] = radius;
+#pragma omp critical
+        {
+            if (_emax > emax)
+            {
+                emax = _emax;
+            }
 
-    }
-
-    for (int i = 0; i < nrows; i++)
-    {
-        if (REAL_PART(dval[i] + rad[i]) > emax)
-            emax = REAL_PART(dval[i] + rad[i]);
-        if (REAL_PART(dval[i] - rad[i]) < emin)
-            emin = REAL_PART(dval[i] - rad[i]);
-
+            if (_emin < emin)
+            {
+                emin = _emin;
+            }
+        }
     }
 
     eval[0] = emin;

--- a/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
@@ -78,55 +78,57 @@ void *TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#pragma omp parallel for default(none) \
+#pragma omp parallel \
+    default(none) \
     shared(N, M, A_nnz, A_index, A_value) \
     shared(A_localRowMin, A_localRowMax, myRank) \
     shared(rad, dval) \
-    private(absham, radius, dvalue) \
-    reduction(max:emax) \
-    reduction(min:emin)
-    //for (int i = 0; i < N; i++)
-    for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
+    shared(emin, emax) \
+    private(absham, radius, dvalue)
     {
-        radius = 0.0;
-        dvalue = 0.0;
+        double _emin = emin;
+        double _emax = emax;
 
-        for (int j = 0; j < A_nnz[i]; j++)
+#pragma omp for nowait
+        for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
         {
-            if (i == A_index[ROWMAJOR(i, j, N, M)])
-                dvalue = A_value[ROWMAJOR(i, j, N, M)];
-            else
+            radius = 0.0;
+            dvalue = 0.0;
+
+            for (int j = 0; j < A_nnz[i]; j++)
             {
-                absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
-                radius += (double) absham;
+                if (i == A_index[ROWMAJOR(i, j, N, M)])
+                    dvalue = A_value[ROWMAJOR(i, j, N, M)];
+                else
+                {
+                    absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
+                    radius += (double) absham;
+                }
+
             }
 
+            dval[i] = dvalue;
+            rad[i] = radius;
+
+            if (REAL_PART(dval[i] + rad[i]) > _emax)
+                _emax = REAL_PART(dval[i] + rad[i]);
+            if (REAL_PART(dval[i] - rad[i]) < _emin)
+                _emin = REAL_PART(dval[i] - rad[i]);
         }
 
-        dval[i] = dvalue;
-        rad[i] = radius;
+#pragma omp critical
+        {
+            if (_emax > emax)
+            {
+                emax = _emax;
+            }
 
-/*
-        emax =
-            (emax >
-             REAL_PART(dvalue + radius) ? emax : REAL_PART(dvalue + radius));
-        emin =
-            (emin <
-             REAL_PART(dvalue - radius) ? emin : REAL_PART(dvalue - radius));
-
-*/
+            if (_emin < emin)
+            {
+                emin = _emin;
+            }
+        }
     }
-    //for (int i = 0; i < N; i++)
-    for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
-    {
-        if (REAL_PART(dval[i] + rad[i]) > emax)
-            emax = REAL_PART(dval[i] + rad[i]);
-        if (REAL_PART(dval[i] - rad[i]) < emin)
-            emin = REAL_PART(dval[i] - rad[i]);
-
-    }
-
-    //printf("%d: emin = %e emax = %e\n", myRank, emin, emax);
 
 #ifdef DO_MPI
     if (bml_getNRanks() > 1 && A->distribution_mode == distributed)
@@ -173,41 +175,55 @@ void *TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#pragma omp parallel for default(none) \
+#pragma omp parallel \
+    default(none) \
     shared(N, M, A_nnz, A_index, A_value) \
     shared(rad, dval) \
-    private(absham, radius, dvalue) \
-    reduction(max:emax) \
-    reduction(min:emin)
-    for (int i = 0; i < nrows; i++)
+    shared(emin, emax) \
+    private(absham, radius, dvalue)
     {
-        radius = 0.0;
-        dvalue = 0.0;
+        double _emin = emin;
+        double _emax = emax;
 
-        for (int j = 0; j < A_nnz[i]; j++)
+#pragma omp for nowait
+        for (int i = 0; i < nrows; i++)
         {
-            if (i == A_index[ROWMAJOR(i, j, N, M)])
-                dvalue = A_value[ROWMAJOR(i, j, N, M)];
-            else
+            radius = 0.0;
+            dvalue = 0.0;
+
+            for (int j = 0; j < A_nnz[i]; j++)
             {
-                absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
-                radius += (double) absham;
+                if (i == A_index[ROWMAJOR(i, j, N, M)])
+                    dvalue = A_value[ROWMAJOR(i, j, N, M)];
+                else
+                {
+                    absham = ABS(A_value[ROWMAJOR(i, j, N, M)]);
+                    radius += (double) absham;
+                }
+
             }
 
+            dval[i] = dvalue;
+            rad[i] = radius;
+
+            if (REAL_PART(dval[i] + rad[i]) > _emax)
+                _emax = REAL_PART(dval[i] + rad[i]);
+            if (REAL_PART(dval[i] - rad[i]) < _emin)
+                _emin = REAL_PART(dval[i] - rad[i]);
         }
 
-        dval[i] = dvalue;
-        rad[i] = radius;
+#pragma omp critical
+        {
+            if (_emax > emax)
+            {
+                emax = _emax;
+            }
 
-    }
-
-    for (int i = 0; i < nrows; i++)
-    {
-        if (REAL_PART(dval[i] + rad[i]) > emax)
-            emax = REAL_PART(dval[i] + rad[i]);
-        if (REAL_PART(dval[i] - rad[i]) < emin)
-            emin = REAL_PART(dval[i] - rad[i]);
-
+            if (_emin < emin)
+            {
+                emin = _emin;
+            }
+        }
     }
 
     eval[0] = emin;

--- a/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
@@ -11,9 +11,10 @@
 #include "bml_types_ellsort.h"
 
 #include <complex.h>
+#include <float.h>
 #include <math.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _OPENMP
@@ -57,8 +58,9 @@ void *TYPED_FUNC(
     const bml_matrix_ellsort_t * A)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 
@@ -155,8 +157,9 @@ void *TYPED_FUNC(
     const int nrows)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 


### PR DESCRIPTION
The min/max reductions in C/C++ were added to the OpenMP standard in
OpenMP 3.1 which is available in >=gcc-4.7. In order to support earlier
compilers we have to replace all occurrences of min/max reduction
clauses with an appropriate alternative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/103)
<!-- Reviewable:end -->
