### PR TITLE
Run only coverty_scan stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,14 @@ addons:
         branch_pattern: coverty_scan
 
 stages:
-  - linter
-  - test-simple
-  - test-full
-  - coverage
+  - name: linter
+    if: branch != coverty_scan
+  - name: test-simple
+    if: branch != coverty_scan
+  - name: test-full
+    if: branch != coverty_scan
+  - name: coverage
+    if: branch != coverty_scan
   - name: docs
     if: branch = master
   - name: coverty


### PR DESCRIPTION
It is not necessary to run the other build stages on the
`coverty_scan` branch. It is tracking the `master` branch which we
will assume is green.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/230)
<!-- Reviewable:end -->
