### PR TITLE
Add new format 'ellblock'

### DIFF
--- a/src/C-interface/CMakeLists.txt
+++ b/src/C-interface/CMakeLists.txt
@@ -85,4 +85,5 @@ endif()
 
 add_subdirectory(dense)
 add_subdirectory(ellpack)
+add_subdirectory(ellblock)
 add_subdirectory(ellsort)

--- a/src/C-interface/bml_add.c
+++ b/src/C-interface/bml_add.c
@@ -4,6 +4,7 @@
 #include "dense/bml_add_dense.h"
 #include "ellpack/bml_add_ellpack.h"
 #include "ellsort/bml_add_ellsort.h"
+#include "ellblock/bml_add_ellblock.h"
 
 #include <stdlib.h>
 
@@ -37,6 +38,9 @@ bml_add(
             break;
         case ellsort:
             bml_add_ellsort(A, B, alpha, beta, threshold);
+            break;
+        case ellblock:
+            bml_add_ellblock(A, B, alpha, beta, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -74,6 +78,9 @@ bml_add_norm(
         case ellpack:
             return bml_add_norm_ellpack(A, B, alpha, beta, threshold);
             break;
+        case ellblock:
+            return bml_add_norm_ellblock(A, B, alpha, beta, threshold);
+            break;
         case ellsort:
             return bml_add_norm_ellsort(A, B, alpha, beta, threshold);
             break;
@@ -107,6 +114,9 @@ bml_add_identity(
             break;
         case ellpack:
             bml_add_identity_ellpack(A, beta, threshold);
+            break;
+        case ellblock:
+            bml_add_identity_ellblock(A, beta, threshold);
             break;
         case ellsort:
             bml_add_identity_ellsort(A, beta, threshold);
@@ -142,6 +152,9 @@ bml_scale_add_identity(
             break;
         case ellpack:
             bml_scale_add_identity_ellpack(A, alpha, beta, threshold);
+            break;
+        case ellblock:
+            bml_scale_add_identity_ellblock(A, alpha, beta, threshold);
             break;
         case ellsort:
             bml_scale_add_identity_ellsort(A, alpha, beta, threshold);

--- a/src/C-interface/bml_adjungate_triangle.c
+++ b/src/C-interface/bml_adjungate_triangle.c
@@ -27,6 +27,10 @@ bml_adjungate_triangle(
         case ellpack:
             bml_adjungate_triangle_ellpack(A, triangle);
             break;
+        case ellblock:
+            LOG_ERROR
+                ("bml_adjungate_triangle function is not implemented for ellblock\n");
+            break;
         default:
             LOG_ERROR("unknown matrix type in bml_adjungate_triangle\n");
             break;

--- a/src/C-interface/bml_allocate.c
+++ b/src/C-interface/bml_allocate.c
@@ -4,6 +4,7 @@
 #include "bml_parallel.h"
 #include "dense/bml_allocate_dense.h"
 #include "ellpack/bml_allocate_ellpack.h"
+#include "ellblock/bml_allocate_ellblock.h"
 #include "ellsort/bml_allocate_ellsort.h"
 
 #include <errno.h>
@@ -128,6 +129,9 @@ bml_deallocate(
             case ellsort:
                 bml_deallocate_ellsort(*A);
                 break;
+            case ellblock:
+                bml_deallocate_ellblock(*A);
+                break;
             default:
                 LOG_ERROR("unknown matrix type (%d)\n", bml_get_type(*A));
                 break;
@@ -175,6 +179,9 @@ bml_clear(
         case ellsort:
             bml_clear_ellsort(A);
             break;
+        case ellblock:
+            bml_clear_ellblock(A);
+            break;
         default:
             LOG_ERROR("unknown matrix type (%d)\n", bml_get_type(A));
             break;
@@ -217,8 +224,49 @@ bml_noinit_rectangular_matrix(
             return bml_noinit_matrix_ellsort(matrix_precision,
                                              matrix_dimension, distrib_mode);
             break;
+        case ellblock:
+            return bml_noinit_matrix_ellblock(matrix_precision,
+                                              matrix_dimension, distrib_mode);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
+            break;
+    }
+    return NULL;
+}
+
+/** Allocate a block matrix
+ *
+ * \param matrix_type The matrix type.
+ * \param matrix_precision The precision of the matrix.
+ * \param NB The number of blocks in a row.
+ * \param bsizes The sizes of each block
+ * \param MB The number of non-zeroes blocks per row.
+ * \param distrib_mode The distribution mode.
+ * \return The matrix.
+ */
+bml_matrix_t *
+bml_block_matrix(
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode)
+{
+    LOG_DEBUG("block matrix with %d blocks\n", NB);
+    switch (matrix_type)
+    {
+        case ellpack:
+            return bml_block_matrix_ellblock(matrix_precision,
+                                             NB, MB, bsizes, distrib_mode);
+            break;
+        case ellblock:
+            return bml_block_matrix_ellblock(matrix_precision,
+                                             NB, MB, bsizes, distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unsupported matrix type (type ID %d)\n", matrix_type);
             break;
     }
     return NULL;
@@ -289,6 +337,10 @@ bml_zero_matrix(
             return bml_zero_matrix_ellsort(matrix_precision, N, M,
                                            distrib_mode);
             break;
+        case ellblock:
+            return bml_zero_matrix_ellblock(matrix_precision, N, M,
+                                            distrib_mode);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -331,6 +383,10 @@ bml_random_matrix(
         case ellsort:
             return bml_random_matrix_ellsort(matrix_precision, N, M,
                                              distrib_mode);
+            break;
+        case ellblock:
+            return bml_random_matrix_ellblock(matrix_precision, N, M,
+                                              distrib_mode);
             break;
         default:
             LOG_ERROR("unknown matrix type (type ID %d)\n", matrix_type);
@@ -419,6 +475,10 @@ bml_identity_matrix(
         case ellsort:
             return bml_identity_matrix_ellsort(matrix_precision, N, M,
                                                distrib_mode);
+            break;
+        case ellblock:
+            return bml_identity_matrix_ellblock(matrix_precision, N, M,
+                                                distrib_mode);
             break;
         default:
             LOG_ERROR("unknown matrix type (type ID %d)\n", matrix_type);

--- a/src/C-interface/bml_convert.c
+++ b/src/C-interface/bml_convert.c
@@ -3,6 +3,7 @@
 #include "dense/bml_convert_dense.h"
 #include "ellpack/bml_convert_ellpack.h"
 #include "ellsort/bml_convert_ellsort.h"
+#include "ellblock/bml_convert_ellblock.h"
 
 #include <stdlib.h>
 
@@ -31,6 +32,9 @@ bml_convert(
             break;
         case ellsort:
             return bml_convert_ellsort(A, matrix_precision, M, distrib_mode);
+            break;
+        case ellblock:
+            return bml_convert_ellblock(A, matrix_precision, M, distrib_mode);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_copy.c
+++ b/src/C-interface/bml_copy.c
@@ -6,6 +6,7 @@
 #include "dense/bml_copy_dense.h"
 #include "ellpack/bml_copy_ellpack.h"
 #include "ellsort/bml_copy_ellsort.h"
+#include "ellblock/bml_copy_ellblock.h"
 
 #include <assert.h>
 #include <stdlib.h>
@@ -34,6 +35,9 @@ bml_copy_new(
             break;
         case ellsort:
             B = bml_copy_ellsort_new(A);
+            break;
+        case ellblock:
+            B = bml_copy_ellblock_new(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -82,6 +86,9 @@ bml_copy(
         case ellsort:
             bml_copy_ellsort(A, B);
             break;
+        case ellblock:
+            bml_copy_ellblock(A, B);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -110,6 +117,9 @@ bml_reorder(
             break;
         case ellsort:
             bml_reorder_ellsort(A, perm);
+            break;
+        case ellblock:
+            bml_reorder_ellblock(A, perm);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_diagonalize.c
+++ b/src/C-interface/bml_diagonalize.c
@@ -5,6 +5,7 @@
 #include "bml_types.h"
 #include "dense/bml_diagonalize_dense.h"
 #include "ellpack/bml_diagonalize_ellpack.h"
+#include "ellblock/bml_diagonalize_ellblock.h"
 
 void
 bml_diagonalize(
@@ -22,6 +23,9 @@ bml_diagonalize(
             break;
         case ellsort:
             LOG_ERROR("diagonalize routine is not implemented for ellsort\n");
+            break;
+        case ellblock:
+            bml_diagonalize_ellblock(A, eigenvalues, eigenvectors);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_export.c
+++ b/src/C-interface/bml_export.c
@@ -4,6 +4,7 @@
 #include "dense/bml_export_dense.h"
 #include "ellpack/bml_export_ellpack.h"
 #include "ellsort/bml_export_ellsort.h"
+#include "ellblock/bml_export_ellblock.h"
 
 #include <stdlib.h>
 
@@ -43,6 +44,8 @@ bml_export_to_dense(
             return bml_export_to_dense_ellpack(A, order);
         case ellsort:
             return bml_export_to_dense_ellsort(A, order);
+        case ellblock:
+            return bml_export_to_dense_ellblock(A, order);
         case type_uninitialized:
             return NULL;
             break;

--- a/src/C-interface/bml_getters.c
+++ b/src/C-interface/bml_getters.c
@@ -4,6 +4,7 @@
 #include "dense/bml_getters_dense.h"
 #include "ellpack/bml_getters_ellpack.h"
 #include "ellsort/bml_getters_ellsort.h"
+#include "ellblock/bml_getters_ellblock.h"
 
 #include <stdio.h>
 
@@ -30,6 +31,9 @@ bml_get(
             break;
         case ellsort:
             return bml_get_ellsort(A, i, j);
+            break;
+        case ellblock:
+            return bml_get_ellblock(A, i, j);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -60,6 +64,9 @@ bml_get_row(
         case ellsort:
             return bml_get_row_ellsort(A, i);
             break;
+        case ellblock:
+            return bml_get_row_ellblock(A, i);
+            break;
         default:
             LOG_ERROR("unknown matrix type in bml_get_row\n");
             break;
@@ -86,6 +93,9 @@ bml_get_diagonal(
             break;
         case ellsort:
             return bml_get_diagonal_ellsort(A);
+            break;
+        case ellblock:
+            return bml_get_diagonal_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type in bml_get_diagonal\n");

--- a/src/C-interface/bml_import.c
+++ b/src/C-interface/bml_import.c
@@ -4,6 +4,7 @@
 #include "dense/bml_import_dense.h"
 #include "ellpack/bml_import_ellpack.h"
 #include "ellsort/bml_import_ellsort.h"
+#include "ellblock/bml_import_ellblock.h"
 
 #include <stdlib.h>
 
@@ -45,6 +46,10 @@ bml_import_from_dense(
             return bml_import_from_dense_ellsort(matrix_precision, order, N,
                                                  A, threshold, M,
                                                  distrib_mode);
+        case ellblock:
+            return bml_import_from_dense_ellblock(matrix_precision, order, N,
+                                                  A, threshold, M,
+                                                  distrib_mode);
         default:
             LOG_ERROR("unknown matrix type\n");
     }

--- a/src/C-interface/bml_introspection.c
+++ b/src/C-interface/bml_introspection.c
@@ -4,6 +4,7 @@
 #include "dense/bml_introspection_dense.h"
 #include "ellpack/bml_introspection_ellpack.h"
 #include "ellsort/bml_introspection_ellsort.h"
+#include "ellblock/bml_introspection_ellblock.h"
 
 #include <stdlib.h>
 
@@ -53,6 +54,9 @@ bml_get_precision(
         case ellsort:
             return bml_get_precision_ellsort(A);
             break;
+        case ellblock:
+            return bml_get_precision_ellblock(A);
+            break;
         default:
             LOG_ERROR("unknown precision");
             break;
@@ -83,6 +87,9 @@ bml_get_N(
         case ellsort:
             return bml_get_N_ellsort(A);
             break;
+        case ellblock:
+            return bml_get_N_ellblock(A);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -112,6 +119,37 @@ bml_get_M(
             break;
         case ellsort:
             return bml_get_M_ellsort(A);
+            break;
+        case ellblock:
+            return bml_get_M_ellblock(A);
+            break;
+        default:
+            LOG_ERROR("unknown matrix type\n");
+            break;
+    }
+    return -1;
+}
+
+int
+bml_get_NB(
+    const bml_matrix_t * A)
+{
+    switch (bml_get_type(A))
+    {
+        case type_uninitialized:
+            return 0;
+            break;
+        case dense:
+            return 1;
+            break;
+        case ellpack:
+            return 1;
+            break;
+        case ellsort:
+            return 1;
+            break;
+        case ellblock:
+            return bml_get_NB_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -228,6 +266,9 @@ bml_get_sparsity(
             break;
         case ellsort:
             return bml_get_sparsity_ellsort(A, threshold);
+            break;
+        case ellblock:
+            return bml_get_sparsity_ellblock(A, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type in bml_get_sparsity\n");

--- a/src/C-interface/bml_introspection.h
+++ b/src/C-interface/bml_introspection.h
@@ -17,6 +17,9 @@ int bml_get_N(
 int bml_get_M(
     const bml_matrix_t * A);
 
+int bml_get_NB(
+    const bml_matrix_t * A);
+
 int bml_get_row_bandwidth(
     const bml_matrix_t * A,
     const int i);

--- a/src/C-interface/bml_inverse.c
+++ b/src/C-interface/bml_inverse.c
@@ -5,6 +5,7 @@
 #include "bml_types.h"
 #include "dense/bml_inverse_dense.h"
 #include "ellpack/bml_inverse_ellpack.h"
+#include "ellblock/bml_inverse_ellblock.h"
 
 bml_matrix_t *
 bml_inverse(
@@ -22,6 +23,9 @@ bml_inverse(
             break;
         case ellsort:
             LOG_ERROR("inverse routine is not implemented for ellsort\n");
+            break;
+        case ellblock:
+            B = bml_inverse_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_multiply.c
+++ b/src/C-interface/bml_multiply.c
@@ -4,6 +4,7 @@
 #include "dense/bml_multiply_dense.h"
 #include "ellpack/bml_multiply_ellpack.h"
 #include "ellsort/bml_multiply_ellsort.h"
+#include "ellblock/bml_multiply_ellblock.h"
 
 #include <stdlib.h>
 
@@ -40,6 +41,9 @@ bml_multiply(
         case ellsort:
             bml_multiply_ellsort(A, B, C, alpha, beta, threshold);
             break;
+        case ellblock:
+            bml_multiply_ellblock(A, B, C, alpha, beta, threshold);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -72,6 +76,9 @@ bml_multiply_x2(
             break;
         case ellsort:
             return bml_multiply_x2_ellsort(X, X2, threshold);
+            break;
+        case ellblock:
+            return bml_multiply_x2_ellblock(X, X2, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -109,6 +116,9 @@ bml_multiply_AB(
         case ellsort:
             bml_multiply_AB_ellsort(A, B, C, threshold);
             break;
+        case ellblock:
+            bml_multiply_AB_ellblock(A, B, C, threshold);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -143,6 +153,9 @@ bml_multiply_adjust_AB(
             break;
         case ellsort:
             bml_multiply_adjust_AB_ellsort(A, B, C, threshold);
+            break;
+        case ellblock:
+            bml_multiply_adjust_AB_ellblock(A, B, C, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_norm.c
+++ b/src/C-interface/bml_norm.c
@@ -4,6 +4,7 @@
 #include "dense/bml_norm_dense.h"
 #include "ellpack/bml_norm_ellpack.h"
 #include "ellsort/bml_norm_ellsort.h"
+#include "ellblock/bml_norm_ellblock.h"
 
 #include <stdlib.h>
 
@@ -28,6 +29,9 @@ bml_sum_squares(
             break;
         case ellsort:
             return bml_sum_squares_ellsort(A);
+            break;
+        case ellblock:
+            return bml_sum_squares_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -98,6 +102,9 @@ bml_sum_squares2(
         case ellsort:
             return bml_sum_squares2_ellsort(A, B, alpha, beta, threshold);
             break;
+        case ellblock:
+            return bml_sum_squares2_ellblock(A, B, alpha, beta, threshold);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -126,6 +133,9 @@ bml_fnorm(
             break;
         case ellsort:
             return bml_fnorm_ellsort(A);
+            break;
+        case ellblock:
+            return bml_fnorm_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_normalize.c
+++ b/src/C-interface/bml_normalize.c
@@ -4,6 +4,7 @@
 #include "dense/bml_normalize_dense.h"
 #include "ellpack/bml_normalize_ellpack.h"
 #include "ellsort/bml_normalize_ellsort.h"
+#include "ellblock/bml_normalize_ellblock.h"
 
 #include <stdlib.h>
 
@@ -31,6 +32,9 @@ bml_normalize(
             break;
         case ellsort:
             bml_normalize_ellsort(A, mineval, maxeval);
+            break;
+        case ellblock:
+            bml_normalize_ellblock(A, mineval, maxeval);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -60,6 +64,9 @@ bml_gershgorin(
             break;
         case ellsort:
             return bml_gershgorin_ellsort(A);
+            break;
+        case ellblock:
+            return bml_gershgorin_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -92,6 +99,9 @@ bml_gershgorin_partial(
             break;
         case ellsort:
             return bml_gershgorin_partial_ellsort(A, nrows);
+            break;
+        case ellblock:
+            LOG_ERROR("bml_gershgorin_partial_ellblock not implemented\n");
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_parallel.c
+++ b/src/C-interface/bml_parallel.c
@@ -194,6 +194,9 @@ bml_allGatherVParallel(
         case ellsort:
             bml_allGatherVParallel_ellsort(A);
             break;
+        case ellblock:
+            LOG_ERROR
+                ("bml_allGatherVParallel function not implemented for ellblock\n");
         default:
             LOG_ERROR("unknown matrix type\n");
             break;

--- a/src/C-interface/bml_scale.c
+++ b/src/C-interface/bml_scale.c
@@ -4,6 +4,7 @@
 #include "dense/bml_scale_dense.h"
 #include "ellpack/bml_scale_ellpack.h"
 #include "ellsort/bml_scale_ellsort.h"
+#include "ellblock/bml_scale_ellblock.h"
 
 #include <stdlib.h>
 
@@ -32,6 +33,9 @@ bml_scale_new(
             break;
         case ellsort:
             B = bml_scale_ellsort_new(scale_factor, A);
+            break;
+        case ellblock:
+            B = bml_scale_ellblock_new(scale_factor, A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -65,6 +69,9 @@ bml_scale(
         case ellsort:
             bml_scale_ellsort(scale_factor, A, B);
             break;
+        case ellblock:
+            bml_scale_ellblock(scale_factor, A, B);
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -93,6 +100,9 @@ bml_scale_inplace(
             break;
         case ellsort:
             bml_scale_inplace_ellsort(scale_factor, A);
+            break;
+        case ellblock:
+            bml_scale_inplace_ellblock(scale_factor, A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_setters.c
+++ b/src/C-interface/bml_setters.c
@@ -4,6 +4,7 @@
 #include "dense/bml_setters_dense.h"
 #include "ellpack/bml_setters_ellpack.h"
 #include "ellsort/bml_setters_ellsort.h"
+#include "ellblock/bml_setters_ellblock.h"
 
 void
 bml_set_element_new(
@@ -22,6 +23,9 @@ bml_set_element_new(
             break;
         case ellsort:
             bml_set_element_new_ellsort(A, i, j, value);
+            break;
+        case ellblock:
+            bml_set_element_new_ellblock(A, i, j, value);
             break;
         default:
             LOG_ERROR("unknown matrix type in bml_set_new\n");
@@ -48,6 +52,9 @@ bml_set_element(
         case ellsort:
             bml_set_element_ellsort(A, i, j, value);
             break;
+        case ellblock:
+            bml_set_element_ellblock(A, i, j, value);
+            break;
         default:
             LOG_ERROR("unknown matrix type in bml_set\n");
             break;
@@ -72,6 +79,9 @@ bml_set_row(
         case ellsort:
             bml_set_row_ellsort(A, i, row, threshold);
             break;
+        case ellblock:
+            bml_set_row_ellblock(A, i, row, threshold);
+            break;
         default:
             LOG_ERROR("unknown matrix type in bml_set_row\n");
             break;
@@ -94,6 +104,9 @@ bml_set_diagonal(
             break;
         case ellsort:
             bml_set_diagonal_ellsort(A, diagonal, threshold);
+            break;
+        case ellblock:
+            bml_set_diagonal_ellblock(A, diagonal, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type in bml_set_diagonal\n");

--- a/src/C-interface/bml_submatrix.c
+++ b/src/C-interface/bml_submatrix.c
@@ -46,6 +46,9 @@ bml_matrix2submatrix_index(
                                                core_halo_index,
                                                vsize, double_jump_flag);
             break;
+        case ellblock:
+            LOG_ERROR("bml_matrix2submatrix_index_ellblock NOT available\n");
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -89,6 +92,9 @@ bml_matrix2submatrix_index_graph(
                                                      nsize, core_halo_index,
                                                      vsize, double_jump_flag);
             break;
+        case ellblock:
+            LOG_ERROR("bml_matrix2submatrix_index_ellblock NOT available\n");
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -122,6 +128,9 @@ bml_group_matrix(
             break;
         case ellsort:
             return bml_group_matrix_ellsort(A, hindex, ngroups, threshold);
+            break;
+        case ellblock:
+            LOG_ERROR("bml_group_matrix_ellblock NOT available\n");
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -157,6 +166,9 @@ bml_matrix2submatrix(
             break;
         case ellsort:
             bml_matrix2submatrix_ellsort(A, B, core_halo_index, lsize);
+            break;
+        case ellblock:
+            LOG_ERROR("bml_matrix2submatrix_ellblock NOT available\n");
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -198,6 +210,9 @@ bml_submatrix2matrix(
             bml_submatrix2matrix_ellsort(A, B, core_halo_index, lsize,
                                          llsize, threshold);
             break;
+        case ellblock:
+            LOG_ERROR("bml_submatrix2matrix_ellblock NOT available\n");
+            break;
         default:
             LOG_ERROR("unknown matrix type\n");
             break;
@@ -231,6 +246,10 @@ bml_adjacency(
             break;
         case ellsort:
             bml_adjacency_ellsort(A, xadj, adjncy, base_flag);
+            break;
+        case ellblock:
+            LOG_ERROR
+                ("bml_adjacency routine is not implemented for ellblock\n");
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -272,6 +291,10 @@ bml_adjacency_group(
         case ellsort:
             bml_adjacency_group_ellsort(A, hindex, nnodes, xadj, adjncy,
                                         base_flag);
+            break;
+        case ellblock:
+            LOG_ERROR
+                ("bml_adjacency_group routine is not implemented for ellblock\n");
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_threshold.c
+++ b/src/C-interface/bml_threshold.c
@@ -4,6 +4,7 @@
 #include "dense/bml_threshold_dense.h"
 #include "ellpack/bml_threshold_ellpack.h"
 #include "ellsort/bml_threshold_ellsort.h"
+#include "ellblock/bml_threshold_ellblock.h"
 
 #include <stdlib.h>
 
@@ -30,6 +31,9 @@ bml_threshold_new(
             break;
         case ellsort:
             return bml_threshold_new_ellsort(A, threshold);
+            break;
+        case ellblock:
+            return bml_threshold_new_ellblock(A, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -61,6 +65,9 @@ bml_threshold(
             break;
         case ellsort:
             bml_threshold_ellsort(A, threshold);
+            break;
+        case ellblock:
+            bml_threshold_ellblock(A, threshold);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_trace.c
+++ b/src/C-interface/bml_trace.c
@@ -4,6 +4,7 @@
 #include "dense/bml_trace_dense.h"
 #include "ellpack/bml_trace_ellpack.h"
 #include "ellsort/bml_trace_ellsort.h"
+#include "ellblock/bml_trace_ellblock.h"
 
 #include <stdlib.h>
 
@@ -28,6 +29,9 @@ bml_trace(
             break;
         case ellsort:
             return bml_trace_ellsort(A);
+            break;
+        case ellblock:
+            return bml_trace_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -59,6 +63,9 @@ bml_traceMult(
             break;
         case ellsort:
             return bml_traceMult_ellsort(A, B);
+            break;
+        case ellblock:
+            return bml_traceMult_ellblock(A, B);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_transpose.c
+++ b/src/C-interface/bml_transpose.c
@@ -4,6 +4,7 @@
 #include "dense/bml_transpose_dense.h"
 #include "ellpack/bml_transpose_ellpack.h"
 #include "ellsort/bml_transpose_ellsort.h"
+#include "ellblock/bml_transpose_ellblock.h"
 
 #include <stdlib.h>
 
@@ -28,6 +29,9 @@ bml_transpose_new(
             break;
         case ellsort:
             return bml_transpose_new_ellsort(A);
+            break;
+        case ellblock:
+            return bml_transpose_new_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");
@@ -57,6 +61,9 @@ bml_transpose(
             break;
         case ellsort:
             bml_transpose_ellsort(A);
+            break;
+        case ellblock:
+            bml_transpose_ellblock(A);
             break;
         default:
             LOG_ERROR("unknown matrix type\n");

--- a/src/C-interface/bml_types.h
+++ b/src/C-interface/bml_types.h
@@ -12,6 +12,8 @@ typedef enum
     dense,
     /** ELLPACK matrix. */
     ellpack,
+    /** BLOCK ELLPACK matrix. */
+    ellblock,
     /** ELLSORT matrix. */
     ellsort,
     /** CSR matrix. */
@@ -57,6 +59,10 @@ typedef struct
     int N_cols;
     /** The maximum number of non-zeros per row (for ellpack). */
     int N_nz_max;
+    /** The block sizes (for block_ellpack). */
+    int *bsizes;
+    /** The number of blocks/row (or column). */
+    int NB;
 } bml_matrix_dimension_t;
 
 /** The supported distribution modes. */

--- a/src/C-interface/bml_utilities.c
+++ b/src/C-interface/bml_utilities.c
@@ -7,6 +7,7 @@
 #include "dense/bml_utilities_dense.h"
 #include "ellpack/bml_utilities_ellpack.h"
 #include "ellsort/bml_utilities_ellsort.h"
+#include "ellblock/bml_utilities_ellblock.h"
 
 #include <complex.h>
 #include <stdio.h>
@@ -133,6 +134,47 @@ bml_print_bml_matrix(
                 default:
                     LOG_ERROR("unknown precision\n");
                     break;
+            }
+            break;
+        case ellblock:
+            switch (bml_get_precision(A))
+            {
+                case single_real:
+                {
+                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    bml_print_dense_matrix(bml_get_N(A), single_real,
+                                           dense_row_major, A_dense, i_l, i_u,
+                                           j_l, j_u);
+                    free(A_dense);
+                    break;
+                }
+                case double_real:
+                {
+                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    bml_print_dense_matrix(bml_get_N(A), double_real,
+                                           dense_row_major, A_dense, i_l, i_u,
+                                           j_l, j_u);
+                    free(A_dense);
+                    break;
+                }
+                case single_complex:
+                {
+                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    bml_print_dense_matrix(bml_get_N(A), single_complex,
+                                           dense_row_major, A_dense, i_l, i_u,
+                                           j_l, j_u);
+                    free(A_dense);
+                    break;
+                }
+                case double_complex:
+                {
+                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    bml_print_dense_matrix(bml_get_N(A), double_complex,
+                                           dense_row_major, A_dense, i_l, i_u,
+                                           j_l, j_u);
+                    free(A_dense);
+                    break;
+                }
             }
             break;
         default:
@@ -395,6 +437,9 @@ bml_read_bml_matrix(
         case ellsort:
             bml_read_bml_matrix_ellsort(A, filename);
             break;
+        case ellblock:
+            bml_read_bml_matrix_ellblock(A, filename);
+            break;
         default:
             LOG_ERROR("unknown type (%d)\n", bml_get_type(A));
             break;
@@ -421,6 +466,9 @@ bml_write_bml_matrix(
             break;
         case ellsort:
             bml_write_bml_matrix_ellsort(A, filename);
+            break;
+        case ellblock:
+            bml_write_bml_matrix_ellblock(A, filename);
             break;
         default:
             LOG_ERROR("unknown type (%d)\n", bml_get_type(A));

--- a/src/C-interface/ellblock/CMakeLists.txt
+++ b/src/C-interface/ellblock/CMakeLists.txt
@@ -1,0 +1,97 @@
+include_directories(..)
+
+set(HEADERS-ELLBLOCK
+  bml_add_ellblock.h
+  bml_allocate_ellblock.h
+  bml_convert_ellblock.h
+  bml_copy_ellblock.h
+  bml_diagonalize_ellblock.h
+  bml_export_ellblock.h
+  bml_getters_ellblock.h
+  bml_import_ellblock.h
+  bml_introspection_ellblock.h
+  bml_inverse_ellblock.h
+  bml_multiply_ellblock.h
+  bml_normalize_ellblock.h
+  bml_norm_ellblock.h
+  bml_scale_ellblock.h
+  bml_setters_ellblock.h
+  bml_threshold_ellblock.h
+  bml_trace_ellblock.h
+  bml_transpose_ellblock.h
+  bml_types_ellblock.h
+  bml_utilities_ellblock.h)
+
+set(SOURCES-ELLBLOCK
+  bml_add_ellblock.c
+  bml_allocate_ellblock.c
+  bml_convert_ellblock.c
+  bml_copy_ellblock.c
+  bml_diagonalize_ellblock.c
+  bml_export_ellblock.c
+  bml_getters_ellblock.c
+  bml_import_ellblock.c
+  bml_introspection_ellblock.c
+  bml_inverse_ellblock.c
+  bml_multiply_ellblock.c
+  bml_normalize_ellblock.c
+  bml_norm_ellblock.c
+  bml_scale_ellblock.c
+  bml_setters_ellblock.c
+  bml_threshold_ellblock.c
+  bml_trace_ellblock.c
+  bml_transpose_ellblock.c
+  bml_utilities_ellblock.c
+)
+
+add_library(bml-ellblock OBJECT ${SOURCES-ELLBLOCK})
+set_target_properties(bml-ellblock
+  PROPERTIES
+  POSITION_INDEPENDENT_CODE yes)
+if(OPENMP_FOUND)
+  set_target_properties(bml-ellblock
+    PROPERTIES
+    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+endif()
+
+set(SOURCES-ELLBLOCK-TYPED
+  bml_add_ellblock_typed.c
+  bml_allocate_ellblock_typed.c
+  bml_convert_ellblock_typed.c
+  bml_copy_ellblock_typed.c
+  bml_diagonalize_ellblock_typed.c
+  bml_export_ellblock_typed.c
+  bml_getters_ellblock_typed.c
+  bml_import_ellblock_typed.c
+  bml_introspection_ellblock_typed.c
+  bml_inverse_ellblock_typed.c
+  bml_multiply_ellblock_typed.c
+  bml_normalize_ellblock_typed.c
+  bml_norm_ellblock_typed.c
+  bml_scale_ellblock_typed.c
+  bml_setters_ellblock_typed.c
+  bml_threshold_ellblock_typed.c
+  bml_trace_ellblock_typed.c
+  bml_transpose_ellblock_typed.c
+  bml_utilities_ellblock_typed.c
+)
+
+include(${CMAKE_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
+bml_add_typed_library(bml-ellblock single_real "${SOURCES-ELLBLOCK-TYPED}")
+bml_add_typed_library(bml-ellblock double_real "${SOURCES-ELLBLOCK-TYPED}")
+bml_add_typed_library(bml-ellblock single_complex "${SOURCES-ELLBLOCK-TYPED}")
+bml_add_typed_library(bml-ellblock double_complex "${SOURCES-ELLBLOCK-TYPED}")
+if(OPENMP_FOUND)
+  set_target_properties(bml-ellblock-single_real
+    PROPERTIES
+    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  set_target_properties(bml-ellblock-double_real
+    PROPERTIES
+    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  set_target_properties(bml-ellblock-single_complex
+    PROPERTIES
+    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  set_target_properties(bml-ellblock-double_complex
+    PROPERTIES
+    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+endif()

--- a/src/C-interface/ellblock/bml_add_ellblock.c
+++ b/src/C-interface/ellblock/bml_add_ellblock.c
@@ -1,0 +1,176 @@
+#include "bml_add.h"
+#include "bml_add_ellblock.h"
+#include "bml_logger.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Matrix addition.
+ *
+ * \f$ A = \alpha A + \beta B \f$
+ *
+ * \ingroup add_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param alpha Scalar factor multiplied by A
+ * \param beta Scalar factor multiplied by B
+ * \param threshold Threshold for matrix addition
+ */
+void
+bml_add_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    switch (B->matrix_precision)
+    {
+        case single_real:
+            bml_add_ellblock_single_real(A, B, alpha, beta, threshold);
+            break;
+        case double_real:
+            bml_add_ellblock_double_real(A, B, alpha, beta, threshold);
+            break;
+        case single_complex:
+            bml_add_ellblock_single_complex(A, B, alpha, beta, threshold);
+            break;
+        case double_complex:
+            bml_add_ellblock_double_complex(A, B, alpha, beta, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Matrix addition and TrNorm calculation.
+ *
+ * \f$ A = \alpha A + \beta B \f$
+ *
+ * \ingroup add_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param alpha Scalar factor multiplied by A
+ * \param beta Scalar factor multiplied by B
+ * \param threshold Threshold for matrix addition
+ */
+double
+bml_add_norm_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    double trnorm = 0.0;
+
+    switch (B->matrix_precision)
+    {
+        case single_real:
+            trnorm =
+                bml_add_norm_ellblock_single_real(A, B, alpha, beta,
+                                                  threshold);
+            break;
+        case double_real:
+            trnorm =
+                bml_add_norm_ellblock_double_real(A, B, alpha, beta,
+                                                  threshold);
+            break;
+        case single_complex:
+            trnorm =
+                bml_add_norm_ellblock_single_complex(A, B, alpha, beta,
+                                                     threshold);
+            break;
+        case double_complex:
+            trnorm =
+                bml_add_norm_ellblock_double_complex(A, B, alpha, beta,
+                                                     threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return trnorm;
+}
+
+/** Matrix addition.
+ *
+ * \f$ A = A + \beta \mathrm{Id} \f$
+ *
+ * \ingroup add_group
+ *
+ * \param A Matrix A
+ * \param beta Scalar factor multiplied by A
+ * \param threshold Threshold for matrix addition
+ */
+void
+bml_add_identity_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_add_identity_ellblock_single_real(A, beta, threshold);
+            break;
+        case double_real:
+            bml_add_identity_ellblock_double_real(A, beta, threshold);
+            break;
+        case single_complex:
+            bml_add_identity_ellblock_single_complex(A, beta, threshold);
+            break;
+        case double_complex:
+            bml_add_identity_ellblock_double_complex(A, beta, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Matrix addition.
+ *
+ * \f$ A = A + \beta \mathrm{Id} \f$
+ *
+ * \ingroup add_group
+ *
+ * \param A Matrix A
+ * \param beta Scalar factor multiplied by A
+ * \param threshold Threshold for matrix addition
+ */
+void
+bml_scale_add_identity_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_scale_add_identity_ellblock_single_real(A, alpha, beta,
+                                                        threshold);
+            break;
+        case double_real:
+            bml_scale_add_identity_ellblock_double_real(A, alpha, beta,
+                                                        threshold);
+            break;
+        case single_complex:
+            bml_scale_add_identity_ellblock_single_complex(A, alpha, beta,
+                                                           threshold);
+            break;
+        case double_complex:
+            bml_scale_add_identity_ellblock_double_complex(A, alpha, beta,
+                                                           threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_add_ellblock.h
+++ b/src/C-interface/ellblock/bml_add_ellblock.h
@@ -1,0 +1,131 @@
+#ifndef __BML_ADD_ELLBLOCK_H
+#define __BML_ADD_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+void bml_add_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_add_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_add_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_add_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_add_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_add_norm_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_add_norm_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_add_norm_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_add_norm_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_add_norm_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_add_identity_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold);
+
+void bml_add_identity_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold);
+
+void bml_add_identity_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold);
+
+void bml_add_identity_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold);
+
+void bml_add_identity_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold);
+
+void bml_scale_add_identity_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_scale_add_identity_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_scale_add_identity_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_scale_add_identity_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_scale_add_identity_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+#endif

--- a/src/C-interface/ellblock/bml_add_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_add_ellblock_typed.c
@@ -1,0 +1,355 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_add.h"
+#include "bml_types.h"
+#include "bml_parallel.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_add_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+
+#include <assert.h>
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Matrix addition.
+ *
+ * \f$ A = \alpha A + \beta B \f$
+ *
+ * \ingroup add_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param alpha Scalar factor multiplied by A
+ * \param beta Scalar factor multiplied by B
+ * \param threshold Threshold for matrix addition
+ */
+void TYPED_FUNC(
+    bml_add_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    assert(A->NB == B->NB);
+    assert(A->bsize[0] == B->bsize[0]);
+
+    int NB = A->NB;
+    int MB = A->MB;
+    int ix[NB], jx[NB];
+
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+
+    int *B_nnzb = B->nnzb;
+    int *B_indexb = B->indexb;
+
+    int *bsize = A->bsize;
+
+    REAL_T *x_ptr[NB];
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    memset(ix, 0, NB * sizeof(int));
+    memset(jx, 0, NB * sizeof(int));
+
+    int maxbsize = 0;
+    for (int ib = 0; ib < NB; ib++)
+        maxbsize = MAX(maxbsize, bsize[ib]);
+    int maxbsize2 = maxbsize * maxbsize;
+    for (int ib = 0; ib < NB; ib++)
+        x_ptr[ib] = calloc(maxbsize2, sizeof(REAL_T));
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        int l = 0;
+        if (alpha > (double) 0.0 || alpha < (double) 0.0)
+            for (int jp = 0; jp < A_nnzb[ib]; jp++)
+            {
+                int ind = ROWMAJOR(ib, jp, NB, MB);
+                int jb = A_indexb[ind];
+                REAL_T *x = x_ptr[jb];
+                int nelements = bsize[ib] * bsize[jb];
+                if (ix[jb] == 0)
+                {
+                    for (int kk = 0; kk < nelements; kk++)
+                    {
+                        x[kk] = 0.0;
+                    }
+                    ix[jb] = ib + 1;
+                    jx[l] = jb;
+                    l++;
+                }
+                REAL_T *A_value = A_ptr_value[ind];
+                for (int kk = 0; kk < nelements; kk++)
+                {
+                    x[kk] = x[kk] + alpha * A_value[kk];
+                }
+            }
+
+        if (beta > (double) 0.0 || beta < (double) 0.0)
+            for (int jp = 0; jp < B_nnzb[ib]; jp++)
+            {
+                int ind = ROWMAJOR(ib, jp, NB, MB);
+                int jb = B_indexb[ind];
+                REAL_T *x = x_ptr[jb];
+                int nelements = bsize[ib] * bsize[jb];
+                if (ix[jb] == 0)
+                {
+                    for (int kk = 0; kk < nelements; kk++)
+                    {
+                        x[kk] = 0.0;
+                    }
+                    ix[jb] = ib + 1;
+                    jx[l] = jb;
+                    l++;
+                }
+                REAL_T *B_value = B_ptr_value[ind];
+                for (int kk = 0; kk < nelements; kk++)
+                {
+                    x[kk] = x[kk] + beta * B_value[kk];
+                }
+            }
+        A_nnzb[ib] = l;
+
+        int ll = 0;
+        for (int jp = 0; jp < l; jp++)
+        {
+            int jb = jx[jp];
+            REAL_T *x = x_ptr[jb];
+            REAL_T normx = TYPED_FUNC(bml_norm_inf)
+                (x, bsize[ib], bsize[jb], bsize[jb]);
+            int nelements = bsize[ib] * bsize[jb];
+            if (is_above_threshold(normx, threshold))
+            {
+                int kb = ROWMAJOR(ib, ll, NB, MB);
+                if (A_ptr_value[kb] == NULL)
+                {
+                    A_ptr_value[kb]
+                        =
+                        bml_noinit_allocate_memory(nelements *
+                                                   sizeof(REAL_T));
+                }
+                for (int kk = 0; kk < nelements; kk++)
+                {
+                    A_ptr_value[kb][kk] = x[kk];
+                }
+                A_indexb[kb] = jb;
+                ll++;
+            }
+            memset(x, 0.0, nelements * sizeof(REAL_T));
+            ix[jb] = 0;
+        }
+        A_nnzb[ib] = ll;
+    }
+
+    for (int ib = 0; ib < NB; ib++)
+        free(x_ptr[ib]);
+}
+
+/** Matrix addition.
+ *
+ * \f$ A = \alpha A + \beta B \f$
+ *
+ * \ingroup add_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param alpha Scalar factor multiplied by A
+ * \param beta Scalar factor multiplied by B
+ * \param threshold Threshold for matrix addition
+ */
+double TYPED_FUNC(
+    bml_add_norm_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int ix[NB], jx[NB];
+
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+
+    int *B_nnzb = B->nnzb;
+    int *B_indexb = B->indexb;
+
+    int *bsize = A->bsize;
+
+    REAL_T *x[NB];
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    memset(ix, 0, NB * sizeof(int));
+    memset(jx, 0, NB * sizeof(int));
+    x[0] = (REAL_T *) calloc(BMAXSIZE * NB, sizeof(REAL_T));
+    for (int i = 1; i < NB; i++)
+    {
+        x[i] = x[0] + i * BMAXSIZE;
+    }
+
+    REAL_T *y[NB];
+    y[0] = (REAL_T *) calloc(BMAXSIZE * NB, sizeof(REAL_T));
+    for (int i = 1; i < NB; i++)
+    {
+        y[i] = y[0] + i * BMAXSIZE;
+    }
+
+
+    double trnorm = 0.0;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        int l = 0;
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            if (ix[jb] == 0)
+            {
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[jb]; jj++)
+                    {
+                        int kk = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                        x[jb][kk] = 0.0;
+                        y[jb][kk] = 0.0;
+                    }
+                ix[jb] = ib + 1;
+                jx[l] = jb;
+                l++;
+            }
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int kk = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    x[jb][kk] = x[jb][kk] + alpha * A_ptr_value[ind][kk];
+                    y[jb][kk] = y[jb][kk] + A_ptr_value[ind][kk];
+                }
+        }
+
+        for (int jp = 0; jp < B_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = B_indexb[ind];
+            if (ix[jb] == 0)
+            {
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[jb]; jj++)
+                    {
+                        int kk = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                        x[jb][kk] = 0.0;
+                        y[jb][kk] = 0.0;
+                    }
+                ix[jb] = ib + 1;
+                jx[l] = jb;
+                l++;
+            }
+            REAL_T *B_value = B_ptr_value[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int kk = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    x[jb][kk] = x[jb][kk] + beta * B_ptr_value[ind][kk];
+                    y[jb][kk] = y[jb][kk] - B_value[kk];
+                }
+        }
+        A_nnzb[ib] = l;
+
+        int ll = 0;
+        for (int jp = 0; jp < l; jp++)
+        {
+            int jb = jx[jp];
+            REAL_T *xTmp = x[jb];
+            REAL_T normx = TYPED_FUNC(bml_norm_inf)
+                (x[jb], bsize[ib], bsize[jb], bsize[jb]);
+            REAL_T normy = TYPED_FUNC(bml_sum_squares)
+                (y[jb], bsize[ib], bsize[jb], bsize[jb]);
+            trnorm += normy * normy;
+            if (is_above_threshold(normx, threshold))
+            {
+                int kb = ROWMAJOR(ib, ll, NB, MB);
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[jb]; jj++)
+                    {
+                        int kk = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                        A_ptr_value[kb][kk] = xTmp[kk];
+                    }
+
+                A_indexb[kb] = jb;
+                ll++;
+            }
+            memset(x[jb], 0.0, bsize[ib] * bsize[jb] * sizeof(REAL_T));
+            memset(y[jb], 0.0, bsize[ib] * bsize[jb] * sizeof(REAL_T));
+            ix[jb] = 0;
+        }
+        A_nnzb[ib] = ll;
+    }
+
+    return trnorm;
+}
+
+/** Matrix addition.
+ *
+ *  A = A + beta * I
+ *
+ *  \ingroup add_group
+ *
+ *  \param A Matrix A
+ *  \param beta Scalar factor multiplied by I
+ *  \param threshold Threshold for matrix addition
+ */
+void TYPED_FUNC(
+    bml_add_identity_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const double beta,
+    const double threshold)
+{
+    REAL_T alpha = (REAL_T) 1.0;
+
+    bml_matrix_ellblock_t *Id =
+        TYPED_FUNC(bml_identity_matrix_ellblock) (A->N, A->M,
+                                                  A->distribution_mode);
+
+    TYPED_FUNC(bml_add_ellblock) (A, Id, alpha, beta, threshold);
+
+    bml_deallocate_ellblock(Id);
+}
+
+/** Matrix addition.
+ *
+ *  A = alpha * A + beta * I
+ *
+ *  \ingroup add_group
+ *
+ *  \param A Matrix A
+ *  \param alpha Scalar factor multiplied by A
+ *  \param beta Scalar factor multiplied by I
+ *  \param threshold Threshold for matrix addition
+ */
+void TYPED_FUNC(
+    bml_scale_add_identity_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    bml_matrix_ellblock_t *Id =
+        TYPED_FUNC(bml_identity_matrix_ellblock) (A->N, A->M,
+                                                  A->distribution_mode);
+
+    TYPED_FUNC(bml_add_ellblock) (A, Id, alpha, beta, threshold);
+
+    bml_deallocate_ellblock(Id);
+}

--- a/src/C-interface/ellblock/bml_allocate_ellblock.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock.c
@@ -1,0 +1,382 @@
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_logger.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+#include "../../macros.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+/*
+ * variables visible only in that file
+ */
+static int *s_default_bsize = NULL;
+static int s_default_block_dim = 4;
+static int s_nb = 0;
+static int s_mb = 0;
+
+/*
+ *  * function to set values of static variables visible in that file only
+ *   * Should be called only once.
+ *    */
+void
+bml_set_block_sizes(
+    const int *bsize,
+    int nb,
+    int mb)
+{
+    printf("bml_set_block_sizes %d %d\n", nb, mb);
+    assert(nb > 0);
+    assert(mb > 0);
+
+    /*
+     * make sure this function is called only once
+     */
+    assert(s_nb == 0);
+
+    s_nb = nb;
+    s_mb = mb;
+    s_default_bsize = malloc(nb * sizeof(int));
+    for (int ib = 0; ib < nb; ib++)
+    {
+        s_default_bsize[ib] = bsize[ib];
+    }
+}
+
+int *
+bml_get_block_sizes(
+    const int N,
+    const int M)
+{
+    if (s_default_bsize == NULL)
+    {
+        assert(M > 0);
+
+        s_nb = N / s_default_block_dim;
+        if (s_nb * s_default_block_dim < N)
+            s_nb++;
+        printf("s_nb = %d\n", s_nb);
+
+        s_mb = M / s_default_block_dim;
+        if (s_mb * s_default_block_dim < M)
+            s_mb++;
+        printf("s_mb = %d\n", s_mb);
+
+        s_default_bsize = malloc(s_nb * sizeof(int));
+        for (int ib = 0; ib < s_nb - 1; ib++)
+        {
+            s_default_bsize[ib] = s_default_block_dim;
+        }
+        s_default_bsize[s_nb - 1] = N % s_default_block_dim;
+    }
+    return s_default_bsize;
+}
+
+int
+bml_get_mb(
+    )
+{
+    return s_mb;
+}
+
+int
+bml_get_nb(
+    )
+{
+    return s_nb;
+}
+
+int
+count_nelements(
+    bml_matrix_ellblock_t * A)
+{
+    int nelements = 0;
+    for (int ib = 0; ib < A->NB; ib++)
+        for (int jp = 0; jp < A->MB; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+            int jb = A->indexb[ind];
+            nelements = nelements + A->bsize[ib] * A->bsize[jb];
+        }
+    //printf("nelements=%d\n", nelements);
+    return nelements;
+}
+
+/** Deallocate a matrix.
+ *
+ * \ingroup allocate_group
+ *
+ * \param A The matrix.
+ */
+void
+bml_deallocate_ellblock(
+    bml_matrix_ellblock_t * A)
+{
+    for (int ib = 0; ib < A->NB; ib++)
+        for (int jp = 0; jp < A->MB; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+            bml_free_memory(A->ptr_value[ind]);
+        }
+    bml_free_memory(A->ptr_value);
+    bml_free_memory(A->indexb);
+    bml_free_memory(A->nnzb);
+    bml_free_memory(A->bsize);
+    bml_free_memory(A);
+}
+
+/** Clear a matrix.
+ *
+ * \ingroup allocate_group
+ *
+ * \param A The matrix.
+ */
+void
+bml_clear_ellblock(
+    bml_matrix_ellblock_t * A)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_clear_ellblock_single_real(A);
+            break;
+        case double_real:
+            bml_clear_ellblock_double_real(A);
+            break;
+        case single_complex:
+            bml_clear_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            bml_clear_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+bml_matrix_ellblock_t *
+bml_noinit_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode)
+{
+    bml_matrix_ellblock_t *A = NULL;
+
+    switch (matrix_precision)
+    {
+        case single_real:
+            A = bml_noinit_matrix_ellblock_single_real(matrix_dimension,
+                                                       distrib_mode);
+            break;
+        case double_real:
+            A = bml_noinit_matrix_ellblock_double_real(matrix_dimension,
+                                                       distrib_mode);
+            break;
+        case single_complex:
+            A = bml_noinit_matrix_ellblock_single_complex(matrix_dimension,
+                                                          distrib_mode);
+            break;
+        case double_complex:
+            A = bml_noinit_matrix_ellblock_double_complex(matrix_dimension,
+                                                          distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return A;
+}
+
+/** Allocate the zero matrix.
+ *
+ *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
+ *  already allocated then the matrix will be deallocated in the
+ *  process.
+ *
+ *  \ingroup allocate_group
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+bml_matrix_ellblock_t *
+bml_zero_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    bml_matrix_ellblock_t *A = NULL;
+
+    switch (matrix_precision)
+    {
+        case single_real:
+            A = bml_zero_matrix_ellblock_single_real(N, M, distrib_mode);
+            break;
+        case double_real:
+            A = bml_zero_matrix_ellblock_double_real(N, M, distrib_mode);
+            break;
+        case single_complex:
+            A = bml_zero_matrix_ellblock_single_complex(N, M, distrib_mode);
+            break;
+        case double_complex:
+            A = bml_zero_matrix_ellblock_double_complex(N, M, distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return A;
+}
+
+bml_matrix_ellblock_t *
+bml_block_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode)
+{
+    bml_matrix_ellblock_t *A = NULL;
+
+    switch (matrix_precision)
+    {
+        case single_real:
+            A = bml_block_matrix_ellblock_single_real(NB, MB, bsizes,
+                                                      distrib_mode);
+            break;
+        case double_real:
+            A = bml_block_matrix_ellblock_double_real(NB, MB, bsizes,
+                                                      distrib_mode);
+            break;
+        case single_complex:
+            A = bml_block_matrix_ellblock_single_complex(NB, MB, bsizes,
+                                                         distrib_mode);
+            break;
+        case double_complex:
+            A = bml_block_matrix_ellblock_double_complex(NB, MB, bsizes,
+                                                         distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return A;
+}
+
+/** Allocate a random matrix.
+ *
+ *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
+ *  already allocated then the matrix will be deallocated in the
+ *  process.
+ *
+ *  \ingroup allocate_group
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+bml_matrix_ellblock_t *
+bml_random_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_random_matrix_ellblock_single_real(N, M, distrib_mode);
+            break;
+        case double_real:
+            return bml_random_matrix_ellblock_double_real(N, M, distrib_mode);
+            break;
+        case single_complex:
+            return bml_random_matrix_ellblock_single_complex(N, M,
+                                                             distrib_mode);
+            break;
+        case double_complex:
+            return bml_random_matrix_ellblock_double_complex(N, M,
+                                                             distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}
+
+/** Allocate the identity matrix.
+ *
+ *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
+ *  already allocated then the matrix will be deallocated in the
+ *  process.
+ *
+ *  \ingroup allocate_group
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+bml_matrix_ellblock_t *
+bml_identity_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_identity_matrix_ellblock_single_real(N, M,
+                                                            distrib_mode);
+            break;
+        case double_real:
+            return bml_identity_matrix_ellblock_double_real(N, M,
+                                                            distrib_mode);
+            break;
+        case single_complex:
+            return bml_identity_matrix_ellblock_single_complex(N, M,
+                                                               distrib_mode);
+            break;
+        case double_complex:
+            return bml_identity_matrix_ellblock_double_complex(N, M,
+                                                               distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}
+
+/** Update the ellblock matrix domain.
+ *
+ * \ingroup allocate_group
+ *
+ * \param A Matrix with domain
+ * \param localPartMin first part on each rank
+ * \param localPartMin last part on each rank
+ * \param nnodesInPart number of nodes per part
+ */
+void
+bml_update_domain_ellblock(
+    bml_matrix_ellblock_t * A,
+    int *localPartMin,
+    int *localPartMax,
+    int *nnodesInPart)
+{
+    LOG_ERROR("bml_update_domain_ellblock not implemented\n");
+}

--- a/src/C-interface/ellblock/bml_allocate_ellblock.h
+++ b/src/C-interface/ellblock/bml_allocate_ellblock.h
@@ -1,0 +1,173 @@
+#ifndef __BML_ALLOCATE_ELLBLOCK_H
+#define __BML_ALLOCATE_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+void bml_deallocate_ellblock(
+    bml_matrix_ellblock_t * A);
+
+void bml_clear_ellblock(
+    bml_matrix_ellblock_t * A);
+
+void bml_clear_ellblock_single_real(
+    bml_matrix_ellblock_t * A);
+
+void bml_clear_ellblock_double_real(
+    bml_matrix_ellblock_t * A);
+
+void bml_clear_ellblock_single_complex(
+    bml_matrix_ellblock_t * A);
+
+void bml_clear_ellblock_double_complex(
+    bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_noinit_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_single_real(
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_double_real(
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_single_complex(
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_double_complex(
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_zero_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_zero_matrix_ellblock_single_real(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_zero_matrix_ellblock_double_real(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_zero_matrix_ellblock_single_complex(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_zero_matrix_ellblock_double_complex(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_random_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_random_matrix_ellblock_single_real(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_random_matrix_ellblock_double_real(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_random_matrix_ellblock_single_complex(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_random_matrix_ellblock_double_complex(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_identity_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_identity_matrix_ellblock_single_real(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_identity_matrix_ellblock_double_real(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_identity_matrix_ellblock_single_complex(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_identity_matrix_ellblock_double_complex(
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_block_matrix_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_block_matrix_ellblock_single_real(
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_block_matrix_ellblock_double_real(
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_block_matrix_ellblock_single_complex(
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_block_matrix_ellblock_double_complex(
+    const int NB,
+    const int MB,
+    const int *bsizes,
+    const bml_distribution_mode_t distrib_mode);
+
+void bml_update_domain_ellblock(
+    bml_matrix_ellblock_t * A,
+    int *localPartMin,
+    int *localPartMax,
+    int *nnodesInPart);
+
+void bml_set_block_sizes(
+    const int *bsize,
+    int NB,
+    int MB);
+int *bml_get_block_sizes(
+    const int N,
+    const int M);
+int bml_get_mb(
+    );
+int bml_get_nb(
+    );
+int count_nelements(
+    bml_matrix_ellblock_t * A);
+#endif

--- a/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
@@ -1,0 +1,241 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Clear a matrix.
+ *
+ * Numbers of non-zeroes, indeces, and values are set to zero.
+ *
+ * \ingroup allocate_group
+ *
+ * \param A The matrix.
+ */
+void TYPED_FUNC(
+    bml_clear_ellblock) (
+    bml_matrix_ellblock_t * A)
+{
+    for (int ib = 0; ib < A->NB; ib++)
+        for (int jp = 0; jp < A->nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+            int jb = A->indexb[ind];
+            memset(A->ptr_value[ind], 0.,
+                   A->bsize[ib] * A->bsize[jb] * sizeof(REAL_T));
+        }
+    memset(A->indexb, 0, A->NB * A->MB * sizeof(int));
+    memset(A->nnzb, 0, A->NB * sizeof(int));
+}
+
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_noinit_matrix_ellblock) (
+    const bml_matrix_dimension_t matrix_dimension,
+    const bml_distribution_mode_t distrib_mode)
+{
+    int N = matrix_dimension.N_rows;
+
+    return TYPED_FUNC(bml_block_matrix_ellblock) (bml_get_nb(), bml_get_mb(),
+                                                  bml_get_block_sizes(N, 0),
+                                                  distrib_mode);
+}
+
+/** Allocate the zero matrix.
+ *
+ *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
+ *  already allocated then the matrix will be deallocated in the
+ *  process.
+ *
+ *  \ingroup allocate_group
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_block_matrix_ellblock) (
+    const int NB,
+    const int MB,
+    const int *bsize,
+    const bml_distribution_mode_t distrib_mode)
+{
+    assert(NB > 0);
+    assert(MB > 0);
+    for (int ib = 0; ib < NB; ib++)
+        assert(bsize[ib] < 1e6);
+
+    bml_matrix_ellblock_t *A =
+        bml_allocate_memory(sizeof(bml_matrix_ellblock_t));
+    A->matrix_type = ellblock;
+    A->matrix_precision = MATRIX_PRECISION;
+    A->NB = NB;
+    A->MB = MB;
+    A->bsize = bml_allocate_memory(sizeof(int) * NB);
+    memcpy(A->bsize, bsize, NB * sizeof(int));
+    A->distribution_mode = distrib_mode;
+    A->indexb = bml_allocate_memory(sizeof(int) * NB * MB);
+    A->nnzb = bml_allocate_memory(sizeof(int) * NB);
+    A->ptr_value = bml_allocate_memory(sizeof(REAL_T *) * NB * MB);
+
+    int N = 0;
+    for (int ib = 0; ib < NB; ib++)
+        N += bsize[ib];
+    A->N = N;
+    //printf("bml_block_matrix_ellblock %d %d\n",NB,MB);
+    if (bml_get_mb() == 0)
+    {
+        bml_set_block_sizes(bsize, NB, MB);
+    }
+    return A;
+}
+
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_zero_matrix_ellblock) (
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    //use default block values that could have been reset by user
+    int *bsize = bml_get_block_sizes(N, M);
+    int mb = bml_get_mb();
+    int nb = bml_get_nb();
+
+    bml_matrix_ellblock_t *A =
+        TYPED_FUNC(bml_block_matrix_ellblock) (nb, mb, bsize, distrib_mode);
+
+    return A;
+}
+
+/** Allocate a random matrix.
+ *
+ *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
+ *  already allocated then the matrix will be deallocated in the
+ *  process.
+ *
+ *  \ingroup allocate_group
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ *
+ *  Note: Do not use OpenMP when setting values for a random matrix,
+ *  this makes the operation non-repeatable.
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_random_matrix_ellblock) (
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    //create matrix
+    int *bsize = bml_get_block_sizes(N, M);
+    int mb = bml_get_mb();
+    int nb = bml_get_nb();
+
+    bml_matrix_ellblock_t *A =
+        TYPED_FUNC(bml_block_matrix_ellblock) (nb, mb, bsize, distrib_mode);
+
+    //now fill with random values
+    int NB = A->NB;
+    int MB = A->MB;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < MB; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            A_indexb[ind] = jp;
+            int jb = A_indexb[ind];
+
+            //allocate storage
+            int nelements = bsize[ib] * bsize[jb];
+            A_ptr_value[ind]
+                = bml_noinit_allocate_memory(nelements * sizeof(REAL_T));
+
+            REAL_T *A_value = A_ptr_value[ind];
+            assert(A_value != NULL);
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])] =
+                        rand() / (REAL_T) RAND_MAX;
+                }
+        }
+        A_nnzb[ib] = MB;
+    }
+    return A;
+}
+
+/** Allocate the identity matrix.
+ *
+ *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
+ *  already allocated then the matrix will be deallocated in the
+ *  process.
+ *
+ *  \ingroup allocate_group
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_identity_matrix_ellblock) (
+    const int N,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    int *bsize = bml_get_block_sizes(N, M);
+    int mb = bml_get_mb();
+    int nb = bml_get_nb();
+    assert(nb > 0);
+    assert(mb > 0);
+
+    bml_matrix_ellblock_t *A =
+        TYPED_FUNC(bml_block_matrix_ellblock) (nb, mb, bsize, distrib_mode);
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    int NB = A->NB;
+    int MB = A->MB;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        int nelements = bsize[ib] * bsize[ib];
+        int ind = ROWMAJOR(ib, 0, NB, MB);
+        A_ptr_value[ind] = bml_allocate_memory(nelements * sizeof(REAL_T));
+        REAL_T *A_value = A_ptr_value[ind];
+        for (int ii = 0; ii < bsize[ib]; ii++)
+        {
+            A_value[ROWMAJOR(ii, ii, bsize[ib], bsize[ib])] = 1.0;
+        }
+        A->nnzb[ib] = 1;
+        A->indexb[ind] = ib;
+    }
+
+    return A;
+}

--- a/src/C-interface/ellblock/bml_convert_ellblock.c
+++ b/src/C-interface/ellblock/bml_convert_ellblock.c
@@ -1,0 +1,36 @@
+#include "bml_convert_ellblock.h"
+#include "bml_logger.h"
+
+#include <stdlib.h>
+
+bml_matrix_ellblock_t *
+bml_convert_ellblock(
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_convert_ellblock_single_real(A, matrix_precision, M,
+                                                    distrib_mode);
+            break;
+        case double_real:
+            return bml_convert_ellblock_double_real(A, matrix_precision, M,
+                                                    distrib_mode);
+            break;
+        case single_complex:
+            return bml_convert_ellblock_single_complex(A, matrix_precision, M,
+                                                       distrib_mode);
+            break;
+        case double_complex:
+            return bml_convert_ellblock_double_complex(A, matrix_precision, M,
+                                                       distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}

--- a/src/C-interface/ellblock/bml_convert_ellblock.h
+++ b/src/C-interface/ellblock/bml_convert_ellblock.h
@@ -1,0 +1,38 @@
+/** \file */
+
+#ifndef __BML_CONVERT_ELLBLOCK_H
+#define __BML_CONVERT_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_ellblock_t *bml_convert_ellblock(
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_convert_ellblock_single_real(
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_convert_ellblock_double_real(
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_convert_ellblock_single_complex(
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_convert_ellblock_double_complex(
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+#endif

--- a/src/C-interface/ellblock/bml_convert_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_convert_ellblock_typed.c
@@ -1,0 +1,72 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_logger.h"
+#include "../bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_getters.h"
+#include "bml_introspection.h"
+#include "bml_setters.h"
+#include "bml_setters_ellblock.h"
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+#include <assert.h>
+#include <stdio.h>
+
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_convert_ellblock) (
+    const bml_matrix_t * A,
+    const bml_matrix_precision_t matrix_precision,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    int N = bml_get_N(A);
+
+    if (N < 0)
+    {
+        LOG_ERROR("A is not intialized\n");
+    }
+
+    //create new empty matrix
+    int *bsize = bml_get_block_sizes(N, N);
+    int nb = bml_get_nb();
+
+    bml_matrix_ellblock_t *B =
+        TYPED_FUNC(bml_block_matrix_ellblock) (nb, nb, bsize, distrib_mode);
+
+    int NB = B->NB;
+    int *offset = malloc(NB * sizeof(int));
+    offset[0] = 0;
+    for (int ib = 1; ib < NB; ib++)
+        offset[ib] = offset[ib - 1] + bsize[ib - 1];
+
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        B->nnzb[ib] = NB;
+        for (int jb = 0; jb < NB; jb++)
+        {
+            int nelements = bsize[ib] * bsize[jb];
+            int ind = ROWMAJOR(ib, jb, NB, NB);
+            B_ptr_value[ind]
+                = bml_noinit_allocate_memory(nelements * sizeof(REAL_T));;
+            B->indexb[ind] = jb;
+
+            REAL_T *block = malloc(nelements * sizeof(REAL_T));
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int i = offset[ib] + ii;
+                    int j = offset[jb] + jj;
+                    REAL_T alpha = *(REAL_T *) bml_get(A, i, j);
+                    block[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])] = alpha;
+                }
+            TYPED_FUNC(bml_set_block_ellblock) (B, ib, jb, block);
+            free(block);
+        }
+    }
+    free(offset);
+
+    return B;
+}

--- a/src/C-interface/ellblock/bml_copy_ellblock.c
+++ b/src/C-interface/ellblock/bml_copy_ellblock.c
@@ -1,0 +1,151 @@
+#include "bml_copy.h"
+#include "bml_copy_ellblock.h"
+#include "bml_logger.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+/** Copy an ellblock matrix - result is a new matrix.
+ *
+ *  \ingroup copy_group
+ *
+ *  \param A The matrix to be copied
+ *  \return A copy of matrix A.
+ */
+bml_matrix_ellblock_t *
+bml_copy_ellblock_new(
+    const bml_matrix_ellblock_t * A)
+{
+    bml_matrix_ellblock_t *B = NULL;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            B = bml_copy_ellblock_new_single_real(A);
+            break;
+        case double_real:
+            B = bml_copy_ellblock_new_double_real(A);
+            break;
+        case single_complex:
+            B = bml_copy_ellblock_new_single_complex(A);
+            break;
+        case double_complex:
+            B = bml_copy_ellblock_new_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return B;
+}
+
+/** Copy an ellblock matrix.
+ *
+ *  \ingroup copy_group
+ *
+ *  \param A The matrix to be copied
+ *  \param B Copy of matrix A
+ */
+void
+bml_copy_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_copy_ellblock_single_real(A, B);
+            break;
+        case double_real:
+            bml_copy_ellblock_double_real(A, B);
+            break;
+        case single_complex:
+            bml_copy_ellblock_single_complex(A, B);
+            break;
+        case double_complex:
+            bml_copy_ellblock_double_complex(A, B);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Reorder an ellblock matrix.
+ *
+ *  \ingroup copy_group
+ *
+ *  \param A The matrix to be reordered
+ *  \param B The permutation matrix
+ */
+void
+bml_reorder_ellblock(
+    bml_matrix_ellblock_t * A,
+    int *perm)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_reorder_ellblock_single_real(A, perm);
+            break;
+        case double_real:
+            bml_reorder_ellblock_double_real(A, perm);
+            break;
+        case single_complex:
+            bml_reorder_ellblock_single_complex(A, perm);
+            break;
+        case double_complex:
+            bml_reorder_ellblock_double_complex(A, perm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Save the domain for an ellblock matrix.
+ *
+ * \ingroup copy_group
+ *
+ * \param A The matrix with the domain to be saved
+ */
+void
+bml_save_domain_ellblock(
+    bml_matrix_ellblock_t * A)
+{
+    bml_copy_domain(A->domain, A->domain2);
+}
+
+/** Restore the domain for an ellblock matrix.
+ *
+ * \ingroup copy_group
+ *
+ * \param A The matrix with the domain to be restored
+ */
+void
+bml_restore_domain_ellblock(
+    bml_matrix_ellblock_t * A)
+{
+    bml_copy_domain(A->domain2, A->domain);
+
+/*
+    if (bml_printRank() == 1)
+    {
+      int nprocs = bml_getNRanks();
+      printf("Restored Domain\n");
+      for (int i = 0; i < nprocs; i++)
+      {
+        printf("rank %d localRow %d %d %d localElem %d localDispl %d\n",
+          i, A->domain->localRowMin[i], A->domain->localRowMax[i],
+          A->domain->localRowExtent[i], A->domain->localElements[i],
+          A->domain->localDispl[i]);
+      }
+    }
+*/
+}

--- a/src/C-interface/ellblock/bml_copy_ellblock.h
+++ b/src/C-interface/ellblock/bml_copy_ellblock.h
@@ -1,0 +1,67 @@
+#ifndef __BML_COPY_ELLBLOCK_H
+#define __BML_COPY_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_ellblock_t *bml_copy_ellblock_new(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_copy_ellblock_new_single_real(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_copy_ellblock_new_double_real(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_copy_ellblock_new_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_copy_ellblock_new_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+void bml_copy_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_copy_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_copy_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_copy_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_copy_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_reorder_ellblock(
+    bml_matrix_ellblock_t * A,
+    int *perm);
+
+void bml_reorder_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    int *perm);
+
+void bml_reorder_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    int *perm);
+
+void bml_reorder_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    int *perm);
+
+void bml_reorder_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    int *perm);
+
+void bml_save_domain_ellblock(
+    bml_matrix_ellblock_t * A);
+
+void bml_restore_domain_ellblock(
+    bml_matrix_ellblock_t * A);
+
+#endif

--- a/src/C-interface/ellblock/bml_copy_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_copy_ellblock_typed.c
@@ -1,0 +1,166 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_copy.h"
+#include "bml_types.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_copy_ellblock.h"
+#include "bml_types_ellblock.h"
+
+#include <assert.h>
+#include <complex.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Copy an ellblock matrix - result is a new matrix.
+ *
+ *  \ingroup copy_group
+ *
+ *  \param A The matrix to be copied
+ *  \return A copy of matrix A.
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_copy_ellblock_new) (
+    const bml_matrix_ellblock_t * A)
+{
+    bml_matrix_ellblock_t *B =
+        TYPED_FUNC(bml_block_matrix_ellblock) (A->NB, A->MB, A->bsize,
+                                               A->distribution_mode);
+
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_indexb = A->indexb;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    int *B_indexb = B->indexb;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    //    memcpy(B->index, A->index, sizeof(int) * A->N * A->M);
+    memcpy(B->nnzb, A->nnzb, sizeof(int) * A->NB);
+    //    memcpy(B->value, A->value, sizeof(REAL_T) * A->N * A->M);
+    memcpy(B->bsize, A->bsize, sizeof(int) * A->NB);
+
+    memcpy(B_indexb, A_indexb, NB * MB * sizeof(int));
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A->nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = B_indexb[ind];
+            B_ptr_value[ind]
+                = malloc(A->bsize[ib] * A->bsize[jb] * sizeof(REAL_T));
+
+            memcpy(B_ptr_value[ind], A_ptr_value[ind],
+                   A->bsize[ib] * A->bsize[jb] * sizeof(REAL_T));
+        }
+    }
+
+    return B;
+}
+
+/** Copy an ellblock matrix.
+ *
+ *  \ingroup copy_group
+ *
+ *  \param A The matrix to be copied
+ *  \param B Copy of matrix A
+ */
+void TYPED_FUNC(
+    bml_copy_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+    assert(A->NB == B->NB);
+
+    int NB = A->NB;
+    int MB = A->MB;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    memcpy(B->nnzb, A->nnzb, sizeof(int) * A->NB);
+
+    int *A_indexb = A->indexb;
+    int *B_indexb = B->indexb;
+    memcpy(B_indexb, A_indexb, NB * MB * sizeof(int));
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A->nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            assert(A_ptr_value[ind] != NULL);
+            int jb = B_indexb[ind];
+            int nelements = A->bsize[ib] * A->bsize[jb];
+            if (B_ptr_value[ind] == NULL)
+                B_ptr_value[ind]
+                    = bml_noinit_allocate_memory(nelements * sizeof(REAL_T));
+            memcpy(B_ptr_value[ind], A_ptr_value[ind],
+                   nelements * sizeof(REAL_T));
+        }
+    }
+}
+
+/** Reorder an ellblock matrix.
+ *
+ *  \ingroup copy_group
+ *
+ *  \param A The matrix to be reordered
+ *  \param B The permutation vector
+ */
+void TYPED_FUNC(
+    bml_reorder_ellblock) (
+    bml_matrix_ellblock_t * A,
+    int *perm)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_bsize = A->bsize;
+
+    bml_matrix_ellblock_t *B = bml_copy_new(A);
+    int *B_indexb = B->indexb;
+    int *B_nnzb = B->nnzb;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+    int *B_bsize = B->bsize;
+
+    for (int i = 0; i < NB; i++)
+    {
+        A_bsize[i] = B_bsize[perm[i]];
+    }
+
+    // Reorder rows - need to copy
+    for (int ib = 0; ib < NB; ib++)
+    {
+        memcpy(&A_indexb[ROWMAJOR(perm[ib], 0, NB, MB)],
+               &B_indexb[ROWMAJOR(ib, 0, NB, MB)], MB * sizeof(int));
+        int count = 0;
+        for (int jp = 0; jp < MB; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = B_indexb[ind];
+            count += B_bsize[jb];
+        }
+        memcpy(A_ptr_value[ROWMAJOR(perm[ib], 0, NB, MB)],
+               B_ptr_value[ROWMAJOR(ib, 0, NB, MB)],
+               B_bsize[ib] * count * sizeof(REAL_T));
+        A_nnzb[perm[ib]] = B_nnzb[ib];
+    }
+
+    bml_deallocate_ellblock(B);
+
+    // Reorder elements in each row - just change index
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            A_indexb[ROWMAJOR(ib, jp, NB, MB)] =
+                perm[A_indexb[ROWMAJOR(ib, jp, NB, MB)]];
+        }
+    }
+}

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock.c
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock.c
@@ -1,0 +1,42 @@
+#include "../bml_logger.h"
+#include "../bml_types.h"
+#include "../bml_utilities.h"
+#include "../dense/bml_types_dense.h"
+#include "bml_diagonalize_ellblock.h"
+#include "bml_types_ellblock.h"
+
+#include <string.h>
+
+/** \page diagonalize
+ *
+ */
+
+void
+bml_diagonalize_ellblock(
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_t * eigenvectors)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_diagonalize_ellblock_single_real(A, eigenvalues,
+                                                 eigenvectors);
+            break;
+        case double_real:
+            bml_diagonalize_ellblock_double_real(A, eigenvalues,
+                                                 eigenvectors);
+            break;
+        case single_complex:
+            bml_diagonalize_ellblock_single_complex(A, eigenvalues,
+                                                    eigenvectors);
+            break;
+        case double_complex:
+            bml_diagonalize_ellblock_double_complex(A, eigenvalues,
+                                                    eigenvectors);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock.h
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock.h
@@ -1,0 +1,31 @@
+#ifndef __BML_DIAGONALIZE_BELLBLOCK_H
+#define __BML_DIAGONALIZE_BELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+void bml_diagonalize_ellblock(
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_t * eigenvectors);
+
+void bml_diagonalize_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_ellblock_t * eigenvectors);
+
+void bml_diagonalize_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_ellblock_t * eigenvectors);
+
+void bml_diagonalize_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_ellblock_t * eigenvectors);
+
+void bml_diagonalize_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_ellblock_t * eigenvectors);
+
+#endif

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock_typed.c
@@ -1,0 +1,91 @@
+#include "bml_allocate_ellblock.h"
+#include "../bml_allocate.h"
+#include "bml_copy_ellblock.h"
+#include "bml_diagonalize_ellblock.h"
+#include "bml_export_ellblock.h"
+#include "bml_import_ellblock.h"
+#include "../bml_diagonalize.h"
+#include "bml_types_ellblock.h"
+#include "../bml_types.h"
+#include "../bml_utilities.h"
+#include "../dense/bml_allocate_dense.h"
+#include "../dense/bml_import_dense.h"
+#include "../dense/bml_diagonalize_dense.h"
+#include "../dense/bml_types_dense.h"
+#include "../../macros.h"
+#include "../../typed.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Diagonalize matrix.
+ *
+ *  \ingroup diag_group
+ *
+ *  \param A The matrix A
+ *  \param eigenvalues Eigenvalues of A
+ *  \param eigenvectors Eigenvectors of A
+ */
+void TYPED_FUNC(
+    bml_diagonalize_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    void *eigenvalues,
+    bml_matrix_ellblock_t * eigenvectors)
+{
+    double threshold = 0.0;
+    bml_matrix_dense_t *D;
+    bml_matrix_dense_t *eigenvectors_bml_dense;
+    REAL_T *A_dense;
+    REAL_T *eigenvectors_dense;
+    REAL_T *typed_eigenvalues = (REAL_T *) eigenvalues;
+    bml_matrix_ellblock_t *myeigenvectors =
+        (bml_matrix_ellblock_t *) eigenvectors;
+
+    // Form ellblock_bml to dense_array
+    A_dense = bml_export_to_dense_ellblock(A, dense_row_major);
+
+    // From dense_array to dense_bml
+    D = bml_import_from_dense_dense(A->matrix_precision, dense_row_major,
+                                    A->N, A_dense, threshold,
+                                    A->distribution_mode);
+    free(A_dense);
+
+    // Allocate eigenvectors matrix in dense_bml
+    eigenvectors_bml_dense =
+        bml_zero_matrix(dense, A->matrix_precision, A->N, A->N, sequential);
+
+    // Diagonalize in dense_bml
+    TYPED_FUNC(bml_diagonalize_dense) (D, typed_eigenvalues,
+                                       eigenvectors_bml_dense);
+
+    bml_deallocate_dense(D);
+
+    // bml_print_bml_matrix(eigenvectors_bml_dense, 0, A->N, 0, A->N);
+
+    // From dense_bml to dense_array
+    eigenvectors_dense =
+        bml_export_to_dense_dense(eigenvectors_bml_dense, dense_row_major);
+    bml_deallocate_dense(eigenvectors_bml_dense);
+
+    // From dense_array to ellblock_bml
+    myeigenvectors = bml_import_from_dense_ellblock(A->matrix_precision,
+                                                    dense_row_major, A->N,
+                                                    eigenvectors_dense,
+                                                    threshold, A->M,
+                                                    A->distribution_mode);
+    free(eigenvectors_dense);
+
+    // This is done in order to pass the changes back to the upper level
+    bml_copy_ellblock(myeigenvectors, eigenvectors);
+
+    bml_deallocate_ellblock(myeigenvectors);
+
+    return;
+}

--- a/src/C-interface/ellblock/bml_export_ellblock.c
+++ b/src/C-interface/ellblock/bml_export_ellblock.c
@@ -1,0 +1,42 @@
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_export_ellblock.h"
+#include "bml_logger.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/** Convert a bml matrix into a dense matrix.
+ *
+ * \ingroup convert_group
+ *
+ * \param A The bml matrix
+ * \return The dense matrix
+ */
+void *
+bml_export_to_dense_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            return bml_export_to_dense_ellblock_single_real(A, order);
+            break;
+        case double_real:
+            return bml_export_to_dense_ellblock_double_real(A, order);
+            break;
+        case single_complex:
+            return bml_export_to_dense_ellblock_single_complex(A, order);
+            break;
+        case double_complex:
+            return bml_export_to_dense_ellblock_double_complex(A, order);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}

--- a/src/C-interface/ellblock/bml_export_ellblock.h
+++ b/src/C-interface/ellblock/bml_export_ellblock.h
@@ -1,0 +1,26 @@
+#ifndef __BML_EXPORT_ELLBLOCK_H
+#define __BML_EXPORT_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+void *bml_export_to_dense_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order);
+
+void *bml_export_to_dense_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order);
+
+void *bml_export_to_dense_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order);
+
+void *bml_export_to_dense_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order);
+
+void *bml_export_to_dense_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order);
+
+#endif

--- a/src/C-interface/ellblock/bml_export_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_export_ellblock_typed.c
@@ -1,0 +1,102 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_export_ellblock.h"
+#include "bml_logger.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdio.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Convert a bml matrix into a dense matrix.
+ *
+ * \ingroup convert_group
+ *
+ * \param A The bml matrix
+ * \return The dense matrix
+ */
+void *TYPED_FUNC(
+    bml_export_to_dense_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_dense_order_t order)
+{
+    assert(A->N > 0);
+
+    int N = A->N;
+    int NB = A->NB;
+    int MB = A->MB;
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+    int *bsize = A->bsize;
+    REAL_T *A_dense = bml_allocate_memory(sizeof(REAL_T) * N * N);
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *offset = malloc(NB * sizeof(int));
+    offset[0] = 0;
+    for (int ib = 1; ib < NB; ib++)
+    {
+        offset[ib] = offset[ib - 1] + bsize[ib - 1];
+        assert(offset[ib] < N);
+    }
+    switch (order)
+    {
+        case dense_row_major:
+            for (int ib = 0; ib < NB; ib++)
+            {
+                for (int jp = 0; jp < A_nnzb[ib]; jp++)
+                {
+                    int ind = ROWMAJOR(ib, jp, NB, MB);
+                    int jb = A_indexb[ind];
+                    REAL_T *A_value = A_ptr_value[ind];
+                    assert(A_value != NULL);
+                    for (int ii = 0; ii < bsize[ib]; ii++)
+                        for (int jj = 0; jj < bsize[jb]; jj++)
+                        {
+                            int i = offset[ib] + ii;
+                            int j = offset[jb] + jj;
+                            A_dense[ROWMAJOR(i, j, N, N)]
+                                =
+                                A_value[ROWMAJOR
+                                        (ii, jj, bsize[ib], bsize[jb])];
+                        }
+                }
+            }
+            break;
+        case dense_column_major:
+            for (int ib = 0; ib < NB; ib++)
+            {
+                for (int jp = 0; jp < A_nnzb[ib]; jp++)
+                {
+                    int ind = ROWMAJOR(ib, jp, NB, MB);
+                    int jb = A_indexb[ind];
+                    REAL_T *A_value = A_ptr_value[ind];
+                    for (int ii = 0; ii < bsize[ib]; ii++)
+                        for (int jj = 0; jj < bsize[jb]; jj++)
+                        {
+                            int i = offset[ib] + ii;
+                            int j = offset[jb] + jj;
+                            A_dense[COLMAJOR(i, j, N, N)]
+                                =
+                                A_value[ROWMAJOR
+                                        (ii, jj, bsize[ib], bsize[jb])];
+                        }
+                }
+            }
+            break;
+        default:
+            LOG_ERROR("unknown order\n");
+            break;
+    }
+    free(offset);
+
+    return A_dense;
+}

--- a/src/C-interface/ellblock/bml_getters_ellblock.c
+++ b/src/C-interface/ellblock/bml_getters_ellblock.c
@@ -1,0 +1,82 @@
+#include "bml_getters_ellblock.h"
+#include "../bml_introspection.h"
+#include "../bml_logger.h"
+#include "bml_types_ellblock.h"
+
+void *
+bml_get_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j)
+{
+    switch (bml_get_precision(A))
+    {
+        case single_real:
+            return bml_get_ellblock_single_real(A, i, j);
+            break;
+        case double_real:
+            return bml_get_ellblock_double_real(A, i, j);
+            break;
+        case single_complex:
+            return bml_get_ellblock_single_complex(A, i, j);
+            break;
+        case double_complex:
+            return bml_get_ellblock_double_complex(A, i, j);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision in bml_get_ellblock\n");
+            break;
+    }
+    return NULL;
+}
+
+void *
+bml_get_row_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i)
+{
+    switch (bml_get_precision(A))
+    {
+        case single_real:
+            return bml_get_row_ellblock_single_real(A, i);
+            break;
+        case double_real:
+            return bml_get_row_ellblock_double_real(A, i);
+            break;
+        case single_complex:
+            return bml_get_row_ellblock_single_complex(A, i);
+            break;
+        case double_complex:
+            return bml_get_row_ellblock_double_complex(A, i);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision in bml_get_row_ellblock\n");
+            break;
+    }
+    return NULL;
+}
+
+void *
+bml_get_diagonal_ellblock(
+    bml_matrix_ellblock_t * A)
+{
+    switch (bml_get_precision(A))
+    {
+        case single_real:
+            return bml_get_diagonal_ellblock_single_real(A);
+            break;
+        case double_real:
+            return bml_get_diagonal_ellblock_double_real(A);
+            break;
+        case single_complex:
+            return bml_get_diagonal_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            return bml_get_diagonal_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision in bml_get_diagonal_ellblock\n");
+            break;
+    }
+    return NULL;
+}

--- a/src/C-interface/ellblock/bml_getters_ellblock.h
+++ b/src/C-interface/ellblock/bml_getters_ellblock.h
@@ -1,0 +1,70 @@
+/** \file */
+
+#ifndef __BML_GETTERS_ELLBLOCK_H
+#define __BML_GETTERS_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+
+void *bml_get_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j);
+
+float *bml_get_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j);
+
+double *bml_get_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j);
+
+float complex *bml_get_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j);
+
+double complex *bml_get_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j);
+
+void *bml_get_row_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i);
+
+void *bml_get_row_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int i);
+
+void *bml_get_row_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int i);
+
+void *bml_get_row_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int i);
+
+void *bml_get_row_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int i);
+
+void *bml_get_diagonal_ellblock(
+    bml_matrix_ellblock_t * A);
+
+void *bml_get_diagonal_ellblock_single_real(
+    bml_matrix_ellblock_t * A);
+
+void *bml_get_diagonal_ellblock_double_real(
+    bml_matrix_ellblock_t * A);
+
+void *bml_get_diagonal_ellblock_single_complex(
+    bml_matrix_ellblock_t * A);
+
+void *bml_get_diagonal_ellblock_double_complex(
+    bml_matrix_ellblock_t * A);
+
+#endif

--- a/src/C-interface/ellblock/bml_getters_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_getters_ellblock_typed.c
@@ -1,0 +1,166 @@
+#include "bml_getters_ellblock.h"
+#include "../bml_introspection.h"
+#include "../bml_logger.h"
+#include "bml_types_ellblock.h"
+#include "../../macros.h"
+#include "../../typed.h"
+
+#include <complex.h>
+#include <stdlib.h>
+#include <assert.h>
+
+/** Return a single matrix element.
+ *
+ * \param A The bml matrix
+ * \param i The row index
+ * \param j The column index
+ * \return The matrix element
+ */
+REAL_T *TYPED_FUNC(
+    bml_get_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const int i,
+    const int j)
+{
+    static REAL_T MINUS_ONE = -1;
+    static REAL_T ZERO = 0;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *bsize = A->bsize;
+
+    if (i < 0 || i >= A->N)
+    {
+        LOG_ERROR("row index out of bounds\n");
+        return &MINUS_ONE;
+    }
+    if (j < 0 || j >= A->N)
+    {
+        LOG_ERROR("column index out of bounds\n");
+        return &MINUS_ONE;
+    }
+    //determine block index and index within block
+    int ib = 0;
+    int jb = 0;
+    int ii = i;
+    int jj = j;
+    while (ii >= bsize[ib])
+    {
+        ii -= bsize[ib];
+        ib++;
+    }
+    while (jj >= bsize[jb])
+    {
+        jj -= bsize[jb];
+        jb++;
+    }
+    for (int jp = 0; jp < A->nnzb[ib]; jp++)
+    {
+        int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+        if (A->indexb[ind] == jb)
+        {
+            REAL_T *A_value = A_ptr_value[ind];
+            return &A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])];
+        }
+    }
+    return &ZERO;
+}
+
+/** Get row i of matrix A.
+ *
+ *  \ingroup getters
+ *
+ *  \param A The matrix which takes row i
+ *  \param i The index of the row to get
+ *  \param row Array to copy the row
+ *
+ */
+void *TYPED_FUNC(
+    bml_get_row_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int i)
+{
+    int A_NB = A->NB;
+    int A_MB = A->MB;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *bsize = A->bsize;
+
+    REAL_T *row = calloc(A->N, sizeof(REAL_T));
+    for (int ii = 0; ii < A->N; ii++)
+    {
+        row[ii] = 0.0;
+    }
+
+    //determine row block index and row index within block
+    int ib = 0;
+    int ii = i;
+    while (ii >= bsize[ib])
+    {
+        ii -= bsize[ib];
+        ib++;
+    }
+
+    int *offset = malloc(A_NB * sizeof(int));
+    offset[0] = 0;
+    for (int jb = 1; jb < A_NB; jb++)
+        offset[jb] = offset[jb - 1] + bsize[jb - 1];
+
+    for (int jp = 0; jp < A_nnzb[ib]; jp++)
+    {
+        int ind = ROWMAJOR(ib, jp, A_NB, A_MB);
+        int jb = A_indexb[ind];
+        if (jb >= 0)
+        {
+            REAL_T *A_value = A_ptr_value[ind];
+            for (int jj = 0; jj < bsize[jb]; jj++)
+            {
+                int ll = offset[jb] + jj;
+                row[ll] = A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])];
+            }
+        }
+    }
+    free(offset);
+
+    return row;
+}
+
+/** Get the diagonal of matrix A.
+ *
+ *  \ingroup getters
+ *
+ *  \param A The matrix which takes row i
+ *  \param Diagonal Array to copy the diagonal
+ *
+ */
+void *TYPED_FUNC(
+    bml_get_diagonal_ellblock) (
+    bml_matrix_ellblock_t * A)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *indexb = A->indexb;
+    int *nnzb = A->nnzb;
+    int *bsize = A->bsize;
+    REAL_T *diagonal = calloc(A->N, sizeof(REAL_T));
+
+    int offset = 0;
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            if (indexb[ind] == ib)
+            {
+                REAL_T *A_value = A_ptr_value[ind];
+                assert(A_value != NULL);
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    diagonal[offset + ii]
+                        = A_value[ROWMAJOR(ii, ii, bsize[ib], bsize[ib])];
+            }
+        }
+        offset += bsize[ib];
+    }
+
+    return diagonal;
+}

--- a/src/C-interface/ellblock/bml_import_ellblock.c
+++ b/src/C-interface/ellblock/bml_import_ellblock.c
@@ -1,0 +1,60 @@
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_import_ellblock.h"
+#include "bml_logger.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/** Convert a dense matrix into a bml matrix.
+ *
+ * \ingroup convert_group
+ *
+ * \param N The number of rows/columns
+ * \param matrix_precision The real precision
+ * \param A The dense matrix
+ * \param threshold The matrix element magnited threshold
+ * \return The bml matrix
+ */
+bml_matrix_ellblock_t *
+bml_import_from_dense_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_import_from_dense_ellblock_single_real(order, N, A,
+                                                              threshold, M,
+                                                              distrib_mode);
+            break;
+        case double_real:
+            return bml_import_from_dense_ellblock_double_real(order, N, A,
+                                                              threshold, M,
+                                                              distrib_mode);
+            break;
+        case single_complex:
+            return bml_import_from_dense_ellblock_single_complex(order, N, A,
+                                                                 threshold,
+                                                                 M,
+                                                                 distrib_mode);
+            break;
+        case double_complex:
+            return bml_import_from_dense_ellblock_double_complex(order, N, A,
+                                                                 threshold,
+                                                                 M,
+                                                                 distrib_mode);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}

--- a/src/C-interface/ellblock/bml_import_ellblock.h
+++ b/src/C-interface/ellblock/bml_import_ellblock.h
@@ -1,0 +1,47 @@
+#ifndef __BML_IMPORT_ELLBLOCK_H
+#define __BML_IMPORT_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_ellblock_t *bml_import_from_dense_ellblock(
+    const bml_matrix_precision_t matrix_precision,
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_import_from_dense_ellblock_single_real(
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_import_from_dense_ellblock_double_real(
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_import_from_dense_ellblock_single_complex(
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+bml_matrix_ellblock_t *bml_import_from_dense_ellblock_double_complex(
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode);
+
+#endif

--- a/src/C-interface/ellblock/bml_import_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_import_ellblock_typed.c
@@ -1,0 +1,103 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_import_ellblock.h"
+#include "bml_logger.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Convert a dense matrix into a bml matrix.
+ *
+ * \ingroup convert_group
+ *
+ * \param N The number of rows/columns
+ * \param matrix_precision The real precision
+ * \param A The dense matrix
+ * \return The bml matrix
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_import_from_dense_ellblock) (
+    const bml_dense_order_t order,
+    const int N,
+    const void *A,
+    const double threshold,
+    const int M,
+    const bml_distribution_mode_t distrib_mode)
+{
+    bml_matrix_ellblock_t *A_bml =
+        TYPED_FUNC(bml_zero_matrix_ellblock) (N, M, distrib_mode);
+
+    int NB = A_bml->NB;
+    int MB = A_bml->MB;
+    int *A_indexb = A_bml->indexb;
+    int *A_nnzb = A_bml->nnzb;
+    int *A_bsize = A_bml->bsize;
+
+    REAL_T *dense_A = (REAL_T *) A;
+
+    int *offset = malloc(NB * sizeof(int));
+    offset[0] = 0;
+    for (int ib = 1; ib < NB; ib++)
+    {
+        offset[ib] = offset[ib - 1] + A_bsize[ib - 1];
+    }
+
+    //allocate and assign data values
+    for (int ib = 0; ib < NB; ib++)
+    {
+        A_nnzb[ib] = 0;
+        for (int jb = 0; jb < NB; jb++)
+        {
+            int nelements = A_bsize[ib] * A_bsize[jb];
+            REAL_T *A_ij = malloc(nelements * sizeof(REAL_T));
+            switch (order)
+            {
+                case dense_row_major:
+                    for (int ii = 0; ii < A_bsize[ib]; ii++)
+                        for (int jj = 0; jj < A_bsize[jb]; jj++)
+                            A_ij[ROWMAJOR(ii, jj, A_bsize[ib], A_bsize[jb])]
+                                = dense_A[ROWMAJOR(offset[ib] + ii,
+                                                   offset[jb] + jj, N, N)];
+                    break;
+                case dense_column_major:
+                    for (int ii = 0; ii < A_bsize[ib]; ii++)
+                        for (int jj = 0; jj < A_bsize[jb]; jj++)
+                            A_ij[ROWMAJOR(ii, jj, A_bsize[ib], A_bsize[jb])]
+                                = dense_A[COLMAJOR(offset[ib] + ii,
+                                                   offset[jb] + jj, N, N)];
+                    break;
+                default:
+                    LOG_ERROR("unknown order\n");
+                    break;
+            }
+            double norminf = TYPED_FUNC(bml_norm_inf)
+                (A_ij, A_bsize[ib], A_bsize[jb], A_bsize[jb]);
+            if (is_above_threshold(norminf, threshold))
+            {
+                int ind = ROWMAJOR(ib, A_nnzb[ib], NB, MB);
+                A_bml->ptr_value[ind] = malloc(nelements * sizeof(REAL_T));
+                REAL_T *A_value = A_bml->ptr_value[ind];
+                assert(A_value != NULL);
+                memcpy(A_value, A_ij, nelements * sizeof(REAL_T));
+                A_indexb[ind] = jb;
+                A_nnzb[ib]++;
+            }
+            free(A_ij);
+        }
+    }
+    free(offset);
+
+    return A_bml;
+}

--- a/src/C-interface/ellblock/bml_introspection_ellblock.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.c
@@ -1,0 +1,192 @@
+#include "bml_introspection_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "bml_logger.h"
+#include "../../macros.h"
+#include "../bml_types.h"
+#include "../bml_introspection.h"
+#include "../bml_logger.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+
+
+/** Return the matrix precision.
+ *
+ * \param A The matrix.
+ * \return The matrix precision.
+ */
+bml_matrix_precision_t
+bml_get_precision_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    if (A != NULL)
+    {
+        return A->matrix_precision;
+    }
+    else
+    {
+        return precision_uninitialized;
+    }
+}
+
+/** Return the matrix distribution mode.
+ *
+ * \param A The matrix.
+ * \return The matrix distribution mode.
+ */
+bml_distribution_mode_t
+bml_get_distribution_mode_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    if (A != NULL)
+    {
+        return A->distribution_mode;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+/** Return the matrix size.
+ *
+ * \param A The matrix.
+ * \return The matrix size.
+ */
+int
+bml_get_N_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    if (A != NULL)
+    {
+        return A->N;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+/** Return the matrix parameter M.
+ *
+ * \param A The matrix.
+ * \return The matrix parameter M.
+ */
+int
+bml_get_M_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    if (A != NULL)
+    {
+        return A->M;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+int
+bml_get_NB_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    if (A != NULL)
+    {
+        return A->NB;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+/** Return the bandwidth of a row in the matrix.
+ *
+ * \param A The bml matrix.
+ * \param i The row index.
+ * \return The bandwidth of row i.
+ */
+int
+bml_get_row_bandwidth_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const int i)
+{
+    //determine block index and index within block
+    int ib = 0;
+    int ii = i;
+    while (ii >= A->bsize[ib])
+    {
+        ii -= A->bsize[ib];
+        ib++;
+    }
+    int row_bandwidth = 0;
+    for (int jp = 0; jp < A->nnzb[ib]; jp++)
+    {
+        int jb = A->indexb[ROWMAJOR(ib, jp, A->NB, A->MB)];
+        row_bandwidth += A->bsize[jb];
+    }
+    return row_bandwidth;
+}
+
+/** Return the bandwidth of a matrix.
+ *
+ * \param A The bml matrix.
+ * \return The bandwidth of row i.
+ */
+int
+bml_get_bandwidth_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    int max_bandwidth = 0;
+    int offset = 0;
+    for (int ib = 0; ib < A->NB; ib++)
+    {
+        int bw = bml_get_row_bandwidth_ellblock(A, offset);
+        max_bandwidth = (bw > max_bandwidth ? bw : max_bandwidth);
+        offset += A->bsize[ib];
+    }
+    return max_bandwidth;
+}
+
+
+/** Return the sparsity of a matrix.
+ *
+ *  Note that the the sparsity of a matrix is defined
+ *  as NumberOfZeroes/N*N where N is the matrix dimension.
+ *  The density of matrix A will be defined as 1-sparsity(A)
+ *
+ * \ingroup introspection_group_C
+ *
+ * \param A The bml matrix.
+ * \param threshold The threshold used to compute the sparsity.
+ * \return The sparsity of A.
+ */
+double
+bml_get_sparsity_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double threshold)
+{
+    switch (bml_get_precision_ellblock(A))
+    {
+        case single_real:
+            return bml_get_sparsity_ellblock_single_real(A, threshold);
+            break;
+        case double_real:
+            return bml_get_sparsity_ellblock_double_real(A, threshold);
+            break;
+        case single_complex:
+            return bml_get_sparsity_ellblock_single_complex(A, threshold);
+            break;
+        case double_complex:
+            return bml_get_sparsity_ellblock_double_complex(A, threshold);
+            break;
+        case precision_uninitialized:
+            LOG_ERROR("precision not initialized");
+            break;
+        default:
+            LOG_ERROR("fatal logic error\n");
+            break;
+    }
+    return -1;
+}

--- a/src/C-interface/ellblock/bml_introspection_ellblock.h
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.h
@@ -1,0 +1,49 @@
+#ifndef __BML_INTROSPECTION_ELLBLOCK_H
+#define __BML_INTROSPECTION_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_precision_t bml_get_precision_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+bml_distribution_mode_t bml_get_distribution_mode_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+int bml_get_N_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+int bml_get_M_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+int bml_get_NB_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+int bml_get_row_bandwidth_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const int i);
+
+int bml_get_bandwidth_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+    // Get the sparsity of a bml matrix
+double bml_get_sparsity_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+double bml_get_sparsity_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+double bml_get_sparsity_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+double bml_get_sparsity_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+double bml_get_sparsity_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+#endif

--- a/src/C-interface/ellblock/bml_introspection_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock_typed.c
@@ -1,0 +1,61 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_introspection.h"
+#include "bml_introspection_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "bml_types.h"
+#include "bml_utilities_ellblock.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <complex.h>
+#include <math.h>
+
+/** Return the sparsity of a matrix.
+ *
+ *  Note that the the sparsity of a matrix is defined
+ *  as NumberOfZeroes/N*N where N is the matrix dimension.
+ *  To density of matrix A will be defined as 1-sparsity(A)
+ *
+ * \ingroup introspection_group_C
+ *
+ * \param A The bml matrix.
+ * \param threshold The threshold used to compute the sparsity.
+ * \return The sparsity of A.
+ */
+double TYPED_FUNC(
+    bml_get_sparsity_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const double threshold)
+{
+    int nnzs = 0;
+    double sparsity;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int NB = A->NB;
+    int MB = A->MB;
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+    int *bsize = A->bsize;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            REAL_T *A_value = A_ptr_value[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    if (ABS(A_value[index]) > threshold)
+                    {
+                        nnzs++;
+                    }
+                }
+        }
+    }
+
+    sparsity = (1.0 - (double) nnzs / ((double) (A->N * A->N)));
+    return sparsity;
+}

--- a/src/C-interface/ellblock/bml_inverse_ellblock.c
+++ b/src/C-interface/ellblock/bml_inverse_ellblock.c
@@ -1,0 +1,41 @@
+#include "../bml_logger.h"
+#include "../bml_types.h"
+#include "bml_inverse_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "../bml_utilities.h"
+
+#include <string.h>
+
+/** \page inverse
+ *
+ */
+
+bml_matrix_ellblock_t *
+bml_inverse_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+
+    bml_matrix_ellblock_t *B = NULL;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            B = bml_inverse_ellblock_single_real(A);
+            break;
+        case double_real:
+            B = bml_inverse_ellblock_double_real(A);
+            break;
+        case single_complex:
+            B = bml_inverse_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            B = bml_inverse_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+
+    return B;
+
+}

--- a/src/C-interface/ellblock/bml_inverse_ellblock.h
+++ b/src/C-interface/ellblock/bml_inverse_ellblock.h
@@ -1,0 +1,21 @@
+#ifndef __BML_INVERSE_ELLBLOCK_H
+#define __BML_INVERSE_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_ellblock_t *bml_inverse_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_inverse_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_inverse_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_inverse_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_inverse_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+#endif

--- a/src/C-interface/ellblock/bml_inverse_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_inverse_ellblock_typed.c
@@ -1,0 +1,68 @@
+#include "bml_allocate_ellblock.h"
+#include "../bml_allocate.h"
+#include "bml_copy_ellblock.h"
+#include "bml_export_ellblock.h"
+#include "bml_inverse_ellblock.h"
+#include "../bml_inverse.h"
+#include "bml_types_ellblock.h"
+#include "../bml_types.h"
+#include "../bml_utilities.h"
+#include "../dense/bml_allocate_dense.h"
+#include "../dense/bml_import_dense.h"
+#include "../dense/bml_inverse_dense.h"
+#include "../dense/bml_types_dense.h"
+#include "bml_import_ellblock.h"
+#include "../../macros.h"
+#include "../../typed.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Matrix inverse.
+ *
+ *  \ingroup inverse_group
+ *
+ *  \param A The matrix A
+ *  \return The inverse of matrix A
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_inverse_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    double threshold = 0.0;
+    bml_matrix_dense_t *D;
+    bml_matrix_ellblock_t *B;
+    REAL_T *A_dense;
+
+    // From ellblock_bml to dense_array
+    A_dense = bml_export_to_dense_ellblock(A, dense_row_major);
+
+    // From dense_array to dense_bml
+    D = bml_import_from_dense_dense(A->matrix_precision, dense_row_major,
+                                    A->N, A_dense, threshold,
+                                    A->distribution_mode);
+
+    bml_free_memory(A_dense);
+
+    // Calculate inverse in dense_bml
+    TYPED_FUNC(bml_inverse_inplace_dense) (D);
+
+    A_dense = bml_export_to_dense_dense(D, dense_row_major);
+    bml_deallocate_dense(D);
+
+    // From dense_array to ellblock_bml
+    B = bml_import_from_dense_ellblock(A->matrix_precision,
+                                       dense_row_major, A->N,
+                                       A_dense,
+                                       threshold, A->M, A->distribution_mode);
+    bml_free_memory(A_dense);
+
+    return B;
+}

--- a/src/C-interface/ellblock/bml_multiply_ellblock.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock.c
@@ -1,0 +1,172 @@
+#include "bml_add.h"
+#include "bml_add_ellblock.h"
+#include "bml_logger.h"
+#include "bml_multiply.h"
+#include "bml_multiply_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Matrix multiply.
+ *
+ * C = alpha * A * B + beta * C
+ *
+ *  \ingroup multiply_group
+ *
+ *  \param A Matrix A
+ *  \param B Matrix B
+ *  \param C Matrix C
+ *  \param alpha Scalar factor multiplied by A * B
+ *  \param beta Scalar factor multiplied by C
+ *  \param threshold Used for sparse multiply
+ */
+void
+bml_multiply_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_multiply_ellblock_single_real(A, B, C, alpha, beta,
+                                              threshold);
+            break;
+        case double_real:
+            bml_multiply_ellblock_double_real(A, B, C, alpha, beta,
+                                              threshold);
+            break;
+        case single_complex:
+            bml_multiply_ellblock_single_complex(A, B, C, alpha, beta,
+                                                 threshold);
+            break;
+        case double_complex:
+            bml_multiply_ellblock_double_complex(A, B, C, alpha, beta,
+                                                 threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Matrix multiply.
+ *
+ * X2 = X * X
+ *
+ *  \ingroup multiply_group
+ *
+ *  \param X Matrix X
+ *  \param X2 Matrix X2
+ *  \param threshold Used for sparse multiply
+ */
+void *
+bml_multiply_x2_ellblock(
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold)
+{
+    switch (X->matrix_precision)
+    {
+        case single_real:
+            return bml_multiply_x2_ellblock_single_real(X, X2, threshold);
+            break;
+        case double_real:
+            return bml_multiply_x2_ellblock_double_real(X, X2, threshold);
+            break;
+        case single_complex:
+            return bml_multiply_x2_ellblock_single_complex(X, X2, threshold);
+            break;
+        case double_complex:
+            return bml_multiply_x2_ellblock_double_complex(X, X2, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}
+
+/** Matrix multiply.
+ *
+ * C = A * B
+ *
+ *  \ingroup multiply_group
+ *
+ *  \param A Matrix A
+ *  \param B Matrix B
+ *  \param C Matrix C
+ *  \param threshold Used for sparse multiply
+ */
+void
+bml_multiply_AB_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_multiply_AB_ellblock_single_real(A, B, C, threshold);
+            break;
+        case double_real:
+            bml_multiply_AB_ellblock_double_real(A, B, C, threshold);
+            break;
+        case single_complex:
+            bml_multiply_AB_ellblock_single_complex(A, B, C, threshold);
+            break;
+        case double_complex:
+            bml_multiply_AB_ellblock_double_complex(A, B, C, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Matrix multiply with threshold adjustment.
+ *
+ * C = A * B
+ *
+ *  \ingroup multiply_group
+ *
+ *  \param A Matrix A
+ *  \param B Matrix B
+ *  \param C Matrix C
+ *  \param threshold Used for sparse multiply
+ */
+void
+bml_multiply_adjust_AB_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_multiply_adjust_AB_ellblock_single_real(A, B, C, threshold);
+            break;
+        case double_real:
+            bml_multiply_adjust_AB_ellblock_double_real(A, B, C, threshold);
+            break;
+        case single_complex:
+            bml_multiply_adjust_AB_ellblock_single_complex(A, B, C,
+                                                           threshold);
+            break;
+        case double_complex:
+            bml_multiply_adjust_AB_ellblock_double_complex(A, B, C,
+                                                           threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_multiply_ellblock.h
+++ b/src/C-interface/ellblock/bml_multiply_ellblock.h
@@ -1,0 +1,131 @@
+#ifndef __BML_MULTIPLY_ELLBLOCK_H
+#define __BML_MULTIPLY_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+void bml_multiply_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_multiply_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_multiply_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_multiply_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void bml_multiply_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+void *bml_multiply_x2_ellblock(
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold);
+
+void *bml_multiply_x2_ellblock_single_real(
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold);
+
+void *bml_multiply_x2_ellblock_double_real(
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold);
+
+void *bml_multiply_x2_ellblock_single_complex(
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold);
+
+void *bml_multiply_x2_ellblock_double_complex(
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold);
+
+void bml_multiply_AB_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_AB_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_AB_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_AB_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_AB_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_adjust_AB_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_adjust_AB_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_adjust_AB_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_adjust_AB_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+void bml_multiply_adjust_AB_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold);
+
+#endif

--- a/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
@@ -1,0 +1,485 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_add.h"
+#include "bml_add_ellblock.h"
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_logger.h"
+#include "bml_multiply.h"
+#include "bml_multiply_ellblock.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+#include "bml_multiply.h"
+#include "../../internal-blas/bml_gemm.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Matrix multiply.
+ *
+ * \f$ C \leftarrow \alpha A \, B + \beta C \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param alpha Scalar factor multiplied by A * B
+ * \param beta Scalar factor multiplied by C
+ * \param threshold Used for sparse multiply
+ */
+void TYPED_FUNC(
+    bml_multiply_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    const double ONE = 1.0;
+    const double ZERO = 0.0;
+
+    if (A == NULL || B == NULL)
+    {
+        LOG_ERROR("Either matrix A or B are NULL\n");
+    }
+
+    if (A == B && alpha == ONE && beta == ZERO)
+    {
+        TYPED_FUNC(bml_multiply_x2_ellblock) (A, C, threshold);
+    }
+    else
+    {
+        bml_matrix_ellblock_t *A2 =
+            TYPED_FUNC(bml_block_matrix_ellblock) (A->NB, A->MB, A->bsize,
+                                                   A->distribution_mode);
+
+        if (A != NULL && A == B)
+        {
+            TYPED_FUNC(bml_multiply_x2_ellblock) (A, A2, threshold);
+        }
+        else
+        {
+            TYPED_FUNC(bml_multiply_AB_ellblock) (A, B, A2, threshold);
+        }
+
+#ifdef DO_MPI
+        if (bml_getNRanks() > 1 && A2->distribution_mode == distributed)
+        {
+            bml_allGatherVParallel(A2);
+        }
+#endif
+
+        TYPED_FUNC(bml_add_ellblock) (C, A2, beta, alpha, threshold);
+
+        bml_deallocate_ellblock(A2);
+    }
+}
+
+/** Matrix multiply.
+ *
+ * \f$ X^{2} \leftarrow X \, X \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param X Matrix X
+ * \param X2 Matrix X2
+ * \param threshold Used for sparse multiply
+ */
+void *TYPED_FUNC(
+    bml_multiply_x2_ellblock) (
+    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X2,
+    const double threshold)
+{
+    int NB = X->NB;
+    int MB = X->MB;
+    int *X_indexb = X->indexb;
+    int *X_nnzb = X->nnzb;
+    int *bsize = X->bsize;
+
+    int *X2_indexb = X2->indexb;
+    int *X2_nnzb = X2->nnzb;
+
+    int ix[NB], jx[NB];
+    REAL_T *x_ptr[NB];
+
+    REAL_T traceX = 0.0;
+    REAL_T traceX2 = 0.0;
+    REAL_T **X_ptr_value = (REAL_T **) X->ptr_value;
+    REAL_T **X2_ptr_value = (REAL_T **) X2->ptr_value;
+
+    double *trace = bml_allocate_memory(sizeof(double) * 2);
+
+    memset(ix, 0, NB * sizeof(int));
+    memset(jx, 0, NB * sizeof(int));
+
+    int maxbsize = 0;
+    for (int ib = 0; ib < NB; ib++)
+        maxbsize = MAX(maxbsize, bsize[ib]);
+    int maxbsize2 = maxbsize * maxbsize;
+    REAL_T *x_ptr_storage = calloc(maxbsize2 * NB, sizeof(REAL_T));
+    for (int ib = 0; ib < NB; ib++)
+        x_ptr[ib] = &x_ptr_storage[ib * maxbsize2];
+
+    //loop over row blocks
+    for (int ib = 0; ib < NB; ib++)
+    {
+        int lb = 0;
+        for (int jp = 0; jp < X_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            REAL_T *X_value_left = X_ptr_value[ind];
+            int jb = X_indexb[ind];
+            if (jb == ib)
+            {
+                for (int kk = 0; kk < bsize[ib]; kk++)
+                    traceX += X_value_left[kk * (1 + bsize[ib])];
+            }
+            for (int kp = 0; kp < X_nnzb[jb]; kp++)
+            {
+                int indk = ROWMAJOR(jb, kp, NB, MB);
+                int kb = X_indexb[indk];
+                if (ix[kb] == 0)
+                {
+                    memset(x_ptr[kb], 0.0, maxbsize2 * sizeof(REAL_T));
+                    jx[lb] = kb;
+                    ix[kb] = ib + 1;
+                    lb++;
+                }
+                REAL_T *x = x_ptr[kb];
+                REAL_T *X_value_right = X_ptr_value[indk];
+
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[kb]; jj++)
+                    {
+                        int k = ROWMAJOR(ii, jj, bsize[ib], bsize[kb]);
+                        for (int kk = 0; kk < bsize[jb]; kk++)
+                        {
+                            x[k] = x[k]
+                                +
+                                X_value_left[ROWMAJOR
+                                             (ii, kk, bsize[ib],
+                                              bsize[jb])] *
+                                X_value_right[ROWMAJOR
+                                              (kk, jj, bsize[jb], bsize[kb])];
+                        }
+                    }
+            }
+        }
+
+        // Check for number of non-zero blocks per block row exceeded
+        if (lb > MB)
+        {
+            LOG_ERROR
+                ("Number of non-zeroes blocks per row > MB, Increase MB\n");
+        }
+
+        int ll = 0;
+        for (int jb = 0; jb < lb; jb++)
+        {
+            assert(ll < MB);
+            int jp = jx[jb];
+            REAL_T *xtmp = x_ptr[jp];
+            REAL_T normx = TYPED_FUNC(bml_norm_inf_fast)
+                (xtmp, bsize[ib] * bsize[jp]);
+            if (jp == ib || is_above_threshold(normx, threshold))
+            {
+                if (jp == ib)
+                {
+                    for (int kk = 0; kk < bsize[ib]; kk++)
+                        traceX2 = traceX2 + xtmp[kk * (1 + bsize[jb])];
+                }
+
+                int nelements = bsize[ib] * bsize[jp];
+                int ind = ROWMAJOR(ib, ll, NB, MB);
+                assert(ind < NB * MB);
+                if (X2_ptr_value[ind] == NULL)
+                    X2_ptr_value[ind] = malloc(nelements * sizeof(REAL_T));
+                REAL_T *X2_value = X2_ptr_value[ind];
+                assert(X2_value != NULL);
+                memcpy(X2_value, xtmp, nelements * sizeof(REAL_T));
+                X2_indexb[ind] = jp;
+                ll++;
+            }
+            ix[jp] = 0;
+            memset(x_ptr[jp], 0, maxbsize2 * sizeof(REAL_T));
+        }
+        X2_nnzb[ib] = ll;
+    }
+
+    trace[0] = traceX;
+    trace[1] = traceX2;
+
+    free(x_ptr_storage);
+
+    return trace;
+}
+
+/** Matrix multiply.
+ *
+ * \f$ C \leftarrow B \, A \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Used for sparse multiply
+ */
+void TYPED_FUNC(
+    bml_multiply_AB_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold)
+{
+    assert(A->NB == B->NB);
+    assert(A->NB == C->NB);
+
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+    int *bsize = A->bsize;
+
+    int *B_nnzb = B->nnzb;
+    int *B_indexb = B->indexb;
+
+    int *C_nnzb = C->nnzb;
+    int *C_indexb = C->indexb;
+
+    int ix[NB], jx[NB];
+    REAL_T *x_ptr[NB];
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+    REAL_T **C_ptr_value = (REAL_T **) C->ptr_value;
+
+    memset(ix, 0, NB * sizeof(int));
+    memset(jx, 0, NB * sizeof(int));
+
+    int maxbsize = 0;
+    for (int ib = 0; ib < NB; ib++)
+        maxbsize = MAX(maxbsize, bsize[ib]);
+    int maxbsize2 = maxbsize * maxbsize;
+    for (int ib = 0; ib < NB; ib++)
+        x_ptr[ib] = calloc(maxbsize2, sizeof(REAL_T));
+
+    //loop over row blocks
+    for (int ib = 0; ib < NB; ib++)
+    {
+        int lb = 0;
+        //loop over blocks in this block row "ib"
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            REAL_T *A_value = A_ptr_value[ind];
+            int jb = A_indexb[ind];
+
+            for (int kp = 0; kp < B_nnzb[jb]; kp++)
+            {
+                int kb = B_indexb[ROWMAJOR(jb, kp, NB, MB)];
+                //compute column block "kb" of result
+                if (ix[kb] == 0)
+                {
+                    memset(x_ptr[kb], 0, maxbsize2 * sizeof(REAL_T));
+                    jx[lb] = kb;
+                    ix[kb] = ib + 1;
+                    lb++;
+                }
+                REAL_T *x = x_ptr[kb];
+                REAL_T *B_value = B_ptr_value[ROWMAJOR(jb, kp, NB, MB)];
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[kb]; jj++)
+                    {
+                        int k = ROWMAJOR(ii, jj, bsize[ib], bsize[kb]);
+                        for (int kk = 0; kk < bsize[jb]; kk++)
+                        {
+                            x[k] = x[k]
+                                +
+                                A_value[ROWMAJOR
+                                        (ii, kk, bsize[ib],
+                                         bsize[jb])] * B_value[ROWMAJOR(kk,
+                                                                        jj,
+                                                                        bsize
+                                                                        [jb],
+                                                                        bsize
+                                                                        [kb])];
+                        }
+                    }
+            }
+        }
+
+        // Check for number of non-zeroes per row exceeded
+        if (lb > MB)
+        {
+            LOG_ERROR("Number of non-zeroes per row > M, Increase M\n");
+        }
+
+        int ll = 0;
+        for (int jb = 0; jb < lb; jb++)
+        {
+            int jp = jx[jb];
+            REAL_T *xtmp = x_ptr[jp];
+            double normx = TYPED_FUNC(bml_norm_inf)
+                (xtmp, bsize[ib], bsize[jp], bsize[jp]);
+
+            if (jp == ib || is_above_threshold(normx, threshold))
+            {
+                int nelements = bsize[ib] * bsize[jp];
+                int ind = ROWMAJOR(ib, ll, NB, MB);
+                C_ptr_value[ind]
+                    = bml_noinit_allocate_memory(nelements * sizeof(REAL_T));
+                memcpy(C_ptr_value[ind], xtmp, nelements * sizeof(REAL_T));
+                C_indexb[ind] = jp;
+                ll++;
+            }
+            ix[jp] = 0;
+            memset(x_ptr[jp], 0, maxbsize2 * sizeof(REAL_T));
+        }
+        C_nnzb[ib] = ll;
+    }
+
+    for (int ib = 0; ib < NB; ib++)
+        free(x_ptr[ib]);
+
+}
+
+/** Matrix multiply with threshold adjustment.
+ *
+ * \f$ C \leftarrow B \, A \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Used for sparse multiply
+ */
+void TYPED_FUNC(
+    bml_multiply_adjust_AB_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * C,
+    const double threshold)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+    int *bsize = A->bsize;
+
+    int *B_nnzb = B->nnzb;
+    int *B_indexb = B->indexb;
+
+    int *C_nnzb = C->nnzb;
+    int *C_indexb = C->indexb;
+
+    int ix[NB], jx[NB];
+    int aflag = 1;
+    REAL_T *x_ptr[NB];
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+    REAL_T **C_ptr_value = (REAL_T **) C->ptr_value;
+
+    REAL_T adjust_threshold = (REAL_T) threshold;
+
+    memset(ix, 0, NB * sizeof(int));
+    memset(jx, 0, NB * sizeof(int));
+
+    int maxbsize = 0;
+    for (int ib = 0; ib < NB; ib++)
+        maxbsize = MAX(maxbsize, bsize[ib]);
+    int maxbsize2 = maxbsize * maxbsize;
+    for (int ib = 0; ib < NB; ib++)
+        x_ptr[ib] = calloc(maxbsize2, sizeof(REAL_T));
+
+    while (aflag > 0)
+    {
+        aflag = 0;
+
+        for (int ib = 0; ib < NB; ib++)
+        {
+            int l = 0;
+            for (int jp = 0; jp < A_nnzb[ib]; jp++)
+            {
+                REAL_T *a = A_ptr_value[ROWMAJOR(ib, jp, NB, MB)];
+                int jb = A_indexb[ROWMAJOR(ib, jp, NB, MB)];
+
+                for (int kp = 0; kp < B_nnzb[jb]; kp++)
+                {
+                    int kb = B_indexb[ROWMAJOR(jb, kp, NB, MB)];
+                    if (ix[kb] == 0)
+                    {
+                        memset(x_ptr[kb], 0, maxbsize2);
+                        jx[l] = kb;
+                        ix[kb] = ib + 1;
+                        l++;
+                    }
+                    // TEMPORARY STORAGE VECTOR LENGTH FULL N
+                    REAL_T *b = B_ptr_value[ROWMAJOR(jb, kp, NB, MB)];
+                    REAL_T *x = x_ptr[kb];
+                    for (int ii = 0; ii < bsize[jb]; ii++)
+                        for (int jj = 0; jj < bsize[kb]; jj++)
+                        {
+                            int k = ii * bsize[kb] + jj;
+                            x[k] =
+                                x[k] +
+                                a[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])] *
+                                b[ROWMAJOR(jj, ii, bsize[jb], bsize[kb])];
+                        }
+                }
+            }
+
+            // Check for number of non-zeroes per row exceeded
+            // Need to adjust threshold
+            if (l > MB)
+            {
+                aflag = 1;
+            }
+
+            int ll = 0;
+            for (int jb = 0; jb < l; jb++)
+            {
+                int jp = jx[jb];
+                REAL_T *xtmp = x_ptr[jp];
+                REAL_T normx = TYPED_FUNC(bml_norm_inf)
+                    (xtmp, bsize[ib], bsize[jp], bsize[jp]);
+                // Diagonal elements are saved in first column
+                if (jp == ib)
+                {
+                    memcpy(C_ptr_value[ROWMAJOR(ib, ll, NB, MB)], xtmp,
+                           bsize[ib] * bsize[ll] * sizeof(REAL_T));
+                    C_indexb[ROWMAJOR(ib, ll, NB, MB)] = jp;
+                    ll++;
+                }
+                else if (is_above_threshold(normx, adjust_threshold))
+                {
+                    memcpy(C_ptr_value[ROWMAJOR(ib, ll, NB, MB)], xtmp,
+                           bsize[ib] * bsize[ll] * sizeof(REAL_T));
+                    C_indexb[ROWMAJOR(ib, ll, NB, MB)] = jp;
+                    ll++;
+                }
+                ix[jp] = 0;
+                memset(x_ptr[jp], 0, maxbsize2 * sizeof(REAL_T));
+            }
+            C_nnzb[ib] = ll;
+        }
+
+        adjust_threshold *= (REAL_T) 2.0;
+    }
+}

--- a/src/C-interface/ellblock/bml_norm_ellblock.c
+++ b/src/C-interface/ellblock/bml_norm_ellblock.c
@@ -1,0 +1,154 @@
+#include "bml_logger.h"
+#include "bml_trace.h"
+#include "bml_norm_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Calculate the sum of squares of the elements of a matrix.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix
+ *  \return The sum of squares of A
+ */
+double
+bml_sum_squares_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            return bml_sum_squares_ellblock_single_real(A);
+            break;
+        case double_real:
+            return bml_sum_squares_ellblock_double_real(A);
+            break;
+        case single_complex:
+            return bml_sum_squares_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            return bml_sum_squares_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return 0;
+}
+
+/** Calculate the sum of squares of the elements of \alpha A + \beta B.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \param alpha Multiplier for A
+ *  \param beta Multiplier for B
+ *  \param threshold Threshold
+ *  \return The sum of squares of \alpha A + \beta B
+ */
+double
+bml_sum_squares2_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            return bml_sum_squares2_ellblock_single_real(A, B, alpha, beta,
+                                                         threshold);
+            break;
+        case double_real:
+            return bml_sum_squares2_ellblock_double_real(A, B, alpha, beta,
+                                                         threshold);
+            break;
+        case single_complex:
+            return bml_sum_squares2_ellblock_single_complex(A, B, alpha, beta,
+                                                            threshold);
+            break;
+        case double_complex:
+            return bml_sum_squares2_ellblock_double_complex(A, B, alpha, beta,
+                                                            threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return 0;
+}
+
+/* Calculate the Frobenius norm of a matrix.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \return The Frobenius norm of A
+ */
+double
+bml_fnorm_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            return bml_fnorm_ellblock_single_real(A);
+            break;
+        case double_real:
+            return bml_fnorm_ellblock_double_real(A);
+            break;
+        case single_complex:
+            return bml_fnorm_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            return bml_fnorm_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return 0;
+}
+
+/* Calculate the Frobenius norm of 2 matrices.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \return The Frobenius norm of A-B
+ */
+double
+bml_fnorm2_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            return bml_fnorm2_ellblock_single_real(A, B);
+            break;
+        case double_real:
+            return bml_fnorm2_ellblock_double_real(A, B);
+            break;
+        case single_complex:
+            return bml_fnorm2_ellblock_single_complex(A, B);
+            break;
+        case double_complex:
+            return bml_fnorm2_ellblock_double_complex(A, B);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return 0;
+}

--- a/src/C-interface/ellblock/bml_norm_ellblock.h
+++ b/src/C-interface/ellblock/bml_norm_ellblock.h
@@ -1,0 +1,111 @@
+#ifndef __BML_NORM_ELLBLOCK_H
+#define __BML_NORM_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+double bml_sum_squares_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+double bml_sum_squares_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+double bml_sum_squares_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+double bml_sum_squares_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+double bml_sum_squares_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+double bml_sum_squares_submatrix_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const int core_size);
+
+double bml_sum_squares_submatrix_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const int core_size);
+
+double bml_sum_squares_submatrix_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const int core_size);
+
+double bml_sum_squares_submatrix_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const int core_size);
+
+double bml_sum_squares_submatrix_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const int core_size);
+
+double bml_sum_squares2_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_sum_squares2_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_sum_squares2_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_sum_squares2_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_sum_squares2_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold);
+
+double bml_fnorm_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+double bml_fnorm_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+double bml_fnorm_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+double bml_fnorm_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+double bml_fnorm_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+double bml_fnorm2_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_fnorm2_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_fnorm2_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_fnorm2_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_fnorm2_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+#endif

--- a/src/C-interface/ellblock/bml_norm_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_norm_ellblock_typed.c
@@ -1,0 +1,297 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_norm.h"
+#include "bml_norm_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+#include "bml_parallel.h"
+#include "bml_utilities_ellblock.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Calculate the sum of squares of the elements of a matrix.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \return The sum of squares of A
+ */
+double TYPED_FUNC(
+    bml_sum_squares_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_nnzb = A->nnzb;
+    int *A_indexb = A->indexb;
+    int *bsize = A->bsize;
+
+    REAL_T sum = 0.0;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            REAL_T *xval = A_ptr_value[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    sum += xval[index] * xval[index];
+                }
+        }
+    }
+
+    return (double) REAL_PART(sum);
+}
+
+/** Calculate the sum of squares of the elements of \alpha A + \beta B.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \param alpha Multiplier for A
+ *  \param beta Multiplier for B
+ *  \pram threshold Threshold
+ *  \return The sum of squares of \alpha A + \beta B
+ */
+double TYPED_FUNC(
+    bml_sum_squares2_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *bsize = A->bsize;
+    int *B_indexb = B->indexb;
+    int *B_nnzb = B->nnzb;
+
+    REAL_T sum = 0.0;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    REAL_T alpha_ = (REAL_T) alpha;
+    REAL_T beta_ = (REAL_T) beta;
+
+    int maxbsize = 0;
+    for (int ib = 0; ib < NB; ib++)
+        maxbsize = MAX(maxbsize, bsize[ib]);
+    int maxbsize2 = maxbsize * maxbsize;
+    REAL_T *y_ptr[NB];
+    for (int ib = 0; ib < NB; ib++)
+        y_ptr[ib] = calloc(maxbsize2, sizeof(REAL_T));
+
+    int ix[NB], jjb[NB];
+
+    memset(ix, 0, NB * sizeof(int));
+    memset(jjb, 0, NB * sizeof(int));
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        int lb = 0;
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            int nelements = bsize[ib] * bsize[jb];
+            if (ix[jb] == 0)
+            {
+                memset(y_ptr[jb], 0, nelements * sizeof(REAL_T));
+                ix[jb] = ib + 1;
+                jjb[lb] = jb;
+                lb++;
+            }
+            REAL_T *y_value = y_ptr[jb];
+            REAL_T *A_value = A_ptr_value[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    y_value[index] += alpha_ * A_value[index];
+                }
+        }
+
+        for (int jp = 0; jp < B_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = B_indexb[ind];
+            int nelements = bsize[ib] * bsize[jb];
+            if (ix[jb] == 0)
+            {
+                memset(y_ptr[jb], 0, nelements * sizeof(REAL_T));
+                ix[jb] = ib + 1;
+                jjb[lb] = jb;
+                lb++;
+            }
+            REAL_T *y_value = y_ptr[jb];
+            REAL_T *B_value = B_ptr_value[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    y_value[index] += beta_ * B_value[index];
+                }
+        }
+
+        for (int jp = 0; jp < lb; jp++)
+        {
+            double normx = TYPED_FUNC(bml_sum_squares)
+                (y_ptr[jjb[jp]], bsize[ib], bsize[jp], bsize[jp]);
+
+            if (normx > threshold * threshold)
+                sum += normx;
+
+            ix[jjb[jp]] = 0;
+            memset(y_ptr[jjb[jp]], 0, maxbsize2 * sizeof(REAL_T));
+            jjb[jp] = 0;
+        }
+    }
+
+    return (double) REAL_PART(sum);
+}
+
+/** Calculate the Frobenius norm of matrix A.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \return The Frobenius norm of A
+ */
+double TYPED_FUNC(
+    bml_fnorm_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    double fnorm = TYPED_FUNC(bml_sum_squares_ellblock) (A);
+#ifdef DO_MPI
+    if (bml_getNRanks() > 1 && A->distribution_mode == distributed)
+    {
+        bml_sumRealReduce(&fnorm);
+    }
+#endif
+    fnorm = sqrt(fnorm);
+
+    return (double) REAL_PART(fnorm);
+}
+
+/** Calculate the Frobenius norm of 2 matrices.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \return The Frobenius norm of A-B
+ */
+double TYPED_FUNC(
+    bml_fnorm2_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+    double fnorm = 0.0;
+    REAL_T *rvalue;
+
+    int *A_nnzb = (int *) A->nnzb;
+    int *A_indexb = (int *) A->indexb;
+    int *bsize = A->bsize;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *B_nnzb = (int *) B->nnzb;
+    int *B_indexb = (int *) B->indexb;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    REAL_T temp;
+
+    int maxbsize = 0;
+    for (int ib = 0; ib < NB; ib++)
+        maxbsize = MAX(maxbsize, bsize[ib]);
+    int maxbsize2 = maxbsize * maxbsize;
+    REAL_T *zero_block = calloc(maxbsize2, sizeof(REAL_T));
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            for (int kp = 0; kp < B_nnzb[ib]; kp++)
+            {
+                if (A_indexb[ROWMAJOR(ib, jp, NB, MB)] ==
+                    B_indexb[ROWMAJOR(ib, kp, NB, MB)])
+                {
+                    rvalue = B_ptr_value[ROWMAJOR(ib, kp, NB, MB)];
+                    break;
+                }
+                rvalue = zero_block;
+            }
+
+            REAL_T *A_value = A_ptr_value[ind];
+            int jb = A_indexb[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                    temp = A_value[index] - rvalue[index];
+                    fnorm += temp * temp;
+                }
+        }
+
+        for (int jp = 0; jp < B_nnzb[ib]; jp++)
+        {
+            for (int kp = 0; kp < A_nnzb[ib]; kp++)
+            {
+                if (A_indexb[ROWMAJOR(ib, kp, NB, MB)] ==
+                    B_indexb[ROWMAJOR(ib, jp, NB, MB)])
+                {
+                    rvalue = A_ptr_value[ROWMAJOR(ib, kp, NB, MB)];
+                    break;
+                }
+                rvalue = NULL;
+            }
+
+            if (rvalue == NULL)
+            {
+                int ind = ROWMAJOR(ib, jp, NB, MB);
+                int jb = A_indexb[ind];
+                REAL_T *B_value = B_ptr_value[ind];
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[jb]; jj++)
+                    {
+                        int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                        temp = B_value[index];
+                        fnorm += temp * temp;
+                    }
+            }
+        }
+    }
+
+#ifdef DO_MPI
+    if (bml_getNRanks() > 1 && A->distribution_mode == distributed)
+    {
+        bml_sumRealReduce(&fnorm);
+    }
+#endif
+
+    fnorm = sqrt(fnorm);
+
+    free(zero_block);
+
+    return (double) REAL_PART(fnorm);
+}

--- a/src/C-interface/ellblock/bml_norm_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_norm_ellblock_typed.c
@@ -165,6 +165,8 @@ double TYPED_FUNC(
         }
     }
 
+    for (int ib = 0; ib < NB; ib++)
+        free(y_ptr[ib]);
     return (double) REAL_PART(sum);
 }
 

--- a/src/C-interface/ellblock/bml_normalize_ellblock.c
+++ b/src/C-interface/ellblock/bml_normalize_ellblock.c
@@ -1,0 +1,75 @@
+#include "bml_logger.h"
+#include "bml_normalize.h"
+#include "bml_normalize_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Normalize ellblock matrix given gershgorin bounds.
+ *
+ *  \ingroup normalize_group
+ *
+ *  \param A The matrix
+ *  \param mineval Calculated min value
+ *  \param maxeval Calculated max value
+ */
+void
+bml_normalize_ellblock(
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_normalize_ellblock_single_real(A, mineval, maxeval);
+            break;
+        case double_real:
+            bml_normalize_ellblock_double_real(A, mineval, maxeval);
+            break;
+        case single_complex:
+            bml_normalize_ellblock_single_complex(A, mineval, maxeval);
+            break;
+        case double_complex:
+            bml_normalize_ellblock_double_complex(A, mineval, maxeval);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+/** Calculate gershgorin bounds for an ellblock matrix.
+ *
+ *  \ingroup normalize_group
+ *
+ *  \param A The matrix
+ *  returns mineval Calculated min value
+ *  returns maxeval Calculated max value
+ */
+void *
+bml_gershgorin_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            return bml_gershgorin_ellblock_single_real(A);
+            break;
+        case double_real:
+            return bml_gershgorin_ellblock_double_real(A);
+            break;
+        case single_complex:
+            return bml_gershgorin_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            return bml_gershgorin_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return NULL;
+}

--- a/src/C-interface/ellblock/bml_normalize_ellblock.h
+++ b/src/C-interface/ellblock/bml_normalize_ellblock.h
@@ -1,0 +1,46 @@
+#ifndef __BML_NORMALIZE_BELLBLOCK_H
+#define __BML_NORMALIZE_BELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+void bml_normalize_ellblock(
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval);
+
+void bml_normalize_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval);
+
+void bml_normalize_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval);
+
+void bml_normalize_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval);
+
+void bml_normalize_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval);
+
+void *bml_gershgorin_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+void *bml_gershgorin_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+void *bml_gershgorin_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+void *bml_gershgorin_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+void *bml_gershgorin_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+#endif

--- a/src/C-interface/ellblock/bml_normalize_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_normalize_ellblock_typed.c
@@ -1,0 +1,129 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_logger.h"
+#include "bml_allocate.h"
+#include "bml_normalize.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_normalize_ellblock.h"
+#include "bml_scale_ellblock.h"
+#include "bml_add_ellblock.h"
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/* Normalize ellblock matrix given Gershgorin bounds.
+ *
+ *  \ingroup normalize_group
+ *
+ *  \param A The matrix
+ *  \param mineval Calculated min value
+ *  \param maxeval Calculated max value
+ */
+void TYPED_FUNC(
+    bml_normalize_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const double mineval,
+    const double maxeval)
+{
+    double maxminusmin = maxeval - mineval;
+    double gershfact = maxeval / maxminusmin;
+    REAL_T scalar = (REAL_T) - 1.0 / maxminusmin;
+    double threshold = 0.0;
+
+    bml_scale_inplace_ellblock(&scalar, A);
+    bml_add_identity_ellblock(A, gershfact, threshold);
+}
+
+/** Calculate Gershgorin bounds for an ellblock matrix.
+ *
+ *  \ingroup normalize_group
+ *
+ *  \param A The matrix
+ *  \param nrows Number of rows to use
+ *  returns mineval Calculated min value
+ *  returns maxeval Calculated max value
+ */
+void *TYPED_FUNC(
+    bml_gershgorin_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    double emin = DBL_MAX;
+    double emax = DBL_MIN;
+
+    double *eval = bml_allocate_memory(sizeof(double) * 2);
+
+    int NB = A->NB;
+    int MB = A->MB;
+    int *A_nnzb = (int *) A->nnzb;
+    int *A_indexb = (int *) A->indexb;
+    int *bsize = A->bsize;
+
+    REAL_T *rad = calloc(A->N, sizeof(REAL_T));
+    REAL_T *dval = calloc(A->N, sizeof(REAL_T));
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    int ioffset = 0;
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            REAL_T *A_value = A_ptr_value[ind];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+            {
+                int i = ioffset + ii;
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    REAL_T absham =
+                        A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])];
+                    if (ib == jb && ii == jj)
+                        dval[i] = (double) absham;
+                    else
+                        rad[i] += (double) ABS(absham);
+                }
+            }
+        }
+
+        ioffset += bsize[ib];
+    }
+    for (int i = 0; i < A->N; i++)
+    {
+        if (REAL_PART(dval[i] + rad[i]) > emax)
+            emax = REAL_PART(dval[i] + rad[i]);
+        if (REAL_PART(dval[i] - rad[i]) < emin)
+            emin = REAL_PART(dval[i] - rad[i]);
+
+    }
+
+    //printf("%d: emin = %e emax = %e\n", myRank, emin, emax);
+
+#ifdef DO_MPI
+    if (bml_getNRanks() > 1 && A->distribution_mode == distributed)
+    {
+        bml_minRealReduce(&emin);
+        bml_maxRealReduce(&emax);
+    }
+#endif
+
+    eval[0] = emin;
+    eval[1] = emax;
+
+    //printf("Global %d: emin = %e emax = %e\n", myRank, emin, emax);
+    free(dval);
+    free(rad);
+
+    return eval;
+}

--- a/src/C-interface/ellblock/bml_scale_ellblock.c
+++ b/src/C-interface/ellblock/bml_scale_ellblock.c
@@ -1,0 +1,101 @@
+#include "bml_logger.h"
+#include "bml_scale.h"
+#include "bml_scale_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Scale an ellblock matrix - result is a new matrix.
+ *
+ *  \ingroup scale_group
+ *
+ *  \param A The matrix to be scaled
+ *  \return A scale version of matrix A.
+ */
+bml_matrix_ellblock_t *
+bml_scale_ellblock_new(
+    const void *scale_factor,
+    const bml_matrix_ellblock_t * A)
+{
+    bml_matrix_ellblock_t *B = NULL;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            B = bml_scale_ellblock_new_single_real(scale_factor, A);
+            break;
+        case double_real:
+            B = bml_scale_ellblock_new_double_real(scale_factor, A);
+            break;
+        case single_complex:
+            B = bml_scale_ellblock_new_single_complex(scale_factor, A);
+            break;
+        case double_complex:
+            B = bml_scale_ellblock_new_double_complex(scale_factor, A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return B;
+}
+
+/** Scale an ellblock matrix.
+ *
+ *  \ingroup scale_group
+ *
+ *  \param A The matrix to be scaled
+ *  \param B Scaled version of matrix A
+ */
+void
+bml_scale_ellblock(
+    const void *scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_scale_ellblock_single_real(scale_factor, A, B);
+            break;
+        case double_real:
+            bml_scale_ellblock_double_real(scale_factor, A, B);
+            break;
+        case single_complex:
+            bml_scale_ellblock_single_complex(scale_factor, A, B);
+            break;
+        case double_complex:
+            bml_scale_ellblock_double_complex(scale_factor, A, B);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_scale_inplace_ellblock(
+    const void *scale_factor,
+    bml_matrix_ellblock_t * A)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_scale_inplace_ellblock_single_real(scale_factor, A);
+            break;
+        case double_real:
+            bml_scale_inplace_ellblock_double_real(scale_factor, A);
+            break;
+        case single_complex:
+            bml_scale_inplace_ellblock_single_complex(scale_factor, A);
+            break;
+        case double_complex:
+            bml_scale_inplace_ellblock_double_complex(scale_factor, A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_scale_ellblock.h
+++ b/src/C-interface/ellblock/bml_scale_ellblock.h
@@ -1,0 +1,73 @@
+#ifndef __BML_SCALE_ELLBLOCK_H
+#define __BML_SCALE_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+
+bml_matrix_ellblock_t *bml_scale_ellblock_new(
+    const void *scale_factor,
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_scale_ellblock_new_single_real(
+    const float *scale_factor,
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_scale_ellblock_new_double_real(
+    const double *scale_factor,
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_scale_ellblock_new_single_complex(
+    const float complex * scale_factor,
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_scale_ellblock_new_double_complex(
+    const double complex * scale_factor,
+    const bml_matrix_ellblock_t * A);
+
+void bml_scale_ellblock(
+    const void *scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_scale_ellblock_single_real(
+    const float *scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_scale_ellblock_double_real(
+    const double *scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_scale_ellblock_single_complex(
+    const float complex * scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_scale_ellblock_double_complex(
+    const double complex * scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+void bml_scale_inplace_ellblock(
+    const void *scale_factor,
+    bml_matrix_ellblock_t * A);
+
+void bml_scale_inplace_ellblock_single_real(
+    const float *scale_factor,
+    bml_matrix_ellblock_t * A);
+
+void bml_scale_inplace_ellblock_double_real(
+    const double *scale_factor,
+    bml_matrix_ellblock_t * A);
+
+void bml_scale_inplace_ellblock_single_complex(
+    const float complex * scale_factor,
+    bml_matrix_ellblock_t * A);
+
+void bml_scale_inplace_ellblock_double_complex(
+    const double complex * scale_factor,
+    bml_matrix_ellblock_t * A);
+
+#endif

--- a/src/C-interface/ellblock/bml_scale_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_scale_ellblock_typed.c
@@ -1,0 +1,86 @@
+#include "../../typed.h"
+#include "../../macros.h"
+#include "../blas.h"
+#include "bml_allocate.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_copy_ellblock.h"
+#include "bml_logger.h"
+#include "bml_parallel.h"
+#include "bml_scale.h"
+#include "bml_scale_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Scale an ellblock matrix - result is a new matrix.
+ *
+ *  \ingroup scale_group
+ *
+ *  \param A The matrix to be scaled
+ *  \return A scale version of matrix A.
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_scale_ellblock_new) (
+    const REAL_T * scale_factor,
+    const bml_matrix_ellblock_t * A)
+{
+    bml_matrix_ellblock_t *B = TYPED_FUNC(bml_copy_ellblock_new) (A);
+
+    TYPED_FUNC(bml_scale_ellblock) (scale_factor, A, B);
+
+    return B;
+}
+
+/** Scale an ellblock matrix.
+ *
+ *  \ingroup scale_group
+ *
+ *  \param A The matrix to be scaled
+ *  \param B Scaled version of matrix A
+ */
+void TYPED_FUNC(
+    bml_scale_ellblock) (
+    const REAL_T * scale_factor,
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+#ifdef NOBLAS
+    LOG_ERROR("No BLAS library");
+#else
+    if (A != B)
+        TYPED_FUNC(bml_copy_ellblock) (A, B);
+
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+    int inc = 1;
+
+    for (int ib = 0; ib < A->NB; ib++)
+    {
+        for (int jp = 0; jp < A->nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+            int jb = A->indexb[ind];
+            int nElems = A->bsize[ib] * A->bsize[jb];
+
+            REAL_T *B_value = B_ptr_value[ind];
+            assert(B_value != NULL);
+
+            C_BLAS(SCAL) (&nElems, scale_factor, &(B_value[0]), &inc);
+        }
+    }
+#endif
+}
+
+void TYPED_FUNC(
+    bml_scale_inplace_ellblock) (
+    const REAL_T * scale_factor,
+    bml_matrix_ellblock_t * A)
+{
+    TYPED_FUNC(bml_scale_ellblock) (scale_factor, A, A);
+}

--- a/src/C-interface/ellblock/bml_setters_ellblock.c
+++ b/src/C-interface/ellblock/bml_setters_ellblock.c
@@ -1,0 +1,140 @@
+#include "../bml_introspection.h"
+#include "../bml_logger.h"
+#include "bml_setters_ellblock.h"
+#include "bml_types_ellblock.h"
+
+
+void
+bml_set_element_new_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value)
+{
+    switch (bml_get_precision(A))
+    {
+        case single_real:
+            bml_set_element_new_ellblock_single_real(A, i, j, value);
+            break;
+        case double_real:
+            bml_set_element_new_ellblock_double_real(A, i, j, value);
+            break;
+        case single_complex:
+            bml_set_element_new_ellblock_single_complex(A, i, j, value);
+            break;
+        case double_complex:
+            bml_set_element_new_ellblock_double_complex(A, i, j, value);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision in bml_set_element_new_ellblock\n");
+            break;
+    }
+}
+
+
+void
+bml_set_element_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value)
+{
+    switch (bml_get_precision(A))
+    {
+        case single_real:
+            bml_set_element_ellblock_single_real(A, i, j, value);
+            break;
+        case double_real:
+            bml_set_element_ellblock_double_real(A, i, j, value);
+            break;
+        case single_complex:
+            bml_set_element_ellblock_single_complex(A, i, j, value);
+            break;
+        case double_complex:
+            bml_set_element_ellblock_double_complex(A, i, j, value);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision in bml_set_element_ellblock\n");
+            break;
+    }
+}
+
+void
+bml_set_row_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const void *row,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_set_row_ellblock_single_real(A, i, row, threshold);
+            break;
+        case double_real:
+            bml_set_row_ellblock_double_real(A, i, row, threshold);
+            break;
+        case single_complex:
+            bml_set_row_ellblock_single_complex(A, i, row, threshold);
+            break;
+        case double_complex:
+            bml_set_row_ellblock_double_complex(A, i, row, threshold);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision\n");
+            break;
+    }
+}
+
+void
+bml_set_diagonal_ellblock(
+    bml_matrix_ellblock_t * A,
+    const void *diagonal,
+    const double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_set_diagonal_ellblock_single_real(A, diagonal, threshold);
+            break;
+        case double_real:
+            bml_set_diagonal_ellblock_double_real(A, diagonal, threshold);
+            break;
+        case single_complex:
+            bml_set_diagonal_ellblock_single_complex(A, diagonal, threshold);
+            break;
+        case double_complex:
+            bml_set_diagonal_ellblock_double_complex(A, diagonal, threshold);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision\n");
+            break;
+    }
+}
+
+void
+bml_set_block_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int ib,
+    const int jb,
+    const void *values)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_set_block_ellblock_single_real(A, ib, jb, values);
+            break;
+        case double_real:
+            bml_set_block_ellblock_double_real(A, ib, jb, values);
+            break;
+        case single_complex:
+            bml_set_block_ellblock_single_complex(A, ib, jb, values);
+            break;
+        case double_complex:
+            bml_set_block_ellblock_double_complex(A, ib, jb, values);
+            break;
+        default:
+            LOG_ERROR("unkonwn precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_setters_ellblock.h
+++ b/src/C-interface/ellblock/bml_setters_ellblock.h
@@ -1,0 +1,151 @@
+/** \file */
+
+#ifndef __BML_SETTERS_ELLBLOCK_H
+#define __BML_SETTERS_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+
+void bml_set_element_new_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_new_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_new_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_new_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_new_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_element_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *value);
+
+void bml_set_row_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const void *row,
+    const double threshold);
+
+void bml_set_row_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const float *row,
+    const double threshold);
+
+void bml_set_row_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const double *row,
+    const double threshold);
+
+void bml_set_row_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const float complex * row,
+    const double threshold);
+
+void bml_set_row_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const double complex * row,
+    const double threshold);
+
+void bml_set_diagonal_ellblock(
+    bml_matrix_ellblock_t * A,
+    const void *diagonal,
+    const double threshold);
+
+void bml_set_diagonal_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const float *diagonal,
+    const double threshold);
+
+void bml_set_diagonal_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const double *diagonal,
+    const double threshold);
+
+void bml_set_diagonal_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const float complex * diagonal,
+    const double threshold);
+
+void bml_set_diagonal_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const double complex * diagonal,
+    const double threshold);
+
+void bml_set_block_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int ib,
+    const int jb,
+    const float *values);
+
+void bml_set_block_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int ib,
+    const int jb,
+    const double *values);
+
+void bml_set_block_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int ib,
+    const int jb,
+    const float complex * values);
+
+void bml_set_block_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int ib,
+    const int jb,
+    const double complex * values);
+
+
+
+#endif

--- a/src/C-interface/ellblock/bml_setters_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_setters_ellblock_typed.c
@@ -1,0 +1,293 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_introspection.h"
+#include "../bml_allocate.h"
+#include "bml_setters_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+#include "bml_types.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <complex.h>
+#include <math.h>
+#include <string.h>
+#include <assert.h>
+
+/** Set element i,j asuming there's no resetting of any element of A.
+ *
+ *  \ingroup setters
+ *
+ *  \param A The matrix which takes row i
+ *  \param i The column index
+ *  \param j The row index
+ *  \param value The element to be added
+ *  \WARNING sets an element from scratch
+ *  \todo set element new.
+ *
+ *
+ */
+void TYPED_FUNC(
+    bml_set_element_new_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *element)
+{
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *A_bsize = A->bsize;
+
+    //determine block index and index within block
+    int ib = 0;
+    int jb = 0;
+    int ii = i;
+    int jj = j;
+    while (ii >= A_bsize[ib])
+    {
+        ii -= A_bsize[ib];
+        ib++;
+    }
+    while (jj >= A_bsize[jb])
+    {
+        jj -= A_bsize[jb];
+        jb++;
+    }
+
+    int block_found = 0;
+    for (int jp = 0; jp < A_nnzb[ib]; jp++)
+    {
+        int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+        if (A_indexb[ind] == jb)
+        {
+            REAL_T *A_value = A_ptr_value[ind];
+            A_value[ROWMAJOR(ii, jj, A_bsize[ib], A_bsize[jb])]
+                = *((REAL_T *) element);
+            block_found = 1;
+        }
+    }
+    if (block_found == 0)
+    {
+        int ind = ROWMAJOR(ib, A_nnzb[ib], A->NB, A->MB);
+        REAL_T *A_value = A_ptr_value[ind];
+        A_value[ROWMAJOR(ii, jj, A_bsize[ib], A_bsize[jb])]
+            = *((REAL_T *) element);
+        A_nnzb[ib]++;
+    }
+}
+
+
+/** Set element i,j of matrix A.
+ *
+ *  \ingroup setters
+ *
+ *  \param A The matrix which takes row i
+ *  \param i The column index
+ *  \param j The row index
+ *  \param value The element to be set
+ *  \WARNING sets an element from scratch
+ *  \todo set element new.
+ *
+ *
+ */
+void TYPED_FUNC(
+    bml_set_element_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const int j,
+    const void *element)
+{
+    TYPED_FUNC(bml_set_element_new_ellblock) (A, i, j, element);
+}
+
+/** Set row i of matrix A.
+ *
+ *  \ingroup setters
+ *
+ *  \param A The matrix which takes row i
+ *  \param i The index of the row to be set
+ *  \param row The row to be set
+ *  \param threshold The threshold value to be set
+ *
+ */
+void TYPED_FUNC(
+    bml_set_row_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int i,
+    const REAL_T * row,
+    const double threshold)
+{
+    int A_N = A->N;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *A_bsize = A->bsize;
+
+    //determine block index and index within block
+    int ib = 0;
+    int ii = i;
+    while (ii >= A_bsize[ib])
+    {
+        ii -= A_bsize[ib];
+        ib++;
+    }
+
+    //loop over elements to insert
+    for (int k = 0; k < A_N; k++)
+    {
+        printf("k=%d\n", k);
+        if (ABS(row[k]) > threshold)
+        {
+            //determine column block index and index within block
+            int jb = 0;
+            int jj = k;
+            while (jj >= A_bsize[jb])
+            {
+                jj -= A_bsize[jb];
+                jb++;
+            }
+            printf("jb=%d\n", jb);
+            int block_found = 0;
+            for (int jp = 0; jp < A_nnzb[ib]; jp++)
+            {
+                int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+                if (A_indexb[ind] == jb)
+                {
+                    REAL_T *A_value = A_ptr_value[ind];
+                    A_value[ROWMAJOR(ii, jj, A_bsize[ib], A_bsize[jb])]
+                        = row[k];
+                    block_found = 1;
+                }
+            }
+            if (block_found == 0)
+            {
+                int ind = ROWMAJOR(ib, A_nnzb[ib], A->NB, A->MB);
+                int nelements = A_bsize[ib] * A_bsize[jb];
+                A_ptr_value[ind]
+                    = bml_allocate_memory(nelements * sizeof(REAL_T));
+                REAL_T *A_value = A_ptr_value[ind];
+                assert(A_value != NULL);
+                A_value[ROWMAJOR(ii, jj, A_bsize[ib], A_bsize[jb])] = row[k];
+                A_nnzb[ib]++;
+                A_indexb[ind] = jb;
+            }
+        }
+    }
+
+}
+
+/** Set diagonal of matrix A.
+ *
+ *  \ingroup setters
+ *
+ *  \param A The matrix which takes diag
+ *  \param diag The diagonal to be set
+ *  \param threshold The threshold value to be used
+ */
+void TYPED_FUNC(
+    bml_set_diagonal_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const REAL_T * diagonal,
+    const double threshold)
+{
+    int A_NB = A->NB;
+    int A_MB = A->MB;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *A_bsize = A->bsize;
+    int ll = 0;
+
+    int offset = 0;
+    for (int ib = 0; ib < A_NB; ib++)
+    {
+        ll = 0;
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A_NB, A_MB);
+            int jb = A_indexb[ind];
+            if (jb == ib)
+            {
+                REAL_T *A_value = A_ptr_value[ind];
+                double normdiag = TYPED_FUNC(bml_norm_inf)
+                    (&diagonal[offset], A_bsize[ib], 1, 1);
+
+                if (normdiag > threshold)
+                {
+                    for (int ii = 0; ii < A_bsize[ib]; ii++)
+                    {
+                        A_value[ROWMAJOR(ii, ii, A_bsize[ib], A_bsize[ib])]
+                            = diagonal[offset + ii];
+                    }
+                }
+                else
+                {
+                    for (int ii = 0; ii < A_bsize[ib]; ii++)
+                    {
+                        A_value[ROWMAJOR(ii, ii, A_bsize[ib], A_bsize[ib])] =
+                            0.0;
+                    }
+                }
+                ll = 1;
+            }
+        }
+
+        /* If there is no diagonal block then
+         */
+        if (ll == 0)
+        {
+            double normdiag = TYPED_FUNC(bml_norm_inf)
+                (&diagonal[offset], A_bsize[ib], 1, 1);
+            if (normdiag > threshold)
+            {
+                A_indexb[ROWMAJOR(ib, A_nnzb[ib], A_NB, A_MB)] = ib;
+                REAL_T *A_value
+                    = A_ptr_value[ROWMAJOR(ib, A_nnzb[ib], A_NB, A_MB)];
+                for (int ii = 0; ii < A_bsize[ib]; ii++)
+                {
+                    A_value[ROWMAJOR(ii, ii, A_bsize[ib], A_bsize[ib])]
+                        = diagonal[offset + ii];
+                }
+                A_nnzb[ib]++;
+            }
+        }
+        offset += A_bsize[ib];
+    }
+}
+
+/*
+ * This function assumes the block structure of the matrix
+ * has already been set and the block ib, jb already exists
+ */
+void TYPED_FUNC(
+    bml_set_block_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int ib,
+    const int jb,
+    const REAL_T * elements)
+{
+    assert(ib < A->NB);
+    assert(jb < A->NB);
+
+    int data_copied = 0;
+    for (int jp = 0; jp < A->nnzb[ib]; jp++)
+    {
+        int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+        if (A->indexb[ind] == jb)
+        {
+            int n2 = A->bsize[ib] * A->bsize[jb];
+            printf("n2=%d, ind=%d\n", n2, ind);
+            REAL_T *A_value = A->ptr_value[ind];
+            assert(A_value != NULL);
+            memcpy(A_value, elements, n2 * sizeof(REAL_T));
+            data_copied = 1;
+            break;
+        }
+    }
+
+    //make sure block was found and data was copied
+    assert(data_copied == 1);
+}

