### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_elemental.c
+++ b/src/C-interface/bml_elemental.c
@@ -16,9 +16,9 @@
  */
 float
 bml_get_single_real(
-    const bml_matrix_t * A,
-    const int i,
-    const int j)
+    bml_matrix_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_type(A))
     {
@@ -47,9 +47,9 @@ bml_get_single_real(
  */
 double
 bml_get_double_real(
-    const bml_matrix_t * A,
-    const int i,
-    const int j)
+    bml_matrix_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_type(A))
     {
@@ -78,9 +78,9 @@ bml_get_double_real(
  */
 float complex
 bml_get_single_complex(
-    const bml_matrix_t * A,
-    const int i,
-    const int j)
+    bml_matrix_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_type(A))
     {
@@ -109,9 +109,9 @@ bml_get_single_complex(
  */
 double complex
 bml_get_double_complex(
-    const bml_matrix_t * A,
-    const int i,
-    const int j)
+    bml_matrix_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_elemental.h
+++ b/src/C-interface/bml_elemental.h
@@ -6,23 +6,23 @@
 #include <complex.h>
 
 float bml_get_single_real(
-    const bml_matrix_t * A,
-    const int i,
-    const int j);
+    bml_matrix_t * A,
+    int i,
+    int j);
 
 double bml_get_double_real(
-    const bml_matrix_t * A,
-    const int i,
-    const int j);
+    bml_matrix_t * A,
+    int i,
+    int j);
 
 float complex bml_get_single_complex(
-    const bml_matrix_t * A,
-    const int i,
-    const int j);
+    bml_matrix_t * A,
+    int i,
+    int j);
 
 double complex bml_get_double_complex(
-    const bml_matrix_t * A,
-    const int i,
-    const int j);
+    bml_matrix_t * A,
+    int i,
+    int j);
 
 #endif

--- a/src/C-interface/dense/bml_elemental_dense.c
+++ b/src/C-interface/dense/bml_elemental_dense.c
@@ -14,9 +14,9 @@
  */
 float
 bml_get_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j)
+    bml_matrix_dense_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -40,9 +40,9 @@ bml_get_dense_single_real(
  */
 double
 bml_get_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j)
+    bml_matrix_dense_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -66,9 +66,9 @@ bml_get_dense_double_real(
  */
 float complex
 bml_get_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j)
+    bml_matrix_dense_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -92,9 +92,9 @@ bml_get_dense_single_complex(
  */
 double complex
 bml_get_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j)
+    bml_matrix_dense_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {

--- a/src/C-interface/dense/bml_elemental_dense.h
+++ b/src/C-interface/dense/bml_elemental_dense.h
@@ -6,23 +6,23 @@
 #include <complex.h>
 
 float bml_get_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 double bml_get_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 float complex bml_get_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 double complex bml_get_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 #endif

--- a/src/C-interface/ellpack/bml_elemental_ellpack.c
+++ b/src/C-interface/ellpack/bml_elemental_ellpack.c
@@ -14,9 +14,9 @@
  */
 float
 bml_get_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j)
 {
     float *A_value = (float *) A->value;
     if (i < 0 || i >= A->N)
@@ -48,9 +48,9 @@ bml_get_ellpack_single_real(
  */
 double
 bml_get_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -81,9 +81,9 @@ bml_get_ellpack_double_real(
  */
 float complex
 bml_get_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -115,9 +115,9 @@ bml_get_ellpack_single_complex(
  */
 double complex
 bml_get_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {

--- a/src/C-interface/ellpack/bml_elemental_ellpack.h
+++ b/src/C-interface/ellpack/bml_elemental_ellpack.h
@@ -6,23 +6,23 @@
 #include <complex.h>
 
 float bml_get_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 double bml_get_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 float complex bml_get_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 double complex bml_get_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 #endif

--- a/src/C-interface/ellsort/bml_elemental_ellsort.c
+++ b/src/C-interface/ellsort/bml_elemental_ellsort.c
@@ -14,9 +14,9 @@
  */
 float
 bml_get_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j)
 {
     float *A_value = (float *) A->value;
     if (i < 0 || i >= A->N)
@@ -48,9 +48,9 @@ bml_get_ellsort_single_real(
  */
 double
 bml_get_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -81,9 +81,9 @@ bml_get_ellsort_double_real(
  */
 float complex
 bml_get_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {
@@ -115,9 +115,9 @@ bml_get_ellsort_single_complex(
  */
 double complex
 bml_get_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j)
 {
     if (i < 0 || i >= A->N)
     {

--- a/src/C-interface/ellsort/bml_elemental_ellsort.h
+++ b/src/C-interface/ellsort/bml_elemental_ellsort.h
@@ -6,23 +6,23 @@
 #include <complex.h>
 
 float bml_get_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 double bml_get_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 float complex bml_get_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 double complex bml_get_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 #endif


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_elemental`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/284)
<!-- Reviewable:end -->
