### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_add.c
+++ b/src/C-interface/bml_add.c
@@ -22,11 +22,11 @@
  */
 void
 bml_add(
-    bml_matrix_t * const A,
-    bml_matrix_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -63,11 +63,11 @@ bml_add(
  */
 double
 bml_add_norm(
-    bml_matrix_t * const A,
-    bml_matrix_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
 
     switch (bml_get_type(A))
@@ -103,9 +103,9 @@ bml_add_norm(
  */
 void
 bml_add_identity(
-    bml_matrix_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_t * A,
+    double beta,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -140,10 +140,10 @@ bml_add_identity(
  */
 void
 bml_scale_add_identity(
-    bml_matrix_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_add.h
+++ b/src/C-interface/bml_add.h
@@ -6,28 +6,28 @@
 #include "bml_types.h"
 
 void bml_add(
-    bml_matrix_t * const A,
-    bml_matrix_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm(
-    bml_matrix_t * const A,
-    bml_matrix_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_identity(
-    bml_matrix_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_t * A,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity(
-    bml_matrix_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_add_dense.c
+++ b/src/C-interface/dense/bml_add_dense.c
@@ -20,10 +20,10 @@
  */
 void
 bml_add_dense(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta)
 {
     switch (A->matrix_precision)
     {
@@ -58,10 +58,10 @@ bml_add_dense(
  */
 double
 bml_add_norm_dense(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta)
 {
     double trnorm = 0.0;
 
@@ -97,8 +97,8 @@ bml_add_norm_dense(
  */
 void
 bml_add_identity_dense(
-    bml_matrix_dense_t * const A,
-    const double beta)
+    bml_matrix_dense_t * A,
+    double beta)
 {
     switch (A->matrix_precision)
     {
@@ -132,9 +132,9 @@ bml_add_identity_dense(
  */
 void
 bml_scale_add_identity_dense(
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta)
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_add_dense.h
+++ b/src/C-interface/dense/bml_add_dense.h
@@ -4,108 +4,108 @@
 #include "bml_types_dense.h"
 
 void bml_add_dense(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 void bml_add_dense_single_real(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 void bml_add_dense_double_real(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 void bml_add_dense_single_complex(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 void bml_add_dense_double_complex(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 double bml_add_norm_dense(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 double bml_add_norm_dense_single_real(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 double bml_add_norm_dense_double_real(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 double bml_add_norm_dense_single_complex(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 double bml_add_norm_dense_double_complex(
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta);
 
 void bml_add_identity_dense(
-    bml_matrix_dense_t * const A,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double beta);
 
 void bml_add_identity_dense_single_real(
-    bml_matrix_dense_t * const A,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double beta);
 
 void bml_add_identity_dense_double_real(
-    bml_matrix_dense_t * const A,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double beta);
 
 void bml_add_identity_dense_single_complex(
-    bml_matrix_dense_t * const A,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double beta);
 
 void bml_add_identity_dense_double_complex(
-    bml_matrix_dense_t * const A,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double beta);
 
 void bml_scale_add_identity_dense(
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta);
 
 void bml_scale_add_identity_dense_single_real(
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta);
 
 void bml_scale_add_identity_dense_double_real(
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta);
 
 void bml_scale_add_identity_dense_single_complex(
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta);
 
 void bml_scale_add_identity_dense_double_complex(
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta);
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta);
 
 #endif

--- a/src/C-interface/dense/bml_add_dense_typed.c
+++ b/src/C-interface/dense/bml_add_dense_typed.c
@@ -39,10 +39,10 @@
  */
 void TYPED_FUNC(
     bml_add_dense) (
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta)
 {
     int myRank = bml_getMyRank();
 
@@ -85,10 +85,10 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_dense) (
-    bml_matrix_dense_t * const A,
-    bml_matrix_dense_t const *const B,
-    double const alpha,
-    double const beta)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta)
 {
     double trnorm = 0.0;
     REAL_T *B_matrix = (REAL_T *) B->matrix;
@@ -125,8 +125,8 @@ double TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_add_identity_dense) (
-    bml_matrix_dense_t * const A,
-    const double beta)
+    bml_matrix_dense_t * A,
+    double beta)
 {
     int N = A->N;
 #if BML_USE_MAGMA
@@ -167,9 +167,9 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_add_identity_dense) (
-    bml_matrix_dense_t * const A,
-    const double alpha,
-    const double beta)
+    bml_matrix_dense_t * A,
+    double alpha,
+    double beta)
 {
     REAL_T _alpha = (REAL_T) alpha;
 

--- a/src/C-interface/ellblock/bml_add_ellblock.c
+++ b/src/C-interface/ellblock/bml_add_ellblock.c
@@ -21,11 +21,11 @@
  */
 void
 bml_add_ellblock(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (B->matrix_precision)
     {
@@ -61,11 +61,11 @@ bml_add_ellblock(
  */
 double
 bml_add_norm_ellblock(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     double trnorm = 0.0;
 
@@ -110,9 +110,9 @@ bml_add_norm_ellblock(
  */
 void
 bml_add_identity_ellblock(
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -146,10 +146,10 @@ bml_add_identity_ellblock(
  */
 void
 bml_scale_add_identity_ellblock(
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_add_ellblock.h
+++ b/src/C-interface/ellblock/bml_add_ellblock.h
@@ -4,128 +4,128 @@
 #include "bml_types_ellblock.h"
 
 void bml_add_ellblock(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellblock_single_real(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellblock_double_real(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellblock_single_complex(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellblock_double_complex(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellblock(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellblock_single_real(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellblock_double_real(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellblock_single_complex(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellblock_double_complex(
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellblock(
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellblock_single_real(
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellblock_double_real(
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellblock_single_complex(
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellblock_double_complex(
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellblock(
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellblock_single_real(
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellblock_double_real(
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellblock_single_complex(
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellblock_double_complex(
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellblock/bml_add_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_add_ellblock_typed.c
@@ -33,11 +33,11 @@
  */
 void TYPED_FUNC(
     bml_add_ellblock) (
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     assert(A->NB == B->NB);
     assert(A->bsize[0] == B->bsize[0]);
@@ -169,11 +169,11 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_ellblock) (
-    bml_matrix_ellblock_t * const A,
-    bml_matrix_ellblock_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int NB = A->NB;
     int MB = A->MB;
@@ -312,9 +312,9 @@ double TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_add_identity_ellblock) (
-    bml_matrix_ellblock_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double beta,
+    double threshold)
 {
     REAL_T alpha = (REAL_T) 1.0;
 
@@ -340,10 +340,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_add_identity_ellblock) (
-    bml_matrix_ellblock_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     bml_matrix_ellblock_t *Id =
         TYPED_FUNC(bml_identity_matrix_ellblock) (A->N, A->M,

--- a/src/C-interface/ellpack/bml_add_ellpack.c
+++ b/src/C-interface/ellpack/bml_add_ellpack.c
@@ -21,11 +21,11 @@
  */
 void
 bml_add_ellpack(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (B->matrix_precision)
     {
@@ -61,11 +61,11 @@ bml_add_ellpack(
  */
 double
 bml_add_norm_ellpack(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     double trnorm = 0.0;
 
@@ -110,9 +110,9 @@ bml_add_norm_ellpack(
  */
 void
 bml_add_identity_ellpack(
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -146,10 +146,10 @@ bml_add_identity_ellpack(
  */
 void
 bml_scale_add_identity_ellpack(
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_add_ellpack.h
+++ b/src/C-interface/ellpack/bml_add_ellpack.h
@@ -4,128 +4,128 @@
 #include "bml_types_ellpack.h"
 
 void bml_add_ellpack(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellpack_single_real(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellpack_double_real(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellpack_single_complex(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellpack_double_complex(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellpack(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellpack_single_real(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellpack_double_real(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellpack_single_complex(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellpack_double_complex(
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellpack(
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellpack_single_real(
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellpack_double_real(
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellpack_single_complex(
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellpack_double_complex(
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellpack(
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellpack_single_real(
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellpack_double_real(
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellpack_single_complex(
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellpack_double_complex(
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_add_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_add_ellpack_typed.c
@@ -31,11 +31,11 @@
  */
 void TYPED_FUNC(
     bml_add_ellpack) (
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int N = A->N;
     int A_M = A->M;
@@ -151,11 +151,11 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_ellpack) (
-    bml_matrix_ellpack_t * const A,
-    bml_matrix_ellpack_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int N = A->N;
     int A_M = A->M;
@@ -287,9 +287,9 @@ double TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_add_identity_ellpack) (
-    bml_matrix_ellpack_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double beta,
+    double threshold)
 {
     REAL_T alpha = (REAL_T) 1.0;
 
@@ -315,10 +315,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_add_identity_ellpack) (
-    bml_matrix_ellpack_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     bml_matrix_ellpack_t *Id =
         TYPED_FUNC(bml_identity_matrix_ellpack) (A->N, A->M,

--- a/src/C-interface/ellsort/bml_add_ellsort.c
+++ b/src/C-interface/ellsort/bml_add_ellsort.c
@@ -21,11 +21,11 @@
  */
 void
 bml_add_ellsort(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (B->matrix_precision)
     {
@@ -61,11 +61,11 @@ bml_add_ellsort(
  */
 double
 bml_add_norm_ellsort(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     double trnorm = 0.0;
 
@@ -110,9 +110,9 @@ bml_add_norm_ellsort(
  */
 void
 bml_add_identity_ellsort(
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -146,10 +146,10 @@ bml_add_identity_ellsort(
  */
 void
 bml_scale_add_identity_ellsort(
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_add_ellsort.h
+++ b/src/C-interface/ellsort/bml_add_ellsort.h
@@ -4,128 +4,128 @@
 #include "bml_types_ellsort.h"
 
 void bml_add_ellsort(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellsort_single_real(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellsort_double_real(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellsort_single_complex(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_ellsort_double_complex(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellsort(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellsort_single_real(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellsort_double_real(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellsort_single_complex(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_add_norm_ellsort_double_complex(
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellsort(
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellsort_single_real(
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellsort_double_real(
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellsort_single_complex(
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold);
 
 void bml_add_identity_ellsort_double_complex(
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellsort(
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellsort_single_real(
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellsort_double_real(
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellsort_single_complex(
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_scale_add_identity_ellsort_double_complex(
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellsort/bml_add_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_add_ellsort_typed.c
@@ -31,11 +31,11 @@
  */
 void TYPED_FUNC(
     bml_add_ellsort) (
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int N = A->N;
     int A_M = A->M;
@@ -154,11 +154,11 @@ void TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_add_norm_ellsort) (
-    bml_matrix_ellsort_t * const A,
-    bml_matrix_ellsort_t const *const B,
-    double const alpha,
-    double const beta,
-    double const threshold)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int N = A->N;
     int A_M = A->M;
@@ -289,9 +289,9 @@ double TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_add_identity_ellsort) (
-    bml_matrix_ellsort_t * const A,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double beta,
+    double threshold)
 {
     REAL_T alpha = (REAL_T) 1.0;
 
@@ -317,10 +317,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_add_identity_ellsort) (
-    bml_matrix_ellsort_t * const A,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double alpha,
+    double beta,
+    double threshold)
 {
     bml_matrix_ellsort_t *Id =
         TYPED_FUNC(bml_identity_matrix_ellsort) (A->N, A->M,


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_add` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/279)
<!-- Reviewable:end -->
