### PR TITLE
Removed pragma omp for random allocation of matrices.

### DIFF
--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -102,6 +102,9 @@ bml_matrix_dense_t *TYPED_FUNC(
  *  \param N The matrix size.
  *  \param distrib_mode The distribution mode.
  *  \return The matrix.
+ *
+ *  Note: Do not use OpenMP when setting values for a random matrix,
+ *  this makes the operation non-repeatable.
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_random_matrix_dense) (
@@ -111,7 +114,6 @@ bml_matrix_dense_t *TYPED_FUNC(
     bml_matrix_dense_t *A =
         TYPED_FUNC(bml_zero_matrix_dense) (N, distrib_mode);
     REAL_T *A_dense = A->matrix;
-#pragma omp parallel for default(none) shared(A_dense)
     for (int i = 0; i < N; i++)
     {
         for (int j = 0; j < N; j++)

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -163,6 +163,9 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  *  \param M The number of non-zeroes per row.
  *  \param distrib_mode The distribution mode.
  *  \return The matrix.
+ *
+ *  Note: Do not use OpenMP when setting values for a random matrix,
+ *  this makes the operation non-repeatable.
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_random_matrix_ellpack) (
@@ -177,7 +180,6 @@ bml_matrix_ellpack_t *TYPED_FUNC(
     int *A_index = A->index;
     int *A_nnz = A->nnz;
 
-#pragma omp parallel for default(none) shared(A_value, A_index, A_nnz)
     for (int i = 0; i < N; i++)
     {
         int jind = 0;

--- a/src/C-interface/ellsort/bml_allocate_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_allocate_ellsort_typed.c
@@ -163,6 +163,9 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  *  \param M The number of non-zeroes per row.
  *  \param distrib_mode The distribution mode.
  *  \return The matrix.
+ *
+ *  Note: Do not use OpenMP when setting values for a random matrix,
+ *  this makes the operation non-repeatable.
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_random_matrix_ellsort) (
@@ -177,7 +180,6 @@ bml_matrix_ellsort_t *TYPED_FUNC(
     int *A_index = A->index;
     int *A_nnz = A->nnz;
 
-#pragma omp parallel for default(none) shared(A_value, A_index, A_nnz)
     for (int i = 0; i < N; i++)
     {
         int jind = 0;


### PR DESCRIPTION
Removed pragma omp for random allocation of matrices. Now the results are repeatable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/216)
<!-- Reviewable:end -->
