### PR TITLE
Restrict build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,12 @@ before_install:
 
 script:
     - >
-        OMP_NUM_THREADS=4 CMAKE_BUILD_TYPE=Debug
-        VERBOSE_MAKEFILE=yes ./build.sh ${COMMAND}
+        if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then \
+            OMP_NUM_THREADS=4 \
+            CMAKE_BUILD_TYPE=Debug \
+            VERBOSE_MAKEFILE=yes \
+            ./build.sh ${COMMAND}; \
+        fi
 
 after_success:
     - codecov --gcov-exec ${GCOV}


### PR DESCRIPTION
On the `coverty_scan` branch we don't need to run the usual build steps.
This change disables them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/118)
<!-- Reviewable:end -->
