### PR TITLE
Fix `const` types in `bml_allocate`

### DIFF
--- a/src/C-interface/bml_allocate.c
+++ b/src/C-interface/bml_allocate.c
@@ -21,12 +21,12 @@
  *
  * \ingroup allocate_group_C
  *
- * \param A Matrix
- * \return >0 if allocated, else -1
+ * \param A[in,out] Matrix
+ * \return \f$ > 0 \f$ if allocated, else -1
  */
 int
 bml_allocated(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     return bml_get_N(A);
 }
@@ -40,7 +40,7 @@ bml_allocated(
  */
 void *
 bml_allocate_memory(
-    const size_t size)
+    size_t size)
 {
     void *ptr = calloc(1, size);
     if (ptr == NULL)
@@ -60,7 +60,7 @@ bml_allocate_memory(
  */
 void *
 bml_noinit_allocate_memory(
-    const size_t size)
+    size_t size)
 {
     void *ptr = malloc(size);
     if (ptr == NULL)
@@ -101,7 +101,7 @@ bml_free_ptr(
  *
  * \ingroup allocate_group_C
  *
- * \param A The matrix.
+ * \param A[in,out] The matrix.
  */
 void
 bml_deallocate(
@@ -144,7 +144,7 @@ bml_deallocate(
  *
  * \ingroup allocate_group_C
  *
- * \param D The domain.
+ * \param D[in,out] The domain.
  */
 void
 bml_deallocate_domain(
@@ -162,7 +162,7 @@ bml_deallocate_domain(
  *
  * \ingroup allocate_group_C
  *
- * \param A The matrix.
+ * \param A[in,out] The matrix.
  */
 void
 bml_clear(
@@ -203,10 +203,10 @@ bml_clear(
  */
 bml_matrix_t *
 bml_noinit_rectangular_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("noinit matrix of size %d (or zero matrix for dense)\n",
               matrix_dimension.N_rows);
@@ -247,12 +247,12 @@ bml_noinit_rectangular_matrix(
  */
 bml_matrix_t *
 bml_block_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("block matrix with %d blocks\n", NB);
     switch (matrix_type)
@@ -288,11 +288,11 @@ bml_block_matrix(
  */
 bml_matrix_t *
 bml_noinit_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dimension_t matrix_dimension = { N, N, M };
     return bml_noinit_rectangular_matrix(matrix_type, matrix_precision,
@@ -315,11 +315,11 @@ bml_noinit_matrix(
  */
 bml_matrix_t *
 bml_zero_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("zero matrix of size %d\n", N);
     bml_matrix_dimension_t matrix_dimension = { N, N, M };
@@ -364,11 +364,11 @@ bml_zero_matrix(
  */
 bml_matrix_t *
 bml_random_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("random matrix of size %d\n", N);
     switch (matrix_type)
@@ -411,11 +411,11 @@ bml_random_matrix(
  */
 bml_matrix_t *
 bml_banded_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("banded matrix of size %d\n", N);
     switch (matrix_type)
@@ -455,11 +455,11 @@ bml_banded_matrix(
  */
 bml_matrix_t *
 bml_identity_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("identity matrix of size %d\n", N);
     switch (matrix_type)
@@ -498,9 +498,9 @@ bml_identity_matrix(
  */
 bml_domain_t *
 bml_default_domain(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     int avgExtent, nleft;
     int nRanks = bml_getNRanks();

--- a/src/C-interface/bml_allocate.h
+++ b/src/C-interface/bml_allocate.h
@@ -8,13 +8,13 @@
 #include <stdlib.h>
 
 int bml_allocated(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 void *bml_allocate_memory(
-    const size_t s);
+    size_t s);
 
 void *bml_noinit_allocate_memory(
-    const size_t s);
+    size_t s);
 
 void bml_free_memory(
     void *ptr);
@@ -32,50 +32,50 @@ void bml_clear(
     bml_matrix_t * A);
 
 bml_matrix_t *bml_noinit_rectangular_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_t *bml_noinit_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_t *bml_zero_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_t *bml_random_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_t *bml_banded_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_t *bml_identity_matrix(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_domain_t *bml_default_domain(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 void bml_update_domain(
     bml_matrix_t * A,

--- a/src/C-interface/dense/bml_allocate_dense.c
+++ b/src/C-interface/dense/bml_allocate_dense.c
@@ -121,10 +121,10 @@ bml_zero_matrix_dense(
  */
 bml_matrix_dense_t *
 bml_banded_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -163,9 +163,9 @@ bml_banded_matrix_dense(
  */
 bml_matrix_dense_t *
 bml_random_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -204,9 +204,9 @@ bml_random_matrix_dense(
  */
 bml_matrix_dense_t *
 bml_identity_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/dense/bml_allocate_dense.h
+++ b/src/C-interface/dense/bml_allocate_dense.h
@@ -22,93 +22,93 @@ void bml_clear_dense_double_complex(
     bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_zero_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_zero_matrix_dense_single_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_zero_matrix_dense_double_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_zero_matrix_dense_single_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_zero_matrix_dense_double_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_banded_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_banded_matrix_dense_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_banded_matrix_dense_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_banded_matrix_dense_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_banded_matrix_dense_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_random_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_random_matrix_dense_single_real(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_random_matrix_dense_double_real(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_random_matrix_dense_single_complex(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_random_matrix_dense_double_complex(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_identity_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_identity_matrix_dense_single_real(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_identity_matrix_dense_double_real(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_identity_matrix_dense_single_complex(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_identity_matrix_dense_double_complex(
-    const int N,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    bml_distribution_mode_t distrib_mode);
 
 void bml_update_domain_dense(
     bml_matrix_dense_t * A,

--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -55,7 +55,7 @@ void TYPED_FUNC(
 bml_matrix_dense_t *TYPED_FUNC(
     bml_zero_matrix_dense) (
     const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dense_t *A = NULL;
 
@@ -105,9 +105,9 @@ bml_matrix_dense_t *TYPED_FUNC(
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_banded_matrix_dense) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dimension_t matrix_dimension = { N, N, M };
     bml_matrix_dense_t *A =
@@ -142,8 +142,8 @@ bml_matrix_dense_t *TYPED_FUNC(
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_random_matrix_dense) (
-    const int N,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dimension_t matrix_dimension = { N, N, N };
     bml_matrix_dense_t *A =
@@ -188,8 +188,8 @@ bml_matrix_dense_t *TYPED_FUNC(
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_identity_matrix_dense) (
-    const int N,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dimension_t matrix_dimension = { N, N, N };
     bml_matrix_dense_t *A =

--- a/src/C-interface/ellblock/bml_allocate_ellblock.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock.c
@@ -23,7 +23,7 @@ static int s_mb = 0;
  *    */
 void
 bml_set_block_sizes(
-    const int *bsize,
+    int *bsize,
     int nb,
     int mb)
 {
@@ -47,8 +47,8 @@ bml_set_block_sizes(
 
 int *
 bml_get_block_sizes(
-    const int N,
-    const int M)
+    int N,
+    int M)
 {
     if (s_default_bsize == NULL)
     {
@@ -159,9 +159,9 @@ bml_clear_ellblock(
 
 bml_matrix_ellblock_t *
 bml_noinit_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellblock_t *A = NULL;
 
@@ -207,10 +207,10 @@ bml_noinit_matrix_ellblock(
  */
 bml_matrix_ellblock_t *
 bml_zero_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellblock_t *A = NULL;
 
@@ -237,11 +237,11 @@ bml_zero_matrix_ellblock(
 
 bml_matrix_ellblock_t *
 bml_block_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellblock_t *A = NULL;
 
@@ -287,10 +287,10 @@ bml_block_matrix_ellblock(
  */
 bml_matrix_ellblock_t *
 bml_random_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -332,10 +332,10 @@ bml_random_matrix_ellblock(
  */
 bml_matrix_ellblock_t *
 bml_identity_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_allocate_ellblock.h
+++ b/src/C-interface/ellblock/bml_allocate_ellblock.h
@@ -22,134 +22,134 @@ void bml_clear_ellblock_double_complex(
     bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_noinit_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_single_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_double_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_single_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_noinit_matrix_ellblock_double_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_zero_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_zero_matrix_ellblock_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_zero_matrix_ellblock_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_zero_matrix_ellblock_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_zero_matrix_ellblock_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_random_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_random_matrix_ellblock_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_random_matrix_ellblock_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_random_matrix_ellblock_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_random_matrix_ellblock_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_identity_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_identity_matrix_ellblock_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_identity_matrix_ellblock_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_identity_matrix_ellblock_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_identity_matrix_ellblock_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_block_matrix_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_block_matrix_ellblock_single_real(
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode);
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_block_matrix_ellblock_double_real(
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode);
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_block_matrix_ellblock_single_complex(
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode);
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_block_matrix_ellblock_double_complex(
-    const int NB,
-    const int MB,
-    const int *bsizes,
-    const bml_distribution_mode_t distrib_mode);
+    int NB,
+    int MB,
+    int *bsizes,
+    bml_distribution_mode_t distrib_mode);
 
 void bml_update_domain_ellblock(
     bml_matrix_ellblock_t * A,
@@ -158,12 +158,12 @@ void bml_update_domain_ellblock(
     int *nnodesInPart);
 
 void bml_set_block_sizes(
-    const int *bsize,
+    int *bsize,
     int NB,
     int MB);
 int *bml_get_block_sizes(
-    const int N,
-    const int M);
+    int N,
+    int M);
 int bml_get_mb(
     );
 int bml_get_nb(

--- a/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
@@ -42,8 +42,8 @@ void TYPED_FUNC(
 
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_noinit_matrix_ellblock) (
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     int N = matrix_dimension.N_rows;
 
@@ -69,10 +69,10 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_block_matrix_ellblock) (
-    const int NB,
-    const int MB,
-    const int *bsize,
-    const bml_distribution_mode_t distrib_mode)
+    int NB,
+    int MB,
+    int *bsize,
+    bml_distribution_mode_t distrib_mode)
 {
     assert(NB > 0);
     assert(MB > 0);
@@ -106,9 +106,9 @@ bml_matrix_ellblock_t *TYPED_FUNC(
 
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_zero_matrix_ellblock) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     //use default block values that could have been reset by user
     int *bsize = bml_get_block_sizes(N, M);
@@ -141,9 +141,9 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_random_matrix_ellblock) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     //create matrix
     int *bsize = bml_get_block_sizes(N, M);
@@ -205,9 +205,9 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_identity_matrix_ellblock) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     int *bsize = bml_get_block_sizes(N, M);
     int mb = bml_get_mb();

--- a/src/C-interface/ellpack/bml_allocate_ellpack.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack.c
@@ -71,9 +71,9 @@ bml_clear_ellpack(
  */
 bml_matrix_ellpack_t *
 bml_noinit_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A = NULL;
 
@@ -119,10 +119,10 @@ bml_noinit_matrix_ellpack(
  */
 bml_matrix_ellpack_t *
 bml_zero_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A = NULL;
 
@@ -164,10 +164,10 @@ bml_zero_matrix_ellpack(
  */
 bml_matrix_ellpack_t *
 bml_banded_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -209,10 +209,10 @@ bml_banded_matrix_ellpack(
  */
 bml_matrix_ellpack_t *
 bml_random_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -254,10 +254,10 @@ bml_random_matrix_ellpack(
  */
 bml_matrix_ellpack_t *
 bml_identity_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_allocate_ellpack.h
+++ b/src/C-interface/ellpack/bml_allocate_ellpack.h
@@ -22,129 +22,129 @@ void bml_clear_ellpack_double_complex(
     bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_noinit_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_noinit_matrix_ellpack_single_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_noinit_matrix_ellpack_double_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_noinit_matrix_ellpack_single_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_noinit_matrix_ellpack_double_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_zero_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_zero_matrix_ellpack_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_zero_matrix_ellpack_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_zero_matrix_ellpack_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_zero_matrix_ellpack_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_banded_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_banded_matrix_ellpack_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_banded_matrix_ellpack_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_banded_matrix_ellpack_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_banded_matrix_ellpack_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_random_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_random_matrix_ellpack_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_random_matrix_ellpack_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_random_matrix_ellpack_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_random_matrix_ellpack_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_identity_matrix_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_identity_matrix_ellpack_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_identity_matrix_ellpack_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_identity_matrix_ellpack_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_identity_matrix_ellpack_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 void bml_update_domain_ellpack(
     bml_matrix_ellpack_t * A,

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -47,8 +47,8 @@ void TYPED_FUNC(
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_noinit_matrix_ellpack) (
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A =
         bml_noinit_allocate_memory(sizeof(bml_matrix_ellpack_t));
@@ -83,9 +83,9 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_zero_matrix_ellpack) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A =
         bml_allocate_memory(sizeof(bml_matrix_ellpack_t));
@@ -120,9 +120,9 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_banded_matrix_ellpack) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A =
         TYPED_FUNC(bml_zero_matrix_ellpack) (N, M, distrib_mode);
@@ -167,9 +167,9 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_random_matrix_ellpack) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A =
         TYPED_FUNC(bml_zero_matrix_ellpack) (N, M, distrib_mode);
@@ -209,9 +209,9 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_identity_matrix_ellpack) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A =
         TYPED_FUNC(bml_zero_matrix_ellpack) (N, M, distrib_mode);

--- a/src/C-interface/ellsort/bml_allocate_ellsort.c
+++ b/src/C-interface/ellsort/bml_allocate_ellsort.c
@@ -71,9 +71,9 @@ bml_clear_ellsort(
  */
 bml_matrix_ellsort_t *
 bml_noinit_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A = NULL;
 
@@ -119,10 +119,10 @@ bml_noinit_matrix_ellsort(
  */
 bml_matrix_ellsort_t *
 bml_zero_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A = NULL;
 
@@ -164,10 +164,10 @@ bml_zero_matrix_ellsort(
  */
 bml_matrix_ellsort_t *
 bml_banded_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -209,10 +209,10 @@ bml_banded_matrix_ellsort(
  */
 bml_matrix_ellsort_t *
 bml_random_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {
@@ -254,10 +254,10 @@ bml_random_matrix_ellsort(
  */
 bml_matrix_ellsort_t *
 bml_identity_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_allocate_ellsort.h
+++ b/src/C-interface/ellsort/bml_allocate_ellsort.h
@@ -22,129 +22,129 @@ void bml_clear_ellsort_double_complex(
     bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_noinit_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_noinit_matrix_ellsort_single_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_noinit_matrix_ellsort_double_real(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_noinit_matrix_ellsort_single_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_noinit_matrix_ellsort_double_complex(
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_zero_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_zero_matrix_ellsort_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_zero_matrix_ellsort_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_zero_matrix_ellsort_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_zero_matrix_ellsort_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_banded_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_banded_matrix_ellsort_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_banded_matrix_ellsort_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_banded_matrix_ellsort_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_banded_matrix_ellsort_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_random_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_random_matrix_ellsort_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_random_matrix_ellsort_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_random_matrix_ellsort_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_random_matrix_ellsort_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_identity_matrix_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_identity_matrix_ellsort_single_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_identity_matrix_ellsort_double_real(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_identity_matrix_ellsort_single_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_identity_matrix_ellsort_double_complex(
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 void bml_update_domain_ellsort(
     bml_matrix_ellsort_t * A,

--- a/src/C-interface/ellsort/bml_allocate_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_allocate_ellsort_typed.c
@@ -47,8 +47,8 @@ void TYPED_FUNC(
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_noinit_matrix_ellsort) (
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A =
         bml_noinit_allocate_memory(sizeof(bml_matrix_ellsort_t));
@@ -83,9 +83,9 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_zero_matrix_ellsort) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A =
         bml_allocate_memory(sizeof(bml_matrix_ellsort_t));
@@ -120,9 +120,9 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_banded_matrix_ellsort) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A =
         TYPED_FUNC(bml_zero_matrix_ellsort) (N, M, distrib_mode);
@@ -167,9 +167,9 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_random_matrix_ellsort) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A =
         TYPED_FUNC(bml_zero_matrix_ellsort) (N, M, distrib_mode);
@@ -209,9 +209,9 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_identity_matrix_ellsort) (
-    const int N,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    int N,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A =
         TYPED_FUNC(bml_zero_matrix_ellsort) (N, M, distrib_mode);


### PR DESCRIPTION
This change adjusts the types in `bml_allocate` so that the const type
modifier applies to the correct part of the type.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/276)
<!-- Reviewable:end -->
