### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_copy.c
+++ b/src/C-interface/bml_copy.c
@@ -21,7 +21,7 @@
  */
 bml_matrix_t *
 bml_copy_new(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     bml_matrix_t *B = NULL;
 
@@ -53,7 +53,7 @@ bml_copy_new(
  */
 void
 bml_copy(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     bml_matrix_t * B)
 {
     assert(A != NULL);
@@ -134,7 +134,7 @@ bml_reorder(
  */
 void
 bml_copy_domain(
-    const bml_domain_t * A,
+    bml_domain_t * A,
     bml_domain_t * B)
 {
     int nRanks = bml_getNRanks();

--- a/src/C-interface/bml_copy.h
+++ b/src/C-interface/bml_copy.h
@@ -6,10 +6,10 @@
 #include "bml_types.h"
 
 bml_matrix_t *bml_copy_new(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 void bml_copy(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     bml_matrix_t * B);
 
 void bml_reorder(
@@ -17,7 +17,7 @@ void bml_reorder(
     int *perm);
 
 void bml_copy_domain(
-    const bml_domain_t * A,
+    bml_domain_t * A,
     bml_domain_t * B);
 
 void bml_save_domain(

--- a/src/C-interface/dense/bml_copy_dense.c
+++ b/src/C-interface/dense/bml_copy_dense.c
@@ -19,7 +19,7 @@
  */
 bml_matrix_dense_t *
 bml_copy_dense_new(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     bml_matrix_dense_t *B = NULL;
     assert(A != NULL);
@@ -53,7 +53,7 @@ bml_copy_dense_new(
  */
 void
 bml_copy_dense(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B)
 {
     assert(A != NULL);

--- a/src/C-interface/dense/bml_copy_dense.h
+++ b/src/C-interface/dense/bml_copy_dense.h
@@ -4,38 +4,38 @@
 #include "bml_types_dense.h"
 
 bml_matrix_dense_t *bml_copy_dense_new(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_copy_dense_new_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_copy_dense_new_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_copy_dense_new_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_copy_dense_new_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void bml_copy_dense(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_copy_dense_single_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_copy_dense_double_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_copy_dense_single_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_copy_dense_double_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_reorder_dense(

--- a/src/C-interface/dense/bml_copy_dense_typed.c
+++ b/src/C-interface/dense/bml_copy_dense_typed.c
@@ -25,7 +25,7 @@
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_copy_dense_new) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     bml_matrix_dimension_t matrix_dimension = { A->N, A->N, A->N };
     bml_matrix_dense_t *B =
@@ -51,7 +51,7 @@ bml_matrix_dense_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_copy_dense) (
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B)
 {
 #ifdef BML_USE_MAGMA

--- a/src/C-interface/ellblock/bml_copy_ellblock.c
+++ b/src/C-interface/ellblock/bml_copy_ellblock.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_ellblock_t *
 bml_copy_ellblock_new(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     bml_matrix_ellblock_t *B = NULL;
 
@@ -52,8 +52,8 @@ bml_copy_ellblock_new(
  */
 void
 bml_copy_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellblock/bml_copy_ellblock.h
+++ b/src/C-interface/ellblock/bml_copy_ellblock.h
@@ -4,39 +4,39 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_ellblock_t *bml_copy_ellblock_new(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_copy_ellblock_new_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_copy_ellblock_new_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_copy_ellblock_new_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_copy_ellblock_new_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void bml_copy_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_copy_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_copy_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_copy_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_copy_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_reorder_ellblock(
     bml_matrix_ellblock_t * A,

--- a/src/C-interface/ellblock/bml_copy_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_copy_ellblock_typed.c
@@ -21,7 +21,7 @@
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_copy_ellblock_new) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     bml_matrix_ellblock_t *B =
         TYPED_FUNC(bml_block_matrix_ellblock) (A->NB, A->MB, A->bsize,
@@ -69,8 +69,8 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_copy_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
     assert(A->NB == B->NB);
 

--- a/src/C-interface/ellpack/bml_copy_ellpack.c
+++ b/src/C-interface/ellpack/bml_copy_ellpack.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_ellpack_t *
 bml_copy_ellpack_new(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     bml_matrix_ellpack_t *B = NULL;
 
@@ -52,8 +52,8 @@ bml_copy_ellpack_new(
  */
 void
 bml_copy_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellpack/bml_copy_ellpack.h
+++ b/src/C-interface/ellpack/bml_copy_ellpack.h
@@ -4,39 +4,39 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_ellpack_t *bml_copy_ellpack_new(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_copy_ellpack_new_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_copy_ellpack_new_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_copy_ellpack_new_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_copy_ellpack_new_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void bml_copy_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_copy_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_copy_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_copy_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_copy_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_reorder_ellpack(
     bml_matrix_ellpack_t * A,

--- a/src/C-interface/ellpack/bml_copy_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_copy_ellpack_typed.c
@@ -20,7 +20,7 @@
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_copy_ellpack_new) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     bml_matrix_dimension_t matrix_dimension = { A->N, A->N, A->M };
     bml_matrix_ellpack_t *B =
@@ -64,8 +64,8 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_copy_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
     int N = A->N;
     int M = A->M;

--- a/src/C-interface/ellsort/bml_copy_ellsort.c
+++ b/src/C-interface/ellsort/bml_copy_ellsort.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_ellsort_t *
 bml_copy_ellsort_new(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     bml_matrix_ellsort_t *B = NULL;
 
@@ -52,8 +52,8 @@ bml_copy_ellsort_new(
  */
 void
 bml_copy_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellsort/bml_copy_ellsort.h
+++ b/src/C-interface/ellsort/bml_copy_ellsort.h
@@ -4,39 +4,39 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_ellsort_t *bml_copy_ellsort_new(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_copy_ellsort_new_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_copy_ellsort_new_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_copy_ellsort_new_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_copy_ellsort_new_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void bml_copy_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_copy_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_copy_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_copy_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_copy_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_reorder_ellsort(
     bml_matrix_ellsort_t * A,

--- a/src/C-interface/ellsort/bml_copy_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_copy_ellsort_typed.c
@@ -20,7 +20,7 @@
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_copy_ellsort_new) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     bml_matrix_dimension_t matrix_dimension = { A->N, A->N, A->M };
     bml_matrix_ellsort_t *B =
@@ -61,8 +61,8 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_copy_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
     int N = A->N;
     int M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_copy` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/282)
<!-- Reviewable:end -->
