### PR TITLE
Fix uninitialized string

### DIFF
--- a/src/C-interface/ellpack/bml_utilities_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_utilities_ellpack_typed.c
@@ -50,7 +50,7 @@ void TYPED_FUNC(
         LOG_ERROR("read error\n");
     }
 
-    char *FMT;
+    char *FMT = "";
     switch (A->matrix_precision)
     {
         case single_real:


### PR DESCRIPTION
The `FMT` string is unitialized. While the code should never reach a
point where it uses `FMT` in this state, it's safer to just initialize
it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/124)
<!-- Reviewable:end -->