--- a/src/C-interface/ellblock/bml_threshold_ellblock.c
+++ b/src/C-interface/ellblock/bml_threshold_ellblock.c
@@ -1,0 +1,77 @@
+#include "bml_logger.h"
+#include "bml_threshold.h"
+#include "bml_threshold_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Threshold a matrix.
+ *
+ *  \ingroup threshold_group
+ *
+ *  \param A The matrix to be thresholded
+ *  \param threshold Threshold value
+ *  \return the thresholded A
+ */
+bml_matrix_ellblock_t
+    * bml_threshold_new_ellblock(const bml_matrix_ellblock_t * A,
+                                 const double threshold)
+{
+    bml_matrix_ellblock_t *B = NULL;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            B = bml_threshold_new_ellblock_single_real(A, threshold);
+            break;
+        case double_real:
+            B = bml_threshold_new_ellblock_double_real(A, threshold);
+            break;
+        case single_complex:
+            B = bml_threshold_new_ellblock_single_complex(A, threshold);
+            break;
+        case double_complex:
+            B = bml_threshold_new_ellblock_double_complex(A, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return B;
+}
+
+/** Threshold a matrix in place.
+ *
+ *  \ingroup threshold_group
+ *
+ *  \param A The matrix to be thresholded
+ *  \param threshold Threshold value
+ *  \return the thresholded A
+ */
+void
+bml_threshold_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double threshold)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_threshold_ellblock_single_real(A, threshold);
+            break;
+        case double_real:
+            bml_threshold_ellblock_double_real(A, threshold);
+            break;
+        case single_complex:
+            bml_threshold_ellblock_single_complex(A, threshold);
+            break;
+        case double_complex:
+            bml_threshold_ellblock_double_complex(A, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_threshold_ellblock.h
+++ b/src/C-interface/ellblock/bml_threshold_ellblock.h
@@ -1,0 +1,46 @@
+#ifndef __BML_THRESHOLD_ELLBLOCK_H
+#define __BML_THRESHOLD_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_ellblock_t *bml_threshold_new_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+bml_matrix_ellblock_t *bml_threshold_new_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+bml_matrix_ellblock_t *bml_threshold_new_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+bml_matrix_ellblock_t *bml_threshold_new_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+bml_matrix_ellblock_t *bml_threshold_new_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+void bml_threshold_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+void bml_threshold_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+void bml_threshold_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+void bml_threshold_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+void bml_threshold_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const double threshold);
+
+#endif

--- a/src/C-interface/ellblock/bml_threshold_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_threshold_ellblock_typed.c
@@ -1,0 +1,151 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_threshold.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_threshold_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Threshold a matrix.
+ *
+ *  \ingroup threshold_group
+ *
+ *  \param A The matrix to be thresholded
+ *  \param threshold Threshold value
+ *  \return the thresholded A
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_threshold_new_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const double threshold)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+    int *bsize = A->bsize;
+
+    bml_matrix_ellblock_t *B =
+        TYPED_FUNC(bml_block_matrix_ellblock) (NB, MB, bsize,
+                                               A->distribution_mode);
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+    int *B_indexb = B->indexb;
+    int *B_nnzb = B->nnzb;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            REAL_T *A_value = A_ptr_value[ind];
+            REAL_T normA = TYPED_FUNC(bml_norm_inf)
+                (A_value, bsize[ib], bsize[jb], bsize[jb]);
+
+            if (is_above_threshold(normA, threshold))
+            {
+                int nelements = bsize[ib] * bsize[jb];
+                int indB = ROWMAJOR(ib, B_nnzb[ib], NB, MB);
+                B_ptr_value[indB]
+                    = bml_noinit_allocate_memory(nelements * sizeof(REAL_T));
+                REAL_T *B_value = B_ptr_value[indB];
+                memcpy(B_value, A_value, nelements * sizeof(REAL_T));
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    for (int jj = 0; jj < bsize[jb]; jj++)
+                    {
+                        int index = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                        if (!is_above_threshold(B_value[index], threshold))
+                        {
+                            B_value[index] = 0.;
+                        }
+                    }
+                B_indexb[indB] = jb;
+                B_nnzb[ib]++;
+            }
+        }
+    }
+
+    return B;
+}
+
+/** Threshold a matrix in place.
+ *
+ *  \ingroup threshold_group
+ *
+ *  \param A The matrix to be thresholded
+ *  \param threshold Threshold value
+ *  \return the thresholded A
+ */
+void TYPED_FUNC(
+    bml_threshold_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const double threshold)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *bsize = A->bsize;
+
+    int rlen;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        rlen = 0;
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            REAL_T *A_value = A_ptr_value[ind];
+            REAL_T normA = TYPED_FUNC(bml_norm_inf)
+                (A_value, bsize[ib], bsize[jb], bsize[jb]);
+
+            if (is_above_threshold(normA, threshold))
+            {
+                if (rlen < jp)
+                {
+                    int new_index = ROWMAJOR(ib, rlen, NB, MB);
+                    A_ptr_value[new_index] =
+                        A_ptr_value[ROWMAJOR(ib, jp, NB, MB)];
+                    A_indexb[new_index] = A_indexb[ROWMAJOR(ib, jp, NB, MB)];
+                    //apply thresholding within block
+                    REAL_T *B_value = A_ptr_value[new_index];
+                    for (int ii = 0; ii < bsize[ib]; ii++)
+                        for (int jj = 0; jj < bsize[jb]; jj++)
+                        {
+                            int index =
+                                ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                            if (!is_above_threshold
+                                (B_value[index], threshold))
+                            {
+                                B_value[index] = 0.;
+                            }
+                        }
+                }
+                rlen++;
+            }
+            else
+            {
+                free(A_ptr_value[ind]);
+            }
+        }
+        A_nnzb[ib] = rlen;
+    }
+}

