### PR TITLE
Bux fix in memory allocation for MAGMA matrices

### DIFF
--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -73,6 +73,8 @@ bml_matrix_dense_t *TYPED_FUNC(
     magma_int_t ret = MAGMA(malloc) ((MAGMA_T **) & A->matrix,
                                      A->ld * matrix_dimension.N_rows);
     assert(ret == MAGMA_SUCCESS);
+
+    bml_clear_dense(A);
 #else
     A->ld = matrix_dimension.N_rows;
     A->matrix =


### PR DESCRIPTION
MAGMA matrices memory allocation was not set to 0 in some cases, which was not consistent with non-MAGMA based dense format. It also lead to test failures on Summit@OLCF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/243)
<!-- Reviewable:end -->
