### PR TITLE
Enable CI testing on OS X

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,6 +45,39 @@ jobs:
       - name: Build docs
         run: ./build.sh --debug docs
 
+  build_osx:
+    name: Build and test the library on OS-X Server (${{ matrix.JOBNAME }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - JOBNAME: gcc-11 C single real
+            TEST_SCRIPT: ./scripts/ci-gcc-11-C-single-real.sh
+          - JOBNAME: gcc-11 C double real
+            TEST_SCRIPT: ./scripts/ci-gcc-11-C-double-real.sh
+          - JOBNAME: gcc-11 C single complex
+            TEST_SCRIPT: ./scripts/ci-gcc-11-C-single-complex.sh
+          - JOBNAME: gcc-11 C double complex
+            TEST_SCRIPT: ./scripts/ci-gcc-11-C-double-complex.sh
+          - JOBNAME: gcc-11 Fortran single real
+            TEST_SCRIPT: ./scripts/ci-gcc-11-Fortran-single-real.sh
+          - JOBNAME: gcc-11 Fortran double real
+            TEST_SCRIPT: ./scripts/ci-gcc-11-Fortran-double-real.sh
+          - JOBNAME: gcc-11 Fortran single complex
+            TEST_SCRIPT: ./scripts/ci-gcc-11-Fortran-single-complex.sh
+          - JOBNAME: gcc-11 Fortran double complex
+            TEST_SCRIPT: ./scripts/ci-gcc-11-Fortran-double-complex.sh
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v2
+      - name: Prepare container
+        run: ./scripts/prepare-container-macos.sh
+      - name: Build and test library
+        env:
+          TEST_SCRIPT: ${{ matrix.TEST_SCRIPT || env.TEST_SCRIPT }}
+        run: ${TEST_SCRIPT} testing
+
   build:
     name: Build and test the library (${{ matrix.JOBNAME }})
     runs-on: ubuntu-18.04

--- a/build.sh
+++ b/build.sh
@@ -227,18 +227,18 @@ configure() {
         -DCUDA_TOOLKIT_ROOT_DIR="${CUDA_TOOLKIT_ROOT_DIR}" \
         -DINTEL_OPT="${INTEL_OPT:=no}" \
         ${CMAKE_ARGS} \
-        | tee --append "${LOG_FILE}"
+        | tee -a "${LOG_FILE}"
     check_pipe_error
     cd "${TOP_DIR}"
 }
 
 compile() {
-    ${CMAKE} --build "${BUILD_DIR}" | tee --append "${LOG_FILE}"
+    ${CMAKE} --build "${BUILD_DIR}" | tee -a "${LOG_FILE}"
     check_pipe_error
 }
 
 docs() {
-    ${CMAKE} --build "${BUILD_DIR}" --target docs 2>&1 | tee --append "${LOG_FILE}"
+    ${CMAKE} --build "${BUILD_DIR}" --target docs 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
     #make -C "${BUILD_DIR}/doc/latex" 2>&1 | tee -a "${LOG_FILE}"
     #check_pipe_error
@@ -248,7 +248,7 @@ docs() {
 }
 
 install() {
-    ${CMAKE} --build "${BUILD_DIR}" --target install 2>&1 | tee --append "${LOG_FILE}"
+    ${CMAKE} --build "${BUILD_DIR}" --target install 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
 }
 
@@ -257,7 +257,7 @@ testing() {
     ctest --verbose \
         --parallel ${PARALLEL_TEST_JOBS} \
         ${TESTING_EXTRA_ARGS} \
-        2>&1 | tee --append "${LOG_FILE}"
+        2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
 
     # Get skipped tests and re-run them with verbose output.
@@ -271,7 +271,7 @@ testing() {
             ctest --verbose \
                 ${TESTING_EXTRA_ARGS} \
                 --tests-regex "${skipped}" \
-                2>&1 | tee --append "${LOG_FILE}"
+                2>&1 | tee -a "${LOG_FILE}"
         done
     fi
     cd "${TOP_DIR}"
@@ -279,17 +279,17 @@ testing() {
 
 check_indent() {
     cd "${TOP_DIR}"
-    "${TOP_DIR}/scripts/indent.sh" 2>&1 | tee --append "${LOG_FILE}"
+    "${TOP_DIR}/scripts/indent.sh" 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
 }
 
 tags() {
-    "${TOP_DIR}/scripts/update_tags.sh" 2>&1 | tee --append "${LOG_FILE}"
+    "${TOP_DIR}/scripts/update_tags.sh" 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
 }
 
 dist() {
-    ${CMAKE} --build "${BUILD_DIR}" --target dist 2>&1 | tee --append "${LOG_FILE}"
+    ${CMAKE} --build "${BUILD_DIR}" --target dist 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
 }
 
@@ -299,7 +299,7 @@ set_defaults
 
 if [[ -n ${BLA_VENDOR} ]]; then
     if [[ -n ${BLAS_VENDOR} ]]; then
-        echo "WARNING: BLAS_VENDOR (${BLAS_VENDOR}) will be used instead of BLA_VENDOR (${BLA_VENDOR})" | tee --append "${LOG_FILE}"
+        echo "WARNING: BLAS_VENDOR (${BLAS_VENDOR}) will be used instead of BLA_VENDOR (${BLA_VENDOR})" | tee -a "${LOG_FILE}"
     else
         BLAS_VENDOR=${BLA_VENDOR}
     fi

--- a/scripts/ci-gcc-11-C-double-complex.sh
+++ b/scripts/ci-gcc-11-C-double-complex.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-C-double-real.sh
+++ b/scripts/ci-gcc-11-C-double-real.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-C-single-complex.sh
+++ b/scripts/ci-gcc-11-C-single-complex.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-C-single-real.sh
+++ b/scripts/ci-gcc-11-C-single-real.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-Fortran-double-complex.sh
+++ b/scripts/ci-gcc-11-Fortran-double-complex.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-Fortran-double-real.sh
+++ b/scripts/ci-gcc-11-Fortran-double-real.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-Fortran-single-complex.sh
+++ b/scripts/ci-gcc-11-Fortran-single-complex.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/ci-gcc-11-Fortran-single-real.sh
+++ b/scripts/ci-gcc-11-Fortran-single-real.sh
@@ -2,7 +2,13 @@
 
 set -e -u -x
 
-basedir=$(readlink --canonicalize $(dirname $0)/..)
+for READLINK in readlink greadlink; do
+    if ${READLINK} --canonicalize ${HOME}; then
+        break
+    fi
+done
+
+basedir=$(${READLINK} --canonicalize $(dirname $0)/..)
 
 export CC=${CC:-gcc-11}
 export CXX=${CXX:-g++-11}

--- a/scripts/prepare-container-macos.sh
+++ b/scripts/prepare-container-macos.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -u -x
+
+SUDO=$(which sudo || true)
+
+brew install coreutils


### PR DESCRIPTION
We keep running into issues only seen on OS X systems. Since Travis-CI
offers OS X based tests, we can leverage it to fix our OS X build
issues. This change enables testing on OS X.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/172)
<!-- Reviewable:end -->