--- a/src/C-interface/ellblock/bml_trace_ellblock.c
+++ b/src/C-interface/ellblock/bml_trace_ellblock.c
@@ -1,0 +1,79 @@
+#include "bml_logger.h"
+#include "bml_trace.h"
+#include "bml_trace_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Calculate the trace of a matrix.
+ *
+ *  \ingroup trace_group
+ *
+ *  \param A The matrix to calculate a trace for
+ *  \return the trace of A
+ */
+double
+bml_trace_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+    double trace = 0.0;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            trace = bml_trace_ellblock_single_real(A);
+            break;
+        case double_real:
+            trace = bml_trace_ellblock_double_real(A);
+            break;
+        case single_complex:
+            trace = bml_trace_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            trace = bml_trace_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return trace;
+}
+
+/** Calculate the trace of a matrix multiplication.
+ * Both matrices must have the same size.
+ *
+ *  \ingroup trace_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \return the trace of A*B
+ */
+double
+bml_traceMult_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+    double trace = 0.0;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            trace = bml_traceMult_ellblock_single_real(A, B);
+            break;
+        case double_real:
+            trace = bml_traceMult_ellblock_double_real(A, B);
+            break;
+        case single_complex:
+            trace = bml_traceMult_ellblock_single_complex(A, B);
+            break;
+        case double_complex:
+            trace = bml_traceMult_ellblock_double_complex(A, B);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return trace;
+}

