### PR TITLE
Fix `const` types in `bml_add_norm`

### DIFF
--- a/src/C-interface/bml_add.c
+++ b/src/C-interface/bml_add.c
@@ -63,11 +63,11 @@ bml_add(
  */
 double
 bml_add_norm(
-    bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_t * const A,
+    bml_matrix_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
 
     switch (bml_get_type(A))

--- a/src/C-interface/bml_add.h
+++ b/src/C-interface/bml_add.h
@@ -13,11 +13,11 @@ void bml_add(
     const double threshold);
 
 double bml_add_norm(
-    bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_t * const A,
+    bml_matrix_t const * const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_identity(
     bml_matrix_t * A,

--- a/src/C-interface/dense/bml_add_dense.c
+++ b/src/C-interface/dense/bml_add_dense.c
@@ -58,10 +58,10 @@ bml_add_dense(
  */
 double
 bml_add_norm_dense(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta)
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta)
 {
     double trnorm = 0.0;
 

--- a/src/C-interface/dense/bml_add_dense.h
+++ b/src/C-interface/dense/bml_add_dense.h
@@ -34,34 +34,34 @@ void bml_add_dense_double_complex(
     const double beta);
 
 double bml_add_norm_dense(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const * const B,
+    double const alpha,
+    double const beta);
 
 double bml_add_norm_dense_single_real(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const * const B,
+    double const alpha,
+    double const beta);
 
 double bml_add_norm_dense_double_real(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const * const B,
+    double const alpha,
+    double const beta);
 
 double bml_add_norm_dense_single_complex(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const * const B,
+    double const alpha,
+    double const beta);
 
 double bml_add_norm_dense_double_complex(
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const * const B,
+    double const alpha,
+    double const beta);
 
 void bml_add_identity_dense(
     bml_matrix_dense_t * A,

--- a/src/C-interface/dense/bml_add_dense_typed.c
+++ b/src/C-interface/dense/bml_add_dense_typed.c
@@ -85,10 +85,10 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_dense) (
-    bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta)
+    bml_matrix_dense_t * const A,
+    bml_matrix_dense_t const *const B,
+    double const alpha,
+    double const beta)
 {
     double trnorm = 0.0;
     REAL_T *B_matrix = (REAL_T *) B->matrix;

--- a/src/C-interface/ellblock/bml_add_ellblock.c
+++ b/src/C-interface/ellblock/bml_add_ellblock.c
@@ -61,11 +61,11 @@ bml_add_ellblock(
  */
 double
 bml_add_norm_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     double trnorm = 0.0;
 

--- a/src/C-interface/ellblock/bml_add_ellblock.h
+++ b/src/C-interface/ellblock/bml_add_ellblock.h
@@ -39,39 +39,39 @@ void bml_add_ellblock_double_complex(
     const double threshold);
 
 double bml_add_norm_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const * const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const * const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const * const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const * const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const * const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_identity_ellblock(
     const bml_matrix_ellblock_t * A,

--- a/src/C-interface/ellblock/bml_add_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_add_ellblock_typed.c
@@ -169,11 +169,11 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * const A,
+    bml_matrix_ellblock_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     int NB = A->NB;
     int MB = A->MB;

--- a/src/C-interface/ellpack/bml_add_ellpack.c
+++ b/src/C-interface/ellpack/bml_add_ellpack.c
@@ -61,11 +61,11 @@ bml_add_ellpack(
  */
 double
 bml_add_norm_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     double trnorm = 0.0;
 

--- a/src/C-interface/ellpack/bml_add_ellpack.h
+++ b/src/C-interface/ellpack/bml_add_ellpack.h
@@ -39,39 +39,39 @@ void bml_add_ellpack_double_complex(
     const double threshold);
 
 double bml_add_norm_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+ bml_matrix_ellpack_t * const A,
+ bml_matrix_ellpack_t const * const B,
+ double const alpha,
+ double const beta,
+ double const threshold);
 
 double bml_add_norm_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+ bml_matrix_ellpack_t * const A,
+ bml_matrix_ellpack_t const * const B,
+ double const alpha,
+ double const beta,
+ double const threshold);
 
 double bml_add_norm_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+ bml_matrix_ellpack_t * const A,
+ bml_matrix_ellpack_t const * const B,
+ double const alpha,
+ double const beta,
+ double const threshold);
 
 double bml_add_norm_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+ bml_matrix_ellpack_t * const A,
+ bml_matrix_ellpack_t const * const B,
+ double const alpha,
+ double const beta,
+ double const threshold);
 
 double bml_add_norm_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+ bml_matrix_ellpack_t * const A,
+ bml_matrix_ellpack_t const * const B,
+ double const alpha,
+ double const beta,
+ double const threshold);
 
 void bml_add_identity_ellpack(
     const bml_matrix_ellpack_t * A,

--- a/src/C-interface/ellpack/bml_add_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_add_ellpack_typed.c
@@ -153,11 +153,11 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     int N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellsort/bml_add_ellsort.c
+++ b/src/C-interface/ellsort/bml_add_ellsort.c
@@ -61,11 +61,11 @@ bml_add_ellsort(
  */
 double
 bml_add_norm_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     double trnorm = 0.0;
 

--- a/src/C-interface/ellsort/bml_add_ellsort.h
+++ b/src/C-interface/ellsort/bml_add_ellsort.h
@@ -39,39 +39,39 @@ void bml_add_ellsort_double_complex(
     const double threshold);
 
 double bml_add_norm_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+     bml_matrix_ellsort_t * const A,
+     bml_matrix_ellsort_t const * const B,
+     double const alpha,
+     double const beta,
+     double const threshold);
 
 double bml_add_norm_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+     bml_matrix_ellsort_t * const A,
+     bml_matrix_ellsort_t const * const B,
+     double const alpha,
+     double const beta,
+     double const threshold);
 
 double bml_add_norm_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+     bml_matrix_ellsort_t * const A,
+     bml_matrix_ellsort_t const * const B,
+     double const alpha,
+     double const beta,
+     double const threshold);
 
 double bml_add_norm_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+     bml_matrix_ellsort_t * const A,
+     bml_matrix_ellsort_t const * const B,
+     double const alpha,
+     double const beta,
+     double const threshold);
 
 double bml_add_norm_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+     bml_matrix_ellsort_t * const A,
+     bml_matrix_ellsort_t const * const B,
+     double const alpha,
+     double const beta,
+     double const threshold);
 
 void bml_add_identity_ellsort(
     const bml_matrix_ellsort_t * A,

--- a/src/C-interface/ellsort/bml_add_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_add_ellsort_typed.c
@@ -156,11 +156,11 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold)
 {
     int N = A->N;
     int A_M = A->M;

--- a/src/Fortran-interface/bml_add_m.F90
+++ b/src/Fortran-interface/bml_add_m.F90
@@ -108,10 +108,10 @@ contains
   !! \param threshold \f$ threshold \f$
   function bml_add_norm(a, b, alpha, beta, threshold) result(trnorm)
 
-    real(C_DOUBLE), intent(in) :: alpha
-    class(bml_matrix_t), intent(in) :: a
-    real(C_DOUBLE), intent(in) :: beta
+    class(bml_matrix_t), intent(inout) :: a
     class(bml_matrix_t), intent(in) :: b
+    real(C_DOUBLE), intent(in) :: alpha
+    real(C_DOUBLE), intent(in) :: beta
     real(C_DOUBLE), optional, intent(in) :: threshold
     real(C_DOUBLE) :: trnorm
 


### PR DESCRIPTION
This change adjusts the types in `bml_add_norm` so that the pointer
`A` is `const`, but the value of `A` is mutable, and both the pointer
and the value of `B` is `const`.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/267)
<!-- Reviewable:end -->
