### PR TITLE
Update `indent.sh` script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -198,10 +198,9 @@ indent() {
 }
 
 check_indent() {
-    cd "${BUILD_DIR}"
+    cd "${TOP_DIR}"
     "${TOP_DIR}/indent.sh" 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
-    cd "${TOP_DIR}"
     git diff 2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
     LINES=$(git diff | wc -l)

--- a/indent.sh
+++ b/indent.sh
@@ -1,34 +1,43 @@
 #!/bin/bash
 
+set -x -u
+
 INDENT_ARGS="-gnu -nut -i4 -bli0 -cli4 -ppi0 -cbi0 -npcs -bfda"
 
 declare -a C_FILES
 declare -a FORTRAN_FILES
 
-if [[ $# -gt 0 ]]; then
-    for f in "$@"; do
-        case "${f##*.}" in
-            "c" | "h")
-                C_FILES[${#C_FILES[@]}]="$f"
-                ;;
-            "F90")
-                FORTRAN_FILES[${#FORTRAN_FILES[@]}]="$f"
-                ;;
-            *)
-                echo "unknown suffix"
-                ;;
-        esac
-    done
-else
-    BASEDIR="$(dirname $0)"
-    C_FILES=($(find "${BASEDIR}" -name '*.c' -o -name '*.h'))
-    FORTRAN_FILES=($(find "${BASEDIR}" -name '*.F90'))
+if ! git status > /dev/null; then
+  cat <<EOF
+We are not inside a git repository. Please specify the files to indent
+manually.
+EOF
+  exit 1
 fi
 
-for f in ${C_FILES[@]} ${FORTRAN_FILES[@]}; do
-    sed -i -e 's:\s\+$::' "${f}"
+if (( $# > 0 )); then
+  for file in "$@"; do
+    case "${file##*.}" in
+      "c" | "h")
+        C_FILES[${#C_FILES[@]}]="$file"
+        ;;
+      "F90")
+        FORTRAN_FILES[${#FORTRAN_FILES[@]}]="$file"
+        ;;
+      *)
+        echo "unknown suffix"
+        ;;
+    esac
+  done
+else
+  readarray -t C_FILES < <(git ls-files -- *.c)
+  readarray -t FORTRAN_FILES < <(git ls-files -- *.F90)
+fi
+
+for f in "${C_FILES[@]}" "${FORTRAN_FILES[@]}"; do
+  sed -i -e 's:\s\+$::' "${f}"
 done
 
-for f in ${C_FILES[@]}; do
-    indent ${INDENT_ARGS} "${f}"
+for f in "${C_FILES[@]}"; do
+  indent ${INDENT_ARGS} "${f}"
 done


### PR DESCRIPTION
This change updates the `indent.sh` script so that it indents only
files that are tracked in git. This avoids indenting files that are
build artifacts.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/264)
<!-- Reviewable:end -->
