### PR TITLE
Add includes to fix building with NOBLAS

### DIFF
--- a/src/C-interface/bml_logger.h
+++ b/src/C-interface/bml_logger.h
@@ -20,6 +20,18 @@ typedef enum
     BML_LOG_ERROR
 } bml_log_level_t;
 
+void bml_log(
+    const bml_log_level_t log_level,
+    const char *format,
+    ...);
+
+void bml_log_location(
+    const bml_log_level_t log_level,
+    const char *filename,
+    const int linenumber,
+    const char *format,
+    ...);
+
 /** Convenience macro to write a BML_LOG_DEBUG level message. */
 #define LOG_DEBUG(format, ...) \
     bml_log_location(BML_LOG_DEBUG, __FILE__, __LINE__, format, ##__VA_ARGS__)
@@ -32,17 +44,5 @@ typedef enum
 /** Convenience macro to write a BML_LOG_ERROR level message. */
 #define LOG_ERROR(format, ...) \
     bml_log_location(BML_LOG_ERROR, __FILE__, __LINE__, format, ##__VA_ARGS__)
-
-void bml_log(
-    const bml_log_level_t log_level,
-    const char *format,
-    ...);
-
-void bml_log_location(
-    const bml_log_level_t log_level,
-    const char *filename,
-    const int linenumber,
-    const char *format,
-    ...);
 
 #endif

--- a/src/C-interface/dense/bml_scale_dense_typed.c
+++ b/src/C-interface/dense/bml_scale_dense_typed.c
@@ -1,12 +1,13 @@
 #include "../typed.h"
 #include "../blas.h"
 #include "bml_allocate.h"
-#include "bml_scale.h"
-#include "bml_parallel.h"
-#include "bml_types.h"
 #include "bml_allocate_dense.h"
 #include "bml_copy_dense.h"
+#include "bml_logger.h"
+#include "bml_parallel.h"
+#include "bml_scale.h"
 #include "bml_scale_dense.h"
+#include "bml_types.h"
 #include "bml_types_dense.h"
 
 #include <complex.h>

--- a/src/C-interface/ellpack/bml_scale_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_scale_ellpack_typed.c
@@ -1,12 +1,13 @@
 #include "../typed.h"
 #include "../blas.h"
 #include "bml_allocate.h"
-#include "bml_scale.h"
-#include "bml_parallel.h"
-#include "bml_types.h"
 #include "bml_allocate_ellpack.h"
 #include "bml_copy_ellpack.h"
+#include "bml_logger.h"
+#include "bml_parallel.h"
+#include "bml_scale.h"
 #include "bml_scale_ellpack.h"
+#include "bml_types.h"
 #include "bml_types_ellpack.h"
 
 #include <stdlib.h>

--- a/src/C-interface/ellsort/bml_scale_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_scale_ellsort_typed.c
@@ -1,12 +1,13 @@
 #include "../typed.h"
 #include "../blas.h"
 #include "bml_allocate.h"
-#include "bml_scale.h"
-#include "bml_parallel.h"
-#include "bml_types.h"
 #include "bml_allocate_ellsort.h"
 #include "bml_copy_ellsort.h"
+#include "bml_logger.h"
+#include "bml_parallel.h"
+#include "bml_scale.h"
 #include "bml_scale_ellsort.h"
+#include "bml_types.h"
 #include "bml_types_ellsort.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
When setting `BLAS_VENDOR=None` the build fails because some sources
do not include `bml_logger.h` for the `LOG_ERROR` macro. This change
adds an include to these sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/162)
<!-- Reviewable:end -->
