### PR TITLE
Use correct OpenMP flags for Fortran API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
             - ubuntu-toolchain-r-test
             - george-edison55-precise-backports
         packages:
+            - clang
             - cmake
             - cmake-data
             - doxygen
@@ -55,6 +56,10 @@ env:
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=yes COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
         - CC=gcc-6   CXX=g++-6   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes COMMAND=testing
+        - CC=clang   CXX=clang   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=no  COMMAND=testing
+        - CC=clang   CXX=clang   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=yes COMMAND=testing
+        - CC=clang   CXX=clang   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no  COMMAND=testing
+        - CC=clang   CXX=clang   FC=gfortran-6   GCOV=gcov-6   BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes COMMAND=testing
 
 before_install:
     # If this is a coverty scan which is not the first matrix job we will exit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ if(BML_OPENMP)
         "not the case, please send email to <nbock@lanl.gov>.")
       set(OpenMP_Fortran_FLAGS ${OpenMP_C_FLAGS})
     endif()
+    if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+      list(APPEND LINK_LIBRARIES "-latomic")
+    endif()
   else()
     message(WARNING "Could not get the compilers to use OpenMP. "
       "Will pretend that this never happened and compile the library "


### PR DESCRIPTION
The OpenMP detection of CMake detects language specific compiler
flags, i.e. it sets separate C and Fortran OpenMP flags. We were using
the C flags for the Fortran API which breaks the build if the C and
Fortran compilers are different (e.g. clang and gfortran).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/150)
<!-- Reviewable:end -->
