### PR TITLE
Split Fortran from C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,14 +437,16 @@ else()
   add_custom_target(dist)
 endif()
 
-string(REPLACE ";" " " LINKLINE "${LINK_LIBRARIES}")
-string(STRIP "${LINKLINE}" LINKLINE)
-message(STATUS "Use '${LINKLINE}' when linking the bml library")
+message(STATUS "When building executables with the bml library, please use the following link flags")
 
 if(OPENMP_FOUND)
   message(STATUS "Additional Fortran compiler link flags: '${OpenMP_Fortran_FLAGS}'")
   message(STATUS "Additional C compiler link flags: '${OpenMP_C_FLAGS}'")
 endif()
+
+string(REPLACE ";" " " LINKLINE "${LINK_LIBRARIES}")
+string(STRIP "${LINKLINE}" LINKLINE)
+message(STATUS "Link flags: '${LINKLINE}'")
 
 configure_file(src/bml.pc.in bml.pc)
 install(FILES ${CMAKE_BINARY_DIR}/bml.pc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,19 +22,19 @@ add_library(bml
   $<TARGET_OBJECTS:bml-ellsort-double_real>
   $<TARGET_OBJECTS:bml-ellsort-single_complex>
   $<TARGET_OBJECTS:bml-ellsort-single_real>
-  $<TARGET_OBJECTS:bml-ellsort>
-  $<TARGET_OBJECTS:bml-fortran>)
+  $<TARGET_OBJECTS:bml-ellsort>)
 set_target_properties(bml
   PROPERTIES
   SOVERSION ${PROJECT_VERSION}
   POSITION_INDEPENDENT_CODE yes)
-if(OPENMP_FOUND)
-  set_target_properties(bml
-    PROPERTIES
-    LINK_FLAGS ${OpenMP_Fortran_FLAGS})
-endif()
-target_link_libraries(bml ${LINK_LIBRARIES})
 
-install(TARGETS bml
+add_library(bml_fortran
+  $<TARGET_OBJECTS:bml-fortran>)
+set_target_properties(bml_fortran
+  PROPERTIES
+  SOVERSION ${PROJECT_VERSION}
+  POSITION_INDEPENDENT_CODE yes)
+
+install(TARGETS bml bml_fortran
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,7 +121,16 @@ foreach(N
 endforeach()
 
 add_executable(test-backtrace test_backtrace.c)
-target_link_libraries(test-backtrace bml)
+target_link_libraries(test-backtrace bml ${LINK_LIBRARIES})
+set_target_properties(test-backtrace
+  PROPERTIES
+  LINK_FLAGS "--coverage")
+if(OPENMP_FOUND)
+  set_target_properties(test-backtrace
+    PROPERTIES
+    COMPILE_FLAGS ${OpenMP_C_FLAGS}
+    LINK_FLAGS ${OpenMP_C_FLAGS})
+endif()
 add_test(backtrace test-backtrace)
 if(ADDR2LINE)
   set_tests_properties(backtrace


### PR DESCRIPTION
The Fortran API potentially requires some additional link time
dependencies which are unnecessary for C applications but need to be
added to the C linker arguments. This change splits the Fortran code
into a separate library.

Fixes: #143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/160)
<!-- Reviewable:end -->
