### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_export.c
+++ b/src/C-interface/bml_export.c
@@ -32,8 +32,8 @@
  */
 void *
 bml_export_to_dense(
-    const bml_matrix_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_t * A,
+    bml_dense_order_t order)
 {
     LOG_DEBUG("Exporting bml matrix to dense\n");
     switch (bml_get_type(A))

--- a/src/C-interface/bml_export.h
+++ b/src/C-interface/bml_export.h
@@ -6,7 +6,7 @@
 #include "bml_types.h"
 
 void *bml_export_to_dense(
-    const bml_matrix_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_t * A,
+    bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/dense/bml_export_dense.c
+++ b/src/C-interface/dense/bml_export_dense.c
@@ -21,8 +21,8 @@
  */
 void *
 bml_export_to_dense_dense(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_export_dense.h
+++ b/src/C-interface/dense/bml_export_dense.h
@@ -4,23 +4,23 @@
 #include "bml_types_dense.h"
 
 void *bml_export_to_dense_dense(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/dense/bml_export_dense_typed.c
+++ b/src/C-interface/dense/bml_export_dense_typed.c
@@ -24,8 +24,8 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order)
 {
     REAL_T *A_dense = bml_allocate_memory(sizeof(REAL_T) * A->N * A->N);
 

--- a/src/C-interface/ellblock/bml_export_ellblock.c
+++ b/src/C-interface/ellblock/bml_export_ellblock.c
@@ -17,8 +17,8 @@
  */
 void *
 bml_export_to_dense_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_export_ellblock.h
+++ b/src/C-interface/ellblock/bml_export_ellblock.h
@@ -4,23 +4,23 @@
 #include "bml_types_ellblock.h"
 
 void *bml_export_to_dense_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/ellblock/bml_export_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_export_ellblock_typed.c
@@ -27,8 +27,8 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_ellblock_t * A,
+    bml_dense_order_t order)
 {
     assert(A->N > 0);
 

--- a/src/C-interface/ellpack/bml_export_ellpack.c
+++ b/src/C-interface/ellpack/bml_export_ellpack.c
@@ -17,8 +17,8 @@
  */
 void *
 bml_export_to_dense_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_export_ellpack.h
+++ b/src/C-interface/ellpack/bml_export_ellpack.h
@@ -4,23 +4,23 @@
 #include "bml_types_ellpack.h"
 
 void *bml_export_to_dense_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/ellpack/bml_export_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_export_ellpack_typed.c
@@ -25,8 +25,8 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_ellpack_t * A,
+    bml_dense_order_t order)
 {
     int N = A->N;
     int M = A->M;

--- a/src/C-interface/ellsort/bml_export_ellsort.c
+++ b/src/C-interface/ellsort/bml_export_ellsort.c
@@ -17,8 +17,8 @@
  */
 void *
 bml_export_to_dense_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_export_ellsort.h
+++ b/src/C-interface/ellsort/bml_export_ellsort.h
@@ -4,23 +4,23 @@
 #include "bml_types_ellsort.h"
 
 void *bml_export_to_dense_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/ellsort/bml_export_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_export_ellsort_typed.c
@@ -25,8 +25,8 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_dense_order_t order)
+    bml_matrix_ellsort_t * A,
+    bml_dense_order_t order)
 {
     int N = A->N;
     int M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_export` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/285)
<!-- Reviewable:end -->
