### PR TITLE
fixed omp index issue in bml_multiply_ellsort_typed.c

### DIFF
--- a/src/C-interface/ellsort/bml_multiply_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_multiply_ellsort_typed.c
@@ -413,7 +413,7 @@ void TYPED_FUNC(
         aflag = 0;
 
 #if defined(__IBMC__) || defined(__ibmxl__)
-#pragma omp parallel for \
+#pragma omp parallel for                     \
   default(none)                              \
   shared(A_N, A_M, A_nnz, A_index, A_value)  \
   shared(A_localRowMin, A_localRowMax)       \


### PR DESCRIPTION
issue was fixed by:

converting "omp parallel" region to "omp parallel for" region

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/249)
<!-- Reviewable:end -->
