### PR TITLE
Print out coverty log files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,4 @@ script:
 after_success:
     - codecov --gcov-exec ${GCOV}
     - coveralls
+    - if [ "${COVERITY_SCAN_BRANCH}" = "1" ]; then ls -lh cov-int; echo "build-log.txt"; cat cov-int/build-log.txt; echo "scm_log.txt"; cat cov-int/scm_log.txt; echo "done"; fi


### PR DESCRIPTION
For debugging coverty issues it could be useful to know the contents of
the coverty log files. Since storing of build artifacts requires a more
complicated Travis-CI setup with S3 backed storage, a simple work around
is to print the contents of the log files so that their content is
visible in the build logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/130)
<!-- Reviewable:end -->