--- a/src/C-interface/ellblock/bml_trace_ellblock.h
+++ b/src/C-interface/ellblock/bml_trace_ellblock.h
@@ -1,0 +1,41 @@
+#ifndef __BML_TRACE_ELLBLOCK_H
+#define __BML_TRACE_ELLNLOCK_H
+
+#include "bml_types_ellblock.h"
+
+double bml_trace_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+double bml_trace_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+double bml_trace_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+double bml_trace_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+double bml_trace_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+double bml_traceMult_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_traceMult_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_traceMult_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_traceMult_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+double bml_traceMult_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B);
+
+#endif

--- a/src/C-interface/ellblock/bml_trace_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_trace_ellblock_typed.c
@@ -1,0 +1,122 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_trace.h"
+#include "bml_trace_ellblock.h"
+#include "bml_submatrix.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+#include "bml_logger.h"
+
+#include <complex.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Calculate the trace of a matrix.
+ *
+ *  \ingroup trace_group
+ *
+ *  \param A The matrix to calculate a trace for
+ *  \return the trace of A
+ */
+double TYPED_FUNC(
+    bml_trace_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_indexb = (int *) A->indexb;
+    int *A_nnzb = (int *) A->nnzb;
+    int *bsize = A->bsize;
+
+    REAL_T trace = 0.0;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[ind];
+            if (ib == jb)
+            {
+                REAL_T *A_value = A_ptr_value[ind];
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                    trace += A_value[ROWMAJOR(ii, ii, bsize[ib], bsize[ib])];
+                break;
+            }
+        }
+    }
+
+    return (double) REAL_PART(trace);
+}
+
+/** Calculate the trace of a matrix multiplication.
+ * Both matrices must have the same size.
+ *
+ *  \ingroup trace_group
+ *
+ *  \param A The matrix A
+ *  \param A The matrix B
+ *  \return the trace of A*B
+ */
+double TYPED_FUNC(
+    bml_traceMult_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * B)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_indexb = (int *) A->indexb;
+    int *A_nnzb = (int *) A->nnzb;
+    int *bsize = A->bsize;
+
+    int *B_indexb = (int *) B->indexb;
+    int *B_nnzb = (int *) B->nnzb;
+
+    REAL_T trace = 0.0;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+
+    if (NB != B->NB || MB != B->MB)
+    {
+        LOG_ERROR
+            ("bml_traceMult_ellblock: Matrices A and B have different number of blocks.");
+    }
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int indA = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[indA];
+            REAL_T *A_value = A_ptr_value[indA];
+
+            for (int kp = 0; kp < B_nnzb[jb]; kp++)
+            {
+                int indB = ROWMAJOR(jb, kp, NB, MB);
+                int kb = B_indexb[indB];
+                if (kb == ib)
+                {
+                    REAL_T *B_value = B_ptr_value[indB];
+                    for (int ii = 0; ii < bsize[ib]; ii++)
+                        for (int jj = 0; jj < bsize[jb]; jj++)
+                        {
+                            int ka = ROWMAJOR(ii, jj, bsize[ib], bsize[jb]);
+                            int kb = ROWMAJOR(jj, ii, bsize[jb], bsize[ib]);
+                            trace += A_value[ka] * B_value[kb];
+                        }
+                }
+            }
+        }
+    }
+
+    return (double) REAL_PART(trace);
+}

