### PR TITLE
Run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,15 @@ env:
         # via the "travis encrypt" command using the project repo's public
         # key.
         - secure: "itC06I482XliT7b2yyoit5eWHdbIa/Wpp+cNIsZElMnWhUyBHCuKiLQHLgyovlhCR6UsL7ISDdyxxNz4Kn7Os1EdPhQ1Q+P+8vZf8pROK1LBIZLrTWM7npea3ydo3PCdpgJdr9qHAEvXhBG9mshmrBgJLdmDuNtJ7yFn2l8nLegCnmsdExkjN1ZbprRutPd9OH6iIu9C8lPAiYR1bcDEPm+fgF3VnE2JFztYvkUt+PBiwIveVFlwAQRjrBqvvF/fk2TqFmD97KFDQ6stdr6MzUmQ1m05arololkLp+y6aQxWYbwug66vorAHma+axXJClkd1Rmt/K7kyRBhRUOwE9CKKnHKL9lKYKvfyv5e7HDasg60PACErfBR1/SIyNOWATIV8KCyejn4qI8Q+QjyYGlIM3D2oUCIhIgy/FPnmb6IWGJmqE7Y2kk6BAYZv0PIXLWrffuht7L2qJnl1FI4nVsej9Kf71zJfhxfa2XY9vuFm40ldOMF0DuSOc5KNKHuIGliLhBFKws91cYqz2GnIJV2SU0Ut0ICJ935R9qz+vKE8dGlyV80RIR9+ILVCOOh/XRu5Ljb2fAT+NvlBfG5of3PwiEzQLZPHM0vtZD0wDd9N39GInYe510DwzRRPVfYpbXYSDhISEUugB4F7ASjsVNrJ7kbgZFMwU17YSe+i5DI="
+        - COVERTY_JOB_NUMBER: 1
+        - COVERAGE_JOB_NUMBER: 4
     matrix:
-        # The first entry will be run by the coverty scan.
+        # 1. entry will be run by the coverty scan.
         - BML_OPENMP=no VERBOSE_MAKEFILE=yes COMMAND=check_indent
         - BML_OPENMP=no VERBOSE_MAKEFILE=yes COMMAND=docs
         - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
-        - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
+        # 4. entry will be analyzed by coverage tools.
+        - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes  COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=yes COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
@@ -54,22 +57,22 @@ env:
 before_install:
     # If this is a coverty scan which is not the first matrix job we will exit
     # early to avoid spending unnecessary CI resources.
-    - if [ "${TRAVIS_BRANCH}" = "coverty_scan" -a "${TRAVIS_JOB_NUMBER##*.}" != "1" ]; then exit 0; fi
+    - if [ "${TRAVIS_BRANCH}" = "coverty_scan" -a "${TRAVIS_JOB_NUMBER##*.}" != "${COVERTY_JOB_NUMBER}" ]; then exit 0; fi
     - if [ "${TRAVIS_BRANCH}" = "coverty_scan" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-; fi
-    - pip install cpp-coveralls
+    - if [ "${TRAVIS_JOB_NUMBER##*.}" = "${COVERAGE_JOB_NUMBER}" ]; then pip install cpp-coveralls; fi
+    - if [ "${TRAVIS_JOB_NUMBER##*.}" = "${COVERAGE_JOB_NUMBER}" ]; then pip install codecov; fi
 
 before_script:
     - bundle install
     - bundle exec danger
-    - pip install codecov
 
 script:
     - export OMP_NUM_THREADS=4
     - export CMAKE_BUILD_TYPE=Debug
     - export VERBOSE_MAKEFILE=yes
     - export PARALLEL_TEST_JOBS=2
-    - if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then ./build.sh ${COMMAND}; fi
+    - if [ "${COVERITY_SCAN_BRANCH}" != "${COVERTY_JOB_NUMBER}" ]; then ./build.sh ${COMMAND}; fi
 
 after_success:
-    - codecov --gcov-exec ${GCOV}
-    - coveralls
+    - if [ "${TRAVIS_JOB_NUMBER##*.}" = "${COVERAGE_JOB_NUMBER}" ]; then codecov --gcov-exec ${GCOV}; fi
+    - if [ "${TRAVIS_JOB_NUMBER##*.}" = "${COVERAGE_JOB_NUMBER}" ]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ script:
     - export OMP_NUM_THREADS=4
     - export CMAKE_BUILD_TYPE=Debug
     - export VERBOSE_MAKEFILE=yes
+    - export PARALLEL_TEST_JOBS=2
     - if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then ./build.sh ${COMMAND}; fi
 
 after_success:

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ TOP_DIR="$(readlink --canonicalize-existing $(dirname "$0"))"
 : ${INSTALL_DIR:=${TOP_DIR}/install}
 LOG_FILE="${TOP_DIR}/build.log"
 : ${VERBOSE_MAKEFILE:=no}
+: ${PARALLEL_TEST_JOBS:=1}
 
 help() {
     cat <<EOF
@@ -43,6 +44,7 @@ EOF
     echo "INSTALL_DIR        Path to install dir      (default is ${INSTALL_DIR})"
     echo "EXTRA_CFLAGS       Extra C flags            (default is '${EXTRA_CFLAGS}')"
     echo "EXTRA_FCFLAGS      Extra fortran flags      (default is '${EXTRA_FCFLAGS}')"
+    echo "PARALLEL_TEST_JOBS The number of test jobs  (default is ${PARALLEL_TEST_JOBS})"
 }
 
 set_defaults() {
@@ -146,7 +148,7 @@ install() {
 
 testing() {
     cd "${BUILD_DIR}"
-    ctest --output-on-failure 2>&1 | tee -a "${LOG_FILE}"
+    ctest --output-on-failure --parallel ${PARALLEL_TEST_JOBS} 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
     cd "${TOP_DIR}"
 }


### PR DESCRIPTION
This change introduces a new option to `build.sh` to set the number of
parallel test jobs to run. We leverage this option on Travis-CI to speed
up testing since we get 2 VCPUs per VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/132)
<!-- Reviewable:end -->
