### PR TITLE
Added missing argument when compiling with magma and omp

### DIFF
--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -72,7 +72,7 @@ void *TYPED_FUNC(
 
 #pragma omp parallel for                        \
   default(none)                                 \
-  shared(N, A_matrix)                           \
+  shared(N, A_matrix, A)                           \
   shared(A_localRowMin, A_localRowMax, myRank)  \
   private(absham, radius, dvalue)               \
   reduction(max:emax)                           \


### PR DESCRIPTION
Added missing variable in omp pragmas that were needed to compile with both 
magma and omp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/252)
<!-- Reviewable:end -->