--- a/src/C-interface/ellblock/bml_transpose_ellblock.c
+++ b/src/C-interface/ellblock/bml_transpose_ellblock.c
@@ -1,0 +1,73 @@
+#include "bml_logger.h"
+#include "bml_transpose.h"
+#include "bml_transpose_ellblock.h"
+#include "bml_types.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Transpose a matrix.
+ *
+ *  \ingroup transpose_group
+ *
+ *  \param A The matrix to be transposeed
+ *  \return the transposeed A
+ */
+bml_matrix_ellblock_t
+    * bml_transpose_new_ellblock(const bml_matrix_ellblock_t * A)
+{
+    bml_matrix_ellblock_t *B = NULL;
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            B = bml_transpose_new_ellblock_single_real(A);
+            break;
+        case double_real:
+            B = bml_transpose_new_ellblock_double_real(A);
+            break;
+        case single_complex:
+            B = bml_transpose_new_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            B = bml_transpose_new_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+    return B;
+}
+
+/** Transpose a matrix in place.
+ *
+ *  \ingroup transpose_group
+ *
+ *  \param A The matrix to be transposeed
+ *  \return the transposeed A
+ */
+void
+bml_transpose_ellblock(
+    const bml_matrix_ellblock_t * A)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_transpose_ellblock_single_real(A);
+            break;
+        case double_real:
+            bml_transpose_ellblock_double_real(A);
+            break;
+        case single_complex:
+            bml_transpose_ellblock_single_complex(A);
+            break;
+        case double_complex:
+            bml_transpose_ellblock_double_complex(A);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_transpose_ellblock.h
+++ b/src/C-interface/ellblock/bml_transpose_ellblock.h
@@ -1,0 +1,36 @@
+#ifndef __BML_TRANSPOSE_BELLBLOCK_H
+#define __BML_TRANSPOSE_BELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+bml_matrix_ellblock_t *bml_transpose_new_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_transpose_new_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_transpose_new_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_transpose_new_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+bml_matrix_ellblock_t *bml_transpose_new_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+void bml_transpose_ellblock(
+    const bml_matrix_ellblock_t * A);
+
+void bml_transpose_ellblock_single_real(
+    const bml_matrix_ellblock_t * A);
+
+void bml_transpose_ellblock_double_real(
+    const bml_matrix_ellblock_t * A);
+
+void bml_transpose_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A);
+
+void bml_transpose_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A);
+
+#endif

