### PR TITLE
Explicitly Including mpi.h

### DIFF
--- a/src/C-interface/bml_parallel.h
+++ b/src/C-interface/bml_parallel.h
@@ -14,6 +14,7 @@
 #endif
 
 #ifdef DO_MPI
+#include <mpi.h>
 extern MPI_Comm ccomm;
 #endif
 


### PR DESCRIPTION
Explicitly including mpi.h in bml_parallel.h due to issues with spack
build and dependencies

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/142)
<!-- Reviewable:end -->
