### PR TITLE
Make build of complex types optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,28 @@ if(LAPACK_FOUND)
   list(APPEND LINK_LIBRARIES ${LAPACK_LIBRARIES})
 endif()
 
+# Check whether the compiler supports complex types. The Nvidia
+# compiler is known not to support them for example.
+
+set(BML_COMPLEX TRUE
+  CACHE BOOL "Whether to build complex types")
+
+if(BML_COMPLEX)
+  try_compile(SUPPORTS_COMPLEX ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/test_complex.c
+    OUTPUT_VARIABLE COMPLEX_OUTPUT
+    )
+  message(STATUS "Compile output: ${COMPLEX_OUTPUT}")
+  if(SUPPORTS_COMPLEX)
+    message(STATUS "The compiler supports complex types")
+    add_definitions(-DBML_COMPLEX)
+  else()
+    message(STATUS "The compiler does not support complex types. Will skip them.")
+    set(BML_COMPLEX FALSE)
+  endif()
+else()
+  message(STATUS "Complex types disabled on user request")
+endif()
+
 find_program(ADDR2LINE addr2line)
 if(ADDR2LINE)
   message(STATUS "Found addr2line, backtrace will resolve line numbers")

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ EOF
     echo "FC                     Path to Fortran compiler    (default is ${FC})"
     echo "BML_OPENMP             {yes,no}                    (default is ${BML_OPENMP})"
     echo "BML_MPI                {yes,no}                    (default is ${BML_MPI})"
+    echo "BML_COMPLEX            {yes,no}                    (default is ${BML_COMPLEX})"
     echo "BML_TESTING            {yes,no}                    (default is ${BML_TESTING})"
     echo "BUILD_DIR              Path to build dir           (default is ${BUILD_DIR})"
     echo "BLAS_VENDOR            {,Intel,MKL,ACML,GNU,IBM,Auto}  (default is '${BLAS_VENDOR}')"
@@ -74,6 +75,7 @@ set_defaults() {
     : ${FC:=gfortran}
     : ${BML_OPENMP:=yes}
     : ${BML_MPI:=no}
+    : ${BML_COMPLEX:=yes}
     : ${BLAS_VENDOR:=}
     : ${BML_INTERNAL_BLAS:=no}
     : ${EXTRA_CFLAGS:=}
@@ -143,6 +145,7 @@ configure() {
         -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
         -DBML_OPENMP="${BML_OPENMP}" \
         -DBML_MPI="${BML_MPI}" \
+        -DBML_COMPLEX="${BML_COMPLEX}" \
         -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS}" \
         -DBML_TESTING="${BML_TESTING:=yes}" \
         -DBLAS_VENDOR="${BLAS_VENDOR}" \

--- a/cmake/test_complex.c
+++ b/cmake/test_complex.c
@@ -1,0 +1,16 @@
+#include <complex.h>
+
+int
+main(
+    int argc,
+    char **argv)
+{
+    double complex x;
+
+    x = 3.0 + 4.0 * _Complex_I;
+    if (creal(x) == 3.0)
+    {
+        return 0;
+    }
+    return 1;
+}

--- a/src/typed.h
+++ b/src/typed.h
@@ -1,7 +1,7 @@
 #ifndef __TYPED_H
 #define __TYPED_H
 
-#if defined(SINGLE_REAL)
+#if defined(SINGLE_REAL) || (defined(SINGLE_COMPLEX) && ! defined(BML_COMPLEX))
 #define REAL_T float
 #define MAGMA_T float
 #define FUNC_SUFFIX single_real
@@ -13,7 +13,7 @@
 #define COMPLEX_CONJUGATE(x) (x)
 #define ABS(x) (fabsf(x))
 #define is_above_threshold(x, t) (fabsf(x) > (float) (t))
-#elif defined(DOUBLE_REAL)
+#elif defined(DOUBLE_REAL) || (defined(DOUBLE_COMPLEX) && ! defined(BML_COMPLEX))
 #define REAL_T double
 #define MAGMA_T double
 #define FUNC_SUFFIX double_real


### PR DESCRIPTION
The Nvidia compilers don't support complex types for device. This
change adds an option to disable building of complex types. In
addition CMake will now verify that the compile can deal with complex
types.

This implementation is pretty crude. If complex types are not built,
then the corresponding types will be mapped to their real valued
counter parts in `typed.h`. The library will still contain functions
that have a `complex` in their name.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/255)
<!-- Reviewable:end -->