--- a/src/C-interface/ellblock/bml_transpose_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_transpose_ellblock_typed.c
@@ -1,0 +1,160 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "bml_allocate.h"
+#include "bml_transpose.h"
+#include "bml_parallel.h"
+#include "bml_types.h"
+#include "bml_allocate_ellblock.h"
+#include "bml_transpose_ellblock.h"
+#include "bml_types_ellblock.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Transpose a matrix.
+ *
+ *  \ingroup transpose_group
+ *
+ *  \param A The matrix to be transposed
+ *  \return the transposed A
+ */
+bml_matrix_ellblock_t *TYPED_FUNC(
+    bml_transpose_new_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+    int *bsize = A->bsize;
+    bml_distribution_mode_t distmode = A->distribution_mode;
+
+    bml_matrix_ellblock_t *B = TYPED_FUNC(bml_block_matrix_ellblock) (NB, MB,
+                                                                      bsize,
+                                                                      distmode);
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+
+    REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
+    int *B_indexb = B->indexb;
+    int *B_nnzb = B->nnzb;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int indA = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[indA];
+            int indB = ROWMAJOR(jb, B_nnzb[jb], NB, MB);
+            int nelements = bsize[ib] * bsize[jb];
+            //add a new block in B
+            B_indexb[indB] = ib;
+            B_ptr_value[indB] =
+                bml_noinit_allocate_memory(nelements * sizeof(REAL_T));
+            B_nnzb[jb]++;
+            //transpose block
+            REAL_T *B_value = B_ptr_value[indB];
+            REAL_T *A_value = A_ptr_value[indA];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                    B_value[ROWMAJOR(jj, ii, bsize[jb], bsize[ib])] =
+                        A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])];
+        }
+    }
+
+    return B;
+}
+
+
+/** Transpose a matrix in place.
+ *
+ *  \ingroup transpose_group
+ *
+ *  \param A The matrix to be transposeed
+ *  \return the transposed A
+ */
+void TYPED_FUNC(
+    bml_transpose_ellblock) (
+    const bml_matrix_ellblock_t * A)
+{
+    int NB = A->NB;
+    int MB = A->MB;
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *bsize = A->bsize;
+
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = A_nnzb[ib] - 1; jp >= 0; jp--)
+        {
+            int indl = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[indl];
+            if (jb >= ib)
+            {
+                int exchangeDone = 0;
+                for (int kp = 0; kp < A_nnzb[jb]; kp++)
+                {
+                    int indr = ROWMAJOR(jb, kp, NB, MB);
+                    if (A_indexb[indr] == ib)
+                    {
+                        REAL_T *A_value_l = A_ptr_value[indl];
+                        REAL_T *A_value_r = A_ptr_value[indr];
+                        if (ib == jb)
+                        {
+                            for (int ii = 0; ii < bsize[ib]; ii++)
+                                for (int jj = 0; jj < ii; jj++)
+                                {
+                                    int il = ROWMAJOR(ii, jj, bsize[ib],
+                                                      bsize[jb]);
+                                    int ir = ROWMAJOR(jj, ii, bsize[jb],
+                                                      bsize[ib]);
+                                    double tmp = A_value_r[il];
+                                    A_value_l[il] = A_value_r[ir];
+                                    A_value_l[ir] = tmp;
+                                }
+                        }
+                        else
+                        {
+                            for (int ii = 0; ii < bsize[ib]; ii++)
+                                for (int jj = 0; jj < bsize[jb]; jj++)
+                                {
+                                    int il = ROWMAJOR(ii, jj, bsize[ib],
+                                                      bsize[jb]);
+                                    int ir = ROWMAJOR(jj, ii, bsize[jb],
+                                                      bsize[ib]);
+                                    double tmp = A_value_l[il];
+                                    A_value_l[il] = A_value_r[ir];
+                                    A_value_r[ir] = tmp;
+                                }
+                        }
+                        exchangeDone = 1;
+                        break;
+                    }
+                }
+                assert(exchangeDone);
+                // If no match add to end of row
+//                if (!exchangeDone)
+//                {
+//                    int jind = A_nnzb[ind];
+//                    {
+//                        A_index[ROWMAJOR(ind, jind, N, M)] = i;
+//                        A_value[ROWMAJOR(ind, jind, N, M)] =
+//                            A_value[ROWMAJOR(i, j, N, M)];
+//                        A_nnz[ind]++;
+//                        A_nnz[i]--;
+//                    }
+//                }
+            }
+        }
+    }
+
+}

