### PR TITLE
Fix the doc target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ if(DOXYGEN_FOUND)
       ${CMAKE_SOURCE_DIR}/src/Fortran-interface)
   endif()
   string(REPLACE ";" " " DOXYGEN_INPUT "${DOXYGEN_INPUT}")
-  configure_file(docs/Doxyfile.in Doxyfile)
+  configure_file(documentation/Doxyfile.in Doxyfile)
   add_custom_target(docs
     COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile)
 else()


### PR DESCRIPTION
The CMake script broke in 050250de8f14077291dc22b9a41092be95c6f22b. This
commit fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/119)
<!-- Reviewable:end -->
