### PR TITLE
Passing different flags to ellpack and ellsort fixed

### DIFF
--- a/src/C-interface/ellpack/CMakeLists.txt
+++ b/src/C-interface/ellpack/CMakeLists.txt
@@ -56,7 +56,7 @@ set_target_properties(bml-ellpack
 if(OPENMP_FOUND)
   set_target_properties(bml-ellpack
     PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    COMPILE_FLAGS "${COMPILE_FLAGS} ${OpenMP_C_FLAGS}")
 endif()
 
 set(SOURCES-ELLPACK-TYPED


### PR DESCRIPTION
Preprocessing flags were different between ellpack and elsort. 
Now we are passing "${COMPILE_FLAGS} ${OpenMP_C_FLAGS}"
to both

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/258)
<!-- Reviewable:end -->