--- a/src/C-interface/ellblock/bml_types_ellblock.h
+++ b/src/C-interface/ellblock/bml_types_ellblock.h
@@ -1,0 +1,40 @@
+#ifndef __BML_TYPES_ELLBLOCK_H
+#define __BML_TYPES_ELLBLOCK_H
+
+#include "bml_types.h"
+
+/** BLOCK ELLPACK matrix type. */
+struct bml_matrix_ellblock_t
+{
+    /** The matrix type identifier. */
+    bml_matrix_type_t matrix_type;
+    /** The real precision. */
+    bml_matrix_precision_t matrix_precision;
+    /** The distribution mode. **/
+    bml_distribution_mode_t distribution_mode;
+    /** The number of rows. */
+    int N;
+    /** The number of columns per row. */
+    int M;
+    /** The number of block rows. */
+    int NB;
+    /** The max. number of blocks per row. */
+    int MB;
+    /** Pointers to blocks of values */
+    void **ptr_value;
+    /** The block index matrix. */
+    int *indexb;
+    /** The vector of non-zeros blocks per row */
+    int *nnzb;
+    /** The dimensions of the blocks */
+    int *bsize;
+    /** The domain decomposition when running in parallel. */
+    bml_domain_t *domain;
+    /** A copy of the domain decomposition. */
+    bml_domain_t *domain2;
+};
+typedef struct bml_matrix_ellblock_t bml_matrix_ellblock_t;
+
+#define BMAXSIZE 25
+
+#endif

