### PR TITLE
Add an include-guard for <omp.h> in bml_allocate.c

### DIFF
--- a/src/C-interface/bml_allocate.c
+++ b/src/C-interface/bml_allocate.c
@@ -74,7 +74,11 @@ bml_allocate_memory(
     else
     {
         void *ptr = malloc(size);
+#ifdef _OPENMP
         int nt = omp_get_num_threads();
+#else
+        int nt = 1;
+#endif
         int step = size / nt;
         int maxi = step * (nt - 1);
         int r = size - maxi;

--- a/src/C-interface/bml_allocate.c
+++ b/src/C-interface/bml_allocate.c
@@ -12,7 +12,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 /** Check if matrix is allocated.
  *


### PR DESCRIPTION
Does what is says ~on the tin~ in the title. Should fix issue #144.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/149)
<!-- Reviewable:end -->
