### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/dense/bml_allocate_dense.c
+++ b/src/C-interface/dense/bml_allocate_dense.c
@@ -75,9 +75,9 @@ bml_clear_dense(
  */
 bml_matrix_dense_t *
 bml_zero_matrix_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_matrix_dimension_t matrix_dimension,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_matrix_dimension_t matrix_dimension,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -54,7 +54,7 @@ void TYPED_FUNC(
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_zero_matrix_dense) (
-    const bml_matrix_dimension_t matrix_dimension,
+    bml_matrix_dimension_t matrix_dimension,
     bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dense_t *A = NULL;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_allocate` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/281)
<!-- Reviewable:end -->