--- a/src/C-interface/ellblock/bml_utilities_ellblock.c
+++ b/src/C-interface/ellblock/bml_utilities_ellblock.c
@@ -1,0 +1,54 @@
+#include "../bml_utilities.h"
+#include "../bml_logger.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+
+void
+bml_read_bml_matrix_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const char *filename)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_read_bml_matrix_ellblock_single_real(A, filename);
+            break;
+        case double_real:
+            bml_read_bml_matrix_ellblock_double_real(A, filename);
+            break;
+        case single_complex:
+            bml_read_bml_matrix_ellblock_single_complex(A, filename);
+            break;
+        case double_complex:
+            bml_read_bml_matrix_ellblock_double_complex(A, filename);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_write_bml_matrix_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const char *filename)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_write_bml_matrix_ellblock_single_real(A, filename);
+            break;
+        case double_real:
+            bml_write_bml_matrix_ellblock_double_real(A, filename);
+            break;
+        case single_complex:
+            bml_write_bml_matrix_ellblock_single_complex(A, filename);
+            break;
+        case double_complex:
+            bml_write_bml_matrix_ellblock_double_complex(A, filename);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellblock/bml_utilities_ellblock.h
+++ b/src/C-interface/ellblock/bml_utilities_ellblock.h
@@ -1,0 +1,107 @@
+/** \file */
+
+#ifndef __BML_UTILITIES_ELLBLOCK_H
+#define __BML_UTILITIES_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <complex.h>
+
+void bml_read_bml_matrix_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_read_bml_matrix_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_read_bml_matrix_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_read_bml_matrix_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_read_bml_matrix_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_write_bml_matrix_ellblock(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_write_bml_matrix_ellblock_single_real(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_write_bml_matrix_ellblock_double_real(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_write_bml_matrix_ellblock_single_complex(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+void bml_write_bml_matrix_ellblock_double_complex(
+    const bml_matrix_ellblock_t * A,
+    const char *filename);
+
+double bml_sum_squares_single_real(
+    const float *v,
+    const int,
+    const int,
+    const int);
+double bml_sum_squares_double_real(
+    const double *v,
+    const int,
+    const int,
+    const int);
+double bml_sum_squares_single_complex(
+    const float complex * v,
+    const int,
+    const int,
+    const int);
+double bml_sum_squares_double_complex(
+    const double complex * v,
+    const int,
+    const int,
+    const int);
+
+double bml_norm_inf_single_real(
+    const float *v,
+    const int,
+    const int,
+    const int);
+double bml_norm_inf_double_real(
+    const double *v,
+    const int,
+    const int,
+    const int);
+double bml_norm_inf_single_complex(
+    const float complex * v,
+    const int,
+    const int,
+    const int);
+double bml_norm_inf_double_complex(
+    const double complex * v,
+    const int,
+    const int,
+    const int);
+
+double bml_norm_inf_fast_single_real(
+    const float *v,
+    const int);
+double bml_norm_inf_fast_double_real(
+    const double *v,
+    const int);
+double bml_norm_inf_fast_single_complex(
+    const float complex * v,
+    const int);
+double bml_norm_inf_fast_double_complex(
+    const double complex * v,
+    const int);
+
+#endif

--- a/src/C-interface/ellblock/bml_utilities_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_utilities_ellblock_typed.c
@@ -1,0 +1,289 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_types.h"
+#include "../bml_logger.h"
+#include "../bml_utilities.h"
+#include "bml_types_ellblock.h"
+#include "bml_utilities_ellblock.h"
+#include "bml_parallel.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+/** Read in a bml matrix from Matrix Market format.
+ *
+ *  \ingroup utilities_group
+ *
+ *  \param A The matrix to be read
+ *  \param filename The Matrix Market format file
+ */
+void TYPED_FUNC(
+    bml_read_bml_matrix_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const char *filename)
+{
+    //for(int i=0;i<A->NB;i++)printf("bsize=%d\n",A->bsize[i]);
+    assert(A->bsize[0] < 1e6);
+
+    FILE *hFile;
+    char header1[20], header2[20], header3[20], header4[20], header5[20];
+    int hdimx, nnz, irow, icol;
+    REAL_T val;
+
+    int NB = A->NB;
+    int MB = A->MB;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *A_bsize = A->bsize;
+
+    hFile = fopen(filename, "r");
+
+    // Read header
+    if (fscanf(hFile, "%s %s %s %s %s", header1, header2, header3, header4,
+               header5) != 5)
+    {
+        LOG_ERROR("read error on header\n");
+    }
+
+    int symflag = strcmp(header5, "symmetric");
+
+    // Read N, N, # of non-zeroes
+    if (fscanf(hFile, "%d %d %d", &hdimx, &hdimx, &nnz) != 3)
+    {
+        LOG_ERROR("read error\n");
+    }
+
+    char *FMT = "";
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            FMT = "%d %d %g\n";
+            break;
+        case double_real:
+            FMT = "%d %d %lg\n";
+            break;
+        case single_complex:
+            FMT = "%d %d %g\n";
+            break;
+        case double_complex:
+            FMT = "%d %d %lg\n";
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+
+    // Read in values
+    for (int i = 0; i < nnz; i++)
+    {
+        if (fscanf(hFile, FMT, &irow, &icol, &val) != 3)
+        {
+            LOG_ERROR("read error\n");
+        }
+        irow--;
+        icol--;
+
+        /*compute block indexes */
+        int ib = 0;
+        while (irow >= A_bsize[ib])
+        {
+            irow -= A_bsize[ib];
+            ib++;
+        }
+
+        int jb = 0;
+        while (icol >= A_bsize[jb])
+        {
+            icol -= A_bsize[jb];
+            jb++;
+        }
+
+        int found_block = 0;
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, NB, MB);
+            int jbb = A_indexb[ind];
+            if (jbb == jb)
+            {
+                found_block = 1;
+                REAL_T *A_value = A_ptr_value[ind];
+                A_value[ROWMAJOR(irow, icol, A_bsize[ib], A_bsize[jb])] = val;
+            }
+        }
+        //add block if needed
+        if (found_block == 0)
+        {
+            //printf("Add new block %d, %d\n",ib, jb);
+            assert(A_nnzb[ib] < MB);
+            int nelements = A_bsize[ib] * A_bsize[jb];
+            int ind = ROWMAJOR(ib, A_nnzb[ib], NB, MB);
+            A_indexb[ind] = jb;
+            A_nnzb[ib]++;
+            A_ptr_value[ind] = calloc(nelements, sizeof(REAL_T));
+            REAL_T *A_value = A_ptr_value[ind];
+            assert(A_value != NULL);
+            A_value[ROWMAJOR(irow, icol, A_bsize[ib], A_bsize[jb])] = val;
+        }
+
+        // Set symmetric value if necessary
+        if (symflag == 0 && icol != irow)
+        {
+            int found_block = 0;
+            for (int ip = 0; ip < A_nnzb[jb]; ip++)
+            {
+                int ind = ROWMAJOR(jb, ip, NB, MB);
+                int ibb = A_indexb[ROWMAJOR(jb, ip, NB, MB)];
+                if (ibb == ib)
+                {
+                    found_block = 1;
+                    REAL_T *A_value = A_ptr_value[ind];
+                    A_value[ROWMAJOR(icol, irow, A_bsize[jb], A_bsize[ib])] =
+                        val;
+                }
+            }
+            //add block if needed
+            if (found_block == 0)
+            {
+                A_indexb[A_nnzb[jb]] = ib;
+                int ind = ROWMAJOR(jb, A_nnzb[jb], NB, MB);
+                A_nnzb[jb]++;
+                REAL_T *A_value = A_ptr_value[ind];
+                A_value[ROWMAJOR(icol, irow, A_bsize[jb], A_bsize[ib])] = val;
+            }
+        }
+    }
+
+    fclose(hFile);
+}
+
+/** Write a Matrix Market format file from a bml matrix.
+ *
+ *  \ingroup utilities_group
+ *
+ *  \param A The matrix to be written
+ *  \param filename The Matrix Market format file
+ */
+void TYPED_FUNC(
+    bml_write_bml_matrix_ellblock) (
+    const bml_matrix_ellblock_t * A,
+    const char *filename)
+{
+    FILE *mFile;
+    int msum;
+
+    int NB = A->NB;
+    int MB = A->MB;
+
+    int *A_indexb = A->indexb;
+    int *A_nnzb = A->nnzb;
+    int *bsize = A->bsize;
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    // Only write from rank 0
+    if (bml_printRank() != 1)
+        return;
+
+    mFile = fopen(filename, "w");
+
+    // Write header
+    fprintf(mFile, "%%%%%%MatrixMarket matrix coordinate real general\n");
+
+    // Collect number of non-zero elements
+    // Write out matrix size as dense and number of non-zero elements
+    msum = 0;
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int kb = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[kb];
+            msum += bsize[ib] * bsize[jb];
+        }
+    }
+    fprintf(mFile, "%d %d %d\n", A->N, A->N, msum);
+
+    int *offset = malloc(NB * sizeof(int));
+    offset[0] = 0;
+    for (int ib = 1; ib < NB; ib++)
+    {
+        offset[ib] = offset[ib - 1] + bsize[ib - 1];
+    }
+
+    // Write out non-zero elements
+    for (int ib = 0; ib < NB; ib++)
+    {
+        for (int jp = 0; jp < A_nnzb[ib]; jp++)
+        {
+            int kb = ROWMAJOR(ib, jp, NB, MB);
+            int jb = A_indexb[kb];
+            REAL_T *A_value = A_ptr_value[kb];
+            for (int ii = 0; ii < bsize[ib]; ii++)
+                for (int jj = 0; jj < bsize[jb]; jj++)
+                {
+                    fprintf(mFile, "%d %d %20.15e\n",
+                            offset[ib] + 1 + ii,
+                            offset[jb] + 1 + jj,
+                            REAL_PART(A_value
+                                      [ROWMAJOR
+                                       (ii, jj, bsize[ib], bsize[jb])]));
+                }
+        }
+    }
+    free(offset);
+
+    fclose(mFile);
+}
+
+double TYPED_FUNC(
+    bml_norm_inf) (
+    const REAL_T * v,
+    const int nrows,
+    const int ncols,
+    const int ld)
+{
+    double norm = 0.;
+    for (int i = 0; i < nrows; i++)
+        for (int j = 0; j < ncols; j++)
+        {
+            double alpha = (double) ABS(v[ROWMAJOR(i, j, nrows, ld)]);
+            if (alpha > norm)
+                norm = alpha;
+        }
+    return norm;
+}
+
+double TYPED_FUNC(
+    bml_norm_inf_fast) (
+    const REAL_T * v,
+    const int n)
+{
+    double norm = 0.;
+    for (int i = 0; i < n; i++)
+    {
+        double alpha = (double) ABS(v[i]);
+        if (alpha > norm)
+            norm = alpha;
+    }
+    return norm;
+}
+
+double TYPED_FUNC(
+    bml_sum_squares) (
+    const REAL_T * v,
+    const int nrows,
+    const int ncols,
+    const int ld)
+{
+    double n2 = 0.;
+    for (int i = 0; i < nrows; i++)
+        for (int j = 0; j < ncols; j++)
+        {
+            double alpha = (double) ABS(v[ROWMAJOR(i, j, nrows, ld)]);
+            n2 = n2 + alpha * alpha;
+        }
+    return n2;
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,11 @@ add_library(bml
   $<TARGET_OBJECTS:bml-ellpack-single_complex>
   $<TARGET_OBJECTS:bml-ellpack-single_real>
   $<TARGET_OBJECTS:bml-ellpack>
+  $<TARGET_OBJECTS:bml-ellblock-double_complex>
+  $<TARGET_OBJECTS:bml-ellblock-double_real>
+  $<TARGET_OBJECTS:bml-ellblock-single_complex>
+  $<TARGET_OBJECTS:bml-ellblock-single_real>
+  $<TARGET_OBJECTS:bml-ellblock>
   $<TARGET_OBJECTS:bml-ellsort-double_complex>
   $<TARGET_OBJECTS:bml-ellsort-double_real>
   $<TARGET_OBJECTS:bml-ellsort-single_complex>

--- a/src/Fortran-interface/bml_allocate_m.F90
+++ b/src/Fortran-interface/bml_allocate_m.F90
@@ -17,6 +17,7 @@ module bml_allocate_m
   public :: bml_random_matrix
   public :: bml_update_domain
   public :: bml_zero_matrix
+  public :: bml_block_matrix
 
 contains
 
@@ -100,6 +101,32 @@ contains
         & n, m, get_dmode_id(distrib_mode_))
 
   end subroutine bml_zero_matrix
+
+  subroutine bml_block_matrix(matrix_type, element_type, element_precision, &
+      & nb, mb, bsizes, a, distrib_mode)
+
+    character(len=*), intent(in) :: matrix_type, element_type
+    character(len=*), optional, intent(in) :: distrib_mode
+    integer, intent(in) :: element_precision
+    integer(C_INT), intent(in) :: nb, mb
+    integer, allocatable, intent(in) :: bsizes(:)
+    type(bml_matrix_t), intent(inout) :: a
+
+    character(len=20) :: distrib_mode_
+
+    if (present(distrib_mode)) then
+      distrib_mode_ = distrib_mode
+    else
+      distrib_mode_ = bml_dmode_sequential
+    endif
+
+    call bml_deallocate(a)
+    print*,'bsizes=',bsizes(1)
+    a%ptr = bml_block_matrix_C(get_matrix_id(matrix_type), &
+        & get_element_id(element_type, element_precision), &
+        & nb, mb, bsizes, get_dmode_id(distrib_mode_))
+
+  end subroutine bml_block_matrix
 
   !> Create a matrix without initializing.
   !!

--- a/src/Fortran-interface/bml_c_interface_m.F90
+++ b/src/Fortran-interface/bml_c_interface_m.F90
@@ -565,6 +565,18 @@ module bml_c_interface_m
       type(C_PTR) :: bml_zero_matrix_C
     end function bml_zero_matrix_C
 
+    function bml_block_matrix_C(matrix_type, matrix_precision, nb, mb, bsizes, &
+        & distrib_mode) bind(C, name="bml_block_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: nb
+      integer(C_INT), value, intent(in) :: mb
+      integer(C_INT), intent(in), dimension(*) :: bsizes
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_block_matrix_C
+    end function bml_block_matrix_C
+
     function bml_noinit_matrix_C(matrix_type, matrix_precision, n, m, &
         & distrib_mode) bind(C, name="bml_noinit_matrix")
       import :: C_INT, C_PTR

--- a/src/Fortran-interface/bml_interface_m.F90
+++ b/src/Fortran-interface/bml_interface_m.F90
@@ -28,6 +28,12 @@ module bml_interface_m
   !> The enum values of the C API. Keep this synchronized with the
   !! enum in bml_types.h.
   !!
+  !! Matrix type is ellblock.
+  integer, parameter :: bml_matrix_type_ellblock_enum_id = 3
+
+  !> The enum values of the C API. Keep this synchronized with the
+  !! enum in bml_types.h.
+  !!
   !! Matrix precision is unitialized.
   integer, parameter :: bml_matrix_precision_uninitialized_id = 0
 
@@ -91,12 +97,15 @@ contains
 
     character(len=*), intent(in) :: type_string
     integer(C_INT) :: id
+    integer dummy
 
     select case (trim(type_string))
     case(BML_MATRIX_DENSE)
       id = bml_matrix_type_dense_enum_id
     case(BML_MATRIX_ELLPACK)
        id = bml_matrix_type_ellpack_enum_id
+    case(BML_MATRIX_ELLBLOCK)
+       id = bml_matrix_type_ellblock_enum_id
     case default
        print *, "unknown matrix type"//trim(type_string)
        error stop

--- a/src/Fortran-interface/bml_types_m.F90
+++ b/src/Fortran-interface/bml_types_m.F90
@@ -8,7 +8,7 @@ module bml_types_m
 
   public :: bml_vector_t, bml_matrix_t
   public :: bml_deallocate
-  public :: BML_MATRIX_DENSE, BML_MATRIX_ELLPACK
+  public :: BML_MATRIX_DENSE, BML_MATRIX_ELLPACK, BML_MATRIX_ELLBLOCK
   public :: BML_ELEMENT_REAL, BML_ELEMENT_COMPLEX
   public :: BML_DMODE_SEQUENTIAL, BML_DMODE_DISTRIBUTED
   public :: BML_DMODE_GRAPH_DISTRIBUTED
@@ -46,6 +46,9 @@ module bml_types_m
 
   !> The bml-ellpack matrix type identifier.
   character(len=*), parameter :: BML_MATRIX_ELLPACK = "ellpack"
+
+  !> The bml-ellblock matrix type identifier.
+  character(len=*), parameter :: BML_MATRIX_ELLBLOCK = "ellblock"
 
   !> The single precision identifier.
   character(len=*), parameter :: BML_ELEMENT_REAL = "real"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,8 +107,9 @@ foreach(N
     submatrix
     threshold
     trace
-    transpose)
-  foreach(T dense ellpack ellsort)
+    transpose
+  )
+  foreach(T dense ellpack ellsort ellblock)
     foreach(P single_real double_real single_complex double_complex)
       #if(BML_MPI)
         #add_test(${N}-${T}-${P} mpirun -np 1 bml-test -n ${N} -t ${T} -p ${P})

--- a/tests/adjacency_matrix_typed.c
+++ b/tests/adjacency_matrix_typed.c
@@ -21,7 +21,8 @@ int TYPED_FUNC(
     bml_matrix_t *A = NULL;
     REAL_T *A_dense = NULL;
 
-    if (matrix_type == dense || matrix_type == ellsort)
+    if (matrix_type == dense || matrix_type == ellsort
+        || matrix_type == ellblock)
     {
         LOG_INFO("adjacency matrix test not available\n");
         return 0;

--- a/tests/adjungate_triangle_matrix_typed.c
+++ b/tests/adjungate_triangle_matrix_typed.c
@@ -21,7 +21,8 @@ int TYPED_FUNC(
     bml_matrix_t *A = NULL;
     REAL_T *A_dense = NULL;
 
-    if (matrix_type == dense || matrix_type == ellsort)
+    if (matrix_type == dense || matrix_type == ellsort
+        || matrix_type == ellblock)
     {
         LOG_INFO("adjungate triangle matrix test not available\n");
         return 0;

--- a/tests/bml_test.c
+++ b/tests/bml_test.c
@@ -114,6 +114,7 @@ print_usage(
     printf("  dense\n");
     printf("  ellpack\n");
     printf("  ellsort\n");
+    printf("  ellblock\n");
     printf("\n");
     printf("Recognized precisions:\n");
     printf("\n");
@@ -212,6 +213,10 @@ main(
                 else if (strcasecmp(optarg, "ellsort") == 0)
                 {
                     matrix_type = ellsort;
+                }
+                else if (strcasecmp(optarg, "ellblock") == 0)
+                {
+                    matrix_type = ellblock;
                 }
                 else
                 {

--- a/tests/inverse_matrix_typed.c
+++ b/tests/inverse_matrix_typed.c
@@ -25,7 +25,8 @@ int TYPED_FUNC(
     bml_matrix_t *aux = NULL;
     float ssum;
 
-    if (matrix_type != dense && matrix_type != ellpack)
+    if (matrix_type != dense && matrix_type != ellpack
+        && matrix_type != ellblock)
     {
         LOG_INFO("inverse for this matrix type is not implemented\n");
         return 0;

--- a/tests/submatrix_matrix_typed.c
+++ b/tests/submatrix_matrix_typed.c
@@ -36,7 +36,7 @@ int TYPED_FUNC(
     double threshold2 = 0.2;
     double threshold3 = 0.3;
 
-    if (matrix_type == dense)
+    if (matrix_type == dense || matrix_type == ellblock)
     {
         LOG_INFO("submatrix matrix test not available\n");
         return 0;


### PR DESCRIPTION
This is based on the ellpack format, but each "element" is now a block.
Block sizes are defined either by the first call to build a matrix with
'bml_block_matrix' or by their default values. They have to be the same
for all matrices. This code seems to work properly and pass all the tests.
It has however not been optimized and does not include OpenMP directives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/244)
<!-- Reviewable:end -->
