### PR TITLE
Restrict coverty scan with Travis-CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,36 +34,41 @@ addons:
 env:
     global:
         # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-        #   via the "travis encrypt" command using the project repo's public key
+        # via the "travis encrypt" command using the project repo's public
+        # key.
         - secure: "itC06I482XliT7b2yyoit5eWHdbIa/Wpp+cNIsZElMnWhUyBHCuKiLQHLgyovlhCR6UsL7ISDdyxxNz4Kn7Os1EdPhQ1Q+P+8vZf8pROK1LBIZLrTWM7npea3ydo3PCdpgJdr9qHAEvXhBG9mshmrBgJLdmDuNtJ7yFn2l8nLegCnmsdExkjN1ZbprRutPd9OH6iIu9C8lPAiYR1bcDEPm+fgF3VnE2JFztYvkUt+PBiwIveVFlwAQRjrBqvvF/fk2TqFmD97KFDQ6stdr6MzUmQ1m05arololkLp+y6aQxWYbwug66vorAHma+axXJClkd1Rmt/K7kyRBhRUOwE9CKKnHKL9lKYKvfyv5e7HDasg60PACErfBR1/SIyNOWATIV8KCyejn4qI8Q+QjyYGlIM3D2oUCIhIgy/FPnmb6IWGJmqE7Y2kk6BAYZv0PIXLWrffuht7L2qJnl1FI4nVsej9Kf71zJfhxfa2XY9vuFm40ldOMF0DuSOc5KNKHuIGliLhBFKws91cYqz2GnIJV2SU0Ut0ICJ935R9qz+vKE8dGlyV80RIR9+ILVCOOh/XRu5Ljb2fAT+NvlBfG5of3PwiEzQLZPHM0vtZD0wDd9N39GInYe510DwzRRPVfYpbXYSDhISEUugB4F7ASjsVNrJ7kbgZFMwU17YSe+i5DI="
     matrix:
+        # The first entry will be run by the coverty scan.
+        - BML_OPENMP=no VERBOSE_MAKEFILE=yes COMMAND=check_indent
+        - BML_OPENMP=no VERBOSE_MAKEFILE=yes COMMAND=docs
         - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
         - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
-        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
-        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
-        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=yes COMMAND=testing
-        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
+        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=yes COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=no  BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
-        - BML_OPENMP=no  VERBOSE_MAKEFILE=yes COMMAND=docs
-        - BML_OPENMP=no  VERBOSE_MAKEFILE=yes COMMAND=check_indent
+        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
+        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=yes COMMAND=testing
+        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
+        - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes COMMAND=testing
+
+before_install:
+    # If this is a coverty scan which is not the first matrix job we will exit
+    # early to avoid spending unnecessary CI resources.
+    - if [ "${TRAVIS_BRANCH}" = "coverty_scan" -a "${TRAVIS_JOB_NUMBER##*.}" != "1" ]; then exit 0; fi
+    - if [ "${TRAVIS_BRANCH}" = "coverty_scan" ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-; fi
+    - pip install cpp-coveralls
 
 before_script:
     - bundle install
     - bundle exec danger
     - pip install codecov
 
-before_install:
-    - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-    - pip install cpp-coveralls
-
 script:
     - export OMP_NUM_THREADS=4
     - export CMAKE_BUILD_TYPE=Debug
     - export VERBOSE_MAKEFILE=yes
-    - if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then ./build.sh ${COMMAND}; else echo "skipping script"; fi
+    - if [ "${COVERITY_SCAN_BRANCH}" != "1" ]; then ./build.sh ${COMMAND}; fi
 
 after_success:
     - codecov --gcov-exec ${GCOV}
     - coveralls
-    - if [ "${COVERITY_SCAN_BRANCH}" = "1" ]; then ls -lh cov-int; echo "build-log.txt"; cat cov-int/build-log.txt; echo "scm_log.txt"; cat cov-int/scm_log.txt; echo "done"; fi


### PR DESCRIPTION
When running coverty scan the Travis-CI build matrix causes the scan to
run for every element of the matrix. This is unnecessary. This change
leverages the environment variables `COVERITY_SCAN_BRANCH` and
`TRAVIS_JOB_NUMBER` to determine whether a coverty scan is run and to
restrict a coverty scan to the first element of the build matrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/133)
<!-- Reviewable:end -->
