### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_convert.c
+++ b/src/C-interface/bml_convert.c
@@ -16,11 +16,11 @@
  */
 bml_matrix_t *
 bml_convert(
-    const bml_matrix_t * A,
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_type)
     {

--- a/src/C-interface/bml_convert.h
+++ b/src/C-interface/bml_convert.h
@@ -6,10 +6,10 @@
 #include "bml_types.h"
 
 bml_matrix_t *bml_convert(
-    const bml_matrix_t * A,
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/dense/bml_convert_dense.c
+++ b/src/C-interface/dense/bml_convert_dense.c
@@ -5,9 +5,9 @@
 
 bml_matrix_dense_t *
 bml_convert_dense(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/dense/bml_convert_dense.h
+++ b/src/C-interface/dense/bml_convert_dense.h
@@ -6,28 +6,28 @@
 #include "bml_types_dense.h"
 
 bml_matrix_dense_t *bml_convert_dense(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_convert_dense_single_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_convert_dense_double_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_convert_dense_single_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_convert_dense_double_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/dense/bml_convert_dense_typed.c
+++ b/src/C-interface/dense/bml_convert_dense_typed.c
@@ -14,9 +14,9 @@
 
 bml_matrix_dense_t *TYPED_FUNC(
     bml_convert_dense) (
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    bml_distribution_mode_t distrib_mode)
 {
     int N = bml_get_N(A);
 

--- a/src/C-interface/ellblock/bml_convert_ellblock.c
+++ b/src/C-interface/ellblock/bml_convert_ellblock.c
@@ -5,10 +5,10 @@
 
 bml_matrix_ellblock_t *
 bml_convert_ellblock(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_convert_ellblock.h
+++ b/src/C-interface/ellblock/bml_convert_ellblock.h
@@ -6,33 +6,33 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_ellblock_t *bml_convert_ellblock(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_convert_ellblock_single_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_convert_ellblock_double_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_convert_ellblock_single_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_convert_ellblock_double_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/ellblock/bml_convert_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_convert_ellblock_typed.c
@@ -15,10 +15,10 @@
 
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_convert_ellblock) (
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     int N = bml_get_N(A);
 

--- a/src/C-interface/ellpack/bml_convert_ellpack.c
+++ b/src/C-interface/ellpack/bml_convert_ellpack.c
@@ -5,10 +5,10 @@
 
 bml_matrix_ellpack_t *
 bml_convert_ellpack(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_convert_ellpack.h
+++ b/src/C-interface/ellpack/bml_convert_ellpack.h
@@ -6,33 +6,33 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_ellpack_t *bml_convert_ellpack(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_convert_ellpack_single_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_convert_ellpack_double_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_convert_ellpack_single_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_convert_ellpack_double_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/ellpack/bml_convert_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_convert_ellpack_typed.c
@@ -11,10 +11,10 @@
 
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_convert_ellpack) (
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     int N = bml_get_N(A);
 

--- a/src/C-interface/ellsort/bml_convert_ellsort.c
+++ b/src/C-interface/ellsort/bml_convert_ellsort.c
@@ -5,10 +5,10 @@
 
 bml_matrix_ellsort_t *
 bml_convert_ellsort(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_convert_ellsort.h
+++ b/src/C-interface/ellsort/bml_convert_ellsort.h
@@ -6,33 +6,33 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_ellsort_t *bml_convert_ellsort(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_convert_ellsort_single_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_convert_ellsort_double_real(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_convert_ellsort_single_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_convert_ellsort_double_complex(
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/ellsort/bml_convert_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_convert_ellsort_typed.c
@@ -11,10 +11,10 @@
 
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_convert_ellsort) (
-    const bml_matrix_t * A,
-    const bml_matrix_precision_t matrix_precision,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_t * A,
+    bml_matrix_precision_t matrix_precision,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     int N = bml_get_N(A);
 


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_convert` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/280)
<!-- Reviewable:end -->
