### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_diagonalize.c
+++ b/src/C-interface/bml_diagonalize.c
@@ -9,7 +9,7 @@
 
 void
 bml_diagonalize(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors)
 {

--- a/src/C-interface/bml_diagonalize.h
+++ b/src/C-interface/bml_diagonalize.h
@@ -4,7 +4,7 @@
 #include "bml_types.h"
 
 void bml_diagonalize(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors);
 

--- a/src/C-interface/dense/bml_diagonalize_dense.c
+++ b/src/C-interface/dense/bml_diagonalize_dense.c
@@ -25,7 +25,7 @@
 
 void
 bml_diagonalize_dense_single_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors)
 {
@@ -114,7 +114,7 @@ bml_diagonalize_dense_single_real(
 
 void
 bml_diagonalize_dense_double_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors)
 {
@@ -199,7 +199,7 @@ bml_diagonalize_dense_double_real(
 
 void
 bml_diagonalize_dense_single_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors)
 {
@@ -291,7 +291,7 @@ bml_diagonalize_dense_single_complex(
 
 void
 bml_diagonalize_dense_double_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors)
 {
@@ -382,7 +382,7 @@ bml_diagonalize_dense_double_complex(
 
 void
 bml_diagonalize_dense(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors)
 {

--- a/src/C-interface/dense/bml_diagonalize_dense.h
+++ b/src/C-interface/dense/bml_diagonalize_dense.h
@@ -4,27 +4,27 @@
 #include "bml_types_dense.h"
 
 void bml_diagonalize_dense(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors);
 
 void bml_diagonalize_dense_single_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors);
 
 void bml_diagonalize_dense_double_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors);
 
 void bml_diagonalize_dense_single_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors);
 
 void bml_diagonalize_dense_double_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     void *eigenvalues,
     bml_matrix_dense_t * eigenvectors);
 

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock.c
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock.c
@@ -13,7 +13,7 @@
 
 void
 bml_diagonalize_ellblock(
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors)
 {

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock.h
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock.h
@@ -4,27 +4,27 @@
 #include "bml_types_ellblock.h"
 
 void bml_diagonalize_ellblock(
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors);
 
 void bml_diagonalize_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_ellblock_t * eigenvectors);
 
 void bml_diagonalize_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_ellblock_t * eigenvectors);
 
 void bml_diagonalize_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_ellblock_t * eigenvectors);
 
 void bml_diagonalize_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_ellblock_t * eigenvectors);
 

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock_typed.c
@@ -35,7 +35,7 @@
  */
 void TYPED_FUNC(
     bml_diagonalize_ellblock) (
-    const bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * A,
     void *eigenvalues,
     bml_matrix_ellblock_t * eigenvectors)
 {

--- a/src/C-interface/ellpack/bml_diagonalize_ellpack.c
+++ b/src/C-interface/ellpack/bml_diagonalize_ellpack.c
@@ -13,7 +13,7 @@
 
 void
 bml_diagonalize_ellpack(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors)
 {

--- a/src/C-interface/ellpack/bml_diagonalize_ellpack.h
+++ b/src/C-interface/ellpack/bml_diagonalize_ellpack.h
@@ -4,27 +4,27 @@
 #include "bml_types_ellpack.h"
 
 void bml_diagonalize_ellpack(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_t * eigenvectors);
 
 void bml_diagonalize_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_ellpack_t * eigenvectors);
 
 void bml_diagonalize_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_ellpack_t * eigenvectors);
 
 void bml_diagonalize_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_ellpack_t * eigenvectors);
 
 void bml_diagonalize_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_ellpack_t * eigenvectors);
 

--- a/src/C-interface/ellpack/bml_diagonalize_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_diagonalize_ellpack_typed.c
@@ -35,7 +35,7 @@
  */
 void TYPED_FUNC(
     bml_diagonalize_ellpack) (
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     void *eigenvalues,
     bml_matrix_ellpack_t * eigenvectors)
 {


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_diagonalize`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/283)
<!-- Reviewable:end -->
