### PR TITLE
Fix order of `bml_shutdown()` in test driver

### DIFF
--- a/tests/bml_test.c
+++ b/tests/bml_test.c
@@ -153,6 +153,7 @@ main(
     int M = -1;
     char *test = NULL;
     int test_index = -1;
+    int test_result;
     bml_matrix_type_t matrix_type = dense;
     bml_matrix_precision_t precision = single_real;
 
@@ -278,7 +279,9 @@ main(
     fprintf(stderr, "N = %d\n", N);
     free(test);
 
+    test_result = testers[test_index] (N, matrix_type, precision, M);
+
     bml_shutdown();
 
-    return testers[test_index] (N, matrix_type, precision, M);
+    return test_result;
 }


### PR DESCRIPTION
We can't shut down the bml before we call the test function (which
will use bml functions). Instead we should store the test result, shut
down the bml and then return the result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/211)
<!-- Reviewable:end -->
