### PR TITLE
Use appropriate values for initial min/max

### DIFF
--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -12,6 +12,7 @@
 #include "bml_types_dense.h"
 
 #include <complex.h>
+#include <float.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -63,8 +64,8 @@ void *TYPED_FUNC(
 
     int myRank = bml_getMyRank();
 
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 
@@ -137,8 +138,8 @@ void *TYPED_FUNC(
     int N = A->N;
     REAL_T *A_matrix = A->matrix;
 
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 

--- a/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
@@ -11,9 +11,10 @@
 #include "bml_types_ellpack.h"
 
 #include <complex.h>
+#include <float.h>
 #include <math.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _OPENMP
@@ -57,8 +58,9 @@ void *TYPED_FUNC(
     const bml_matrix_ellpack_t * A)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 
@@ -157,8 +159,9 @@ void *TYPED_FUNC(
     const int nrows)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 

--- a/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
@@ -11,9 +11,10 @@
 #include "bml_types_ellsort.h"
 
 #include <complex.h>
+#include <float.h>
 #include <math.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _OPENMP
@@ -57,8 +58,9 @@ void *TYPED_FUNC(
     const bml_matrix_ellsort_t * A)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 
@@ -155,8 +157,9 @@ void *TYPED_FUNC(
     const int nrows)
 {
     REAL_T radius, absham, dvalue;
-    double emin = 100000000000.0;
-    double emax = -100000000000.0;
+
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
 
     double *eval = bml_allocate_memory(sizeof(double) * 2);
 


### PR DESCRIPTION
Using a finite value to initialize min/max variables has the
disadvantage that any value might be too small or too large. Instead, we
should use the type dependent representable min/max value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/108)
<!-- Reviewable:end -->
