### PR TITLE
Install coveralls and codecov as user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: precise
 
 addons:
     coverity_scan:


### PR DESCRIPTION
Before we can switch to trusty on Travis-CI, the coverage tools need to
be installed with the `--user` flag (see documentation of coveralls).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/136)
<!-- Reviewable:end -->
