### PR TITLE
Only test on build for memory leaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - CMAKE_BUILD_TYPE=Debug
     - VERBOSE_MAKEFILE=yes
     - PARALLEL_TEST_JOBS=2
-    - DEVEL_PACKAGES="cmake cmake-data valgrind libblas-dev liblapack-dev"
+    - DEVEL_PACKAGES="cmake cmake-data libblas-dev liblapack-dev"
 
 addons:
   apt:
@@ -38,7 +38,7 @@ jobs:
         - env CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 GCOV=gcov-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes ./build.sh testing
     - stage: test-full
       script:
-        - env packages="${DEVEL_PACKAGES} gcc-6 g++-6 gfortran-6" ./install_packages.sh
+        - env packages="${DEVEL_PACKAGES} valgrind gcc-6 g++-6 gfortran-6" ./install_packages.sh
         - env CC=gcc-6 CXX=g++-6 FC=gfortran-6 GCOV=gcov-6 BUILD_SHARED_LIBS=no BML_OPENMP=no BML_INTERNAL_BLAS=no ./build.sh testing
     - script:
         - env packages="${DEVEL_PACKAGES} gcc-6 g++-6 gfortran-6" ./install_packages.sh


### PR DESCRIPTION
It is not necessary to test all builds for memory leaks with
valgrind. Assuming that the compiler does not introduce leaks, one
tested job tells us already what we want to know: Whether the code is
leaking memory or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/224)
<!-- Reviewable:end -->
