### PR TITLE
Make `emacs` binary configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
         - pip install proselint
         - bundle exec danger
         - packages="indent emacs26" ./install_packages.sh
-        - BML_OPENMP=no VERBOSE_MAKEFILE=yes ./build.sh check_indent
+        - BML_OPENMP=no VERBOSE_MAKEFILE=yes EMACS=emacs26 ./build.sh check_indent
     - stage: docs
       name: "Build Docs"
       env:

--- a/indent.sh
+++ b/indent.sh
@@ -2,7 +2,8 @@
 
 set -x
 
-INDENT_ARGS="-gnu -nut -i4 -bli0 -cli4 -ppi0 -cbi0 -npcs -bfda"
+: ${EMACS:=$(command -v emacs)}
+: ${INDENT_ARGS:="-gnu -nut -i4 -bli0 -cli4 -ppi0 -cbi0 -npcs -bfda"}
 
 declare -a C_FILES
 declare -a FORTRAN_FILES
@@ -43,7 +44,7 @@ for f in "${C_FILES[@]}"; do
 done
 
 for f in "${FORTRAN_FILES[@]}"; do
-  emacs26 --batch \
+  ${EMACS} --batch \
     "${f}" \
     --eval "(describe-variable major-mode)" \
     --eval "(indent-region (minibuffer-prompt-end) (point-max) nil)" \

--- a/src/C-interface/bml_add.h
+++ b/src/C-interface/bml_add.h
@@ -14,7 +14,7 @@ void bml_add(
 
 double bml_add_norm(
     bml_matrix_t * const A,
-    bml_matrix_t const * const B,
+    bml_matrix_t const *const B,
     double const alpha,
     double const beta,
     double const threshold);

--- a/src/C-interface/dense/bml_add_dense.h
+++ b/src/C-interface/dense/bml_add_dense.h
@@ -35,31 +35,31 @@ void bml_add_dense_double_complex(
 
 double bml_add_norm_dense(
     bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const * const B,
+    bml_matrix_dense_t const *const B,
     double const alpha,
     double const beta);
 
 double bml_add_norm_dense_single_real(
     bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const * const B,
+    bml_matrix_dense_t const *const B,
     double const alpha,
     double const beta);
 
 double bml_add_norm_dense_double_real(
     bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const * const B,
+    bml_matrix_dense_t const *const B,
     double const alpha,
     double const beta);
 
 double bml_add_norm_dense_single_complex(
     bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const * const B,
+    bml_matrix_dense_t const *const B,
     double const alpha,
     double const beta);
 
 double bml_add_norm_dense_double_complex(
     bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const * const B,
+    bml_matrix_dense_t const *const B,
     double const alpha,
     double const beta);
 

--- a/src/C-interface/ellblock/bml_add_ellblock.h
+++ b/src/C-interface/ellblock/bml_add_ellblock.h
@@ -40,35 +40,35 @@ void bml_add_ellblock_double_complex(
 
 double bml_add_norm_ellblock(
     bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const * const B,
+    bml_matrix_ellblock_t const *const B,
     double const alpha,
     double const beta,
     double const threshold);
 
 double bml_add_norm_ellblock_single_real(
     bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const * const B,
+    bml_matrix_ellblock_t const *const B,
     double const alpha,
     double const beta,
     double const threshold);
 
 double bml_add_norm_ellblock_double_real(
     bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const * const B,
+    bml_matrix_ellblock_t const *const B,
     double const alpha,
     double const beta,
     double const threshold);
 
 double bml_add_norm_ellblock_single_complex(
     bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const * const B,
+    bml_matrix_ellblock_t const *const B,
     double const alpha,
     double const beta,
     double const threshold);
 
 double bml_add_norm_ellblock_double_complex(
     bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const * const B,
+    bml_matrix_ellblock_t const *const B,
     double const alpha,
     double const beta,
     double const threshold);

--- a/src/C-interface/ellpack/bml_add_ellpack.h
+++ b/src/C-interface/ellpack/bml_add_ellpack.h
@@ -39,39 +39,39 @@ void bml_add_ellpack_double_complex(
     double const threshold);
 
 double bml_add_norm_ellpack(
- bml_matrix_ellpack_t * const A,
- bml_matrix_ellpack_t const * const B,
- double const alpha,
- double const beta,
- double const threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellpack_single_real(
- bml_matrix_ellpack_t * const A,
- bml_matrix_ellpack_t const * const B,
- double const alpha,
- double const beta,
- double const threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellpack_double_real(
- bml_matrix_ellpack_t * const A,
- bml_matrix_ellpack_t const * const B,
- double const alpha,
- double const beta,
- double const threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellpack_single_complex(
- bml_matrix_ellpack_t * const A,
- bml_matrix_ellpack_t const * const B,
- double const alpha,
- double const beta,
- double const threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellpack_double_complex(
- bml_matrix_ellpack_t * const A,
- bml_matrix_ellpack_t const * const B,
- double const alpha,
- double const beta,
- double const threshold);
+    bml_matrix_ellpack_t * const A,
+    bml_matrix_ellpack_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_identity_ellpack(
     const bml_matrix_ellpack_t * A,

--- a/src/C-interface/ellsort/bml_add_ellsort.h
+++ b/src/C-interface/ellsort/bml_add_ellsort.h
@@ -39,39 +39,39 @@ void bml_add_ellsort_double_complex(
     double const threshold);
 
 double bml_add_norm_ellsort(
-     bml_matrix_ellsort_t * const A,
-     bml_matrix_ellsort_t const * const B,
-     double const alpha,
-     double const beta,
-     double const threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellsort_single_real(
-     bml_matrix_ellsort_t * const A,
-     bml_matrix_ellsort_t const * const B,
-     double const alpha,
-     double const beta,
-     double const threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellsort_double_real(
-     bml_matrix_ellsort_t * const A,
-     bml_matrix_ellsort_t const * const B,
-     double const alpha,
-     double const beta,
-     double const threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellsort_single_complex(
-     bml_matrix_ellsort_t * const A,
-     bml_matrix_ellsort_t const * const B,
-     double const alpha,
-     double const beta,
-     double const threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 double bml_add_norm_ellsort_double_complex(
-     bml_matrix_ellsort_t * const A,
-     bml_matrix_ellsort_t const * const B,
-     double const alpha,
-     double const beta,
-     double const threshold);
+    bml_matrix_ellsort_t * const A,
+    bml_matrix_ellsort_t const *const B,
+    double const alpha,
+    double const beta,
+    double const threshold);
 
 void bml_add_identity_ellsort(
     const bml_matrix_ellsort_t * A,


### PR DESCRIPTION
For local testing it can be convenient to be able to set the `emacs`
binary explicitly. This change introduces the environment variable
`EMACS` to specify which `emacs` binary to use.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/270)
<!-- Reviewable:end -->
