### PR TITLE
Add Fortran library to linker flags

### DIFF
--- a/src/bml.pc.in
+++ b/src/bml.pc.in
@@ -6,4 +6,4 @@ Name: bml
 Description: The basic matrix library
 Version: @PROJECT_VERSION@
 Cflags: -I@CMAKE_INSTALL_FULL_INCLUDEDIR@
-Libs: -L@CMAKE_INSTALL_FULL_LIBDIR@ -lbml @LINKLINE@
+Libs: -L@CMAKE_INSTALL_FULL_LIBDIR@ -lbml_fortran -lbml @LINKLINE@


### PR DESCRIPTION
Since we split the library into two, the linker flags advertised in
the pkg file need to be updated and the new `libbml_fortran` library
added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/164)
<!-- Reviewable:end -->
