### PR TITLE
Fix `const` types in `bml_add`

### DIFF
--- a/src/C-interface/bml_add.c
+++ b/src/C-interface/bml_add.c
@@ -22,11 +22,11 @@
  */
 void
 bml_add(
-    bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_t * const A,
+    bml_matrix_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_add.h
+++ b/src/C-interface/bml_add.h
@@ -6,11 +6,11 @@
 #include "bml_types.h"
 
 void bml_add(
-    bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_t * const A,
+    bml_matrix_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm(
     bml_matrix_t * A,

--- a/src/C-interface/dense/bml_add_dense.c
+++ b/src/C-interface/dense/bml_add_dense.c
@@ -20,10 +20,10 @@
  */
 void
 bml_add_dense(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta)
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_add_dense.h
+++ b/src/C-interface/dense/bml_add_dense.h
@@ -4,34 +4,34 @@
 #include "bml_types_dense.h"
 
 void bml_add_dense(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta);
 
 void bml_add_dense_single_real(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta);
 
 void bml_add_dense_double_real(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta);
 
 void bml_add_dense_single_complex(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta);
 
 void bml_add_dense_double_complex(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta);
 
 double bml_add_norm_dense(
     bml_matrix_dense_t * A,

--- a/src/C-interface/dense/bml_add_dense_typed.c
+++ b/src/C-interface/dense/bml_add_dense_typed.c
@@ -39,10 +39,10 @@
  */
 void TYPED_FUNC(
     bml_add_dense) (
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta)
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta)
 {
     int myRank = bml_getMyRank();
 

--- a/src/C-interface/ellblock/bml_add_ellblock.c
+++ b/src/C-interface/ellblock/bml_add_ellblock.c
@@ -21,11 +21,11 @@
  */
 void
 bml_add_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     switch (B->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_add_ellblock.h
+++ b/src/C-interface/ellblock/bml_add_ellblock.h
@@ -4,39 +4,39 @@
 #include "bml_types_ellblock.h"
 
 void bml_add_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellblock(
     const bml_matrix_ellblock_t * A,

--- a/src/C-interface/ellblock/bml_add_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_add_ellblock_typed.c
@@ -33,11 +33,11 @@
  */
 void TYPED_FUNC(
     bml_add_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     assert(A->NB == B->NB);
     assert(A->bsize[0] == B->bsize[0]);

--- a/src/C-interface/ellpack/bml_add_ellpack.c
+++ b/src/C-interface/ellpack/bml_add_ellpack.c
@@ -21,11 +21,11 @@
  */
 void
 bml_add_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     switch (B->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_add_ellpack.h
+++ b/src/C-interface/ellpack/bml_add_ellpack.h
@@ -4,39 +4,39 @@
 #include "bml_types_ellpack.h"
 
 void bml_add_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellpack(
     const bml_matrix_ellpack_t * A,

--- a/src/C-interface/ellpack/bml_add_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_add_ellpack_typed.c
@@ -31,11 +31,11 @@
  */
 void TYPED_FUNC(
     bml_add_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     int N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellsort/bml_add_ellsort.c
+++ b/src/C-interface/ellsort/bml_add_ellsort.c
@@ -21,11 +21,11 @@
  */
 void
 bml_add_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     switch (B->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_add_ellsort.h
+++ b/src/C-interface/ellsort/bml_add_ellsort.h
@@ -4,39 +4,39 @@
 #include "bml_types_ellsort.h"
 
 void bml_add_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellsort(
     const bml_matrix_ellsort_t * A,

--- a/src/C-interface/ellsort/bml_add_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_add_ellsort_typed.c
@@ -31,11 +31,11 @@
  */
 void TYPED_FUNC(
     bml_add_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     int N = A->N;
     int A_M = A->M;

--- a/src/Fortran-interface/bml_c_interface_m.F90
+++ b/src/Fortran-interface/bml_c_interface_m.F90
@@ -21,7 +21,7 @@ module bml_c_interface_m
 
   interface
 
-     subroutine bml_add_C(a, b, alpha, beta, threshold) bind(C, name="bml_add")
+    subroutine bml_add_C(a, b, alpha, beta, threshold) bind(C, name="bml_add")
       import :: C_PTR, C_DOUBLE
       type(C_PTR), value, intent(in) :: a
       type(C_PTR), value, intent(in) :: b
@@ -31,7 +31,7 @@ module bml_c_interface_m
     end subroutine bml_add_C
 
     function bml_add_norm_C(a, b, alpha, beta, threshold) &
-        & bind(C, name="bml_add_norm")
+         & bind(C, name="bml_add_norm")
       import :: C_PTR, C_DOUBLE
       type(C_PTR), value, intent(in) :: a
       type(C_PTR), value, intent(in) :: b


### PR DESCRIPTION
This change adjusts the types in `bml_add` so that the pointer `A` is
`const`, but the value of `A` is mutable, and both the pointer and the
value of `B` is `const`.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/265)
<!-- Reviewable:end -->
