### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_getters.c
+++ b/src/C-interface/bml_getters.c
@@ -17,9 +17,9 @@
  */
 void *
 bml_get(
-    const bml_matrix_t * A,
-    const int i,
-    const int j)
+    bml_matrix_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_type(A))
     {
@@ -51,7 +51,7 @@ bml_get(
 void *
 bml_get_row(
     bml_matrix_t * A,
-    const int i)
+    int i)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_getters.h
+++ b/src/C-interface/bml_getters.h
@@ -6,13 +6,13 @@
 #include "bml_types.h"
 
 void *bml_get(
-    const bml_matrix_t * A,
-    const int i,
-    const int j);
+    bml_matrix_t * A,
+    int i,
+    int j);
 
 void *bml_get_row(
     bml_matrix_t * A,
-    const int i);
+    int i);
 
 void *bml_get_diagonal(
     bml_matrix_t * A);

--- a/src/C-interface/dense/bml_getters_dense.c
+++ b/src/C-interface/dense/bml_getters_dense.c
@@ -5,9 +5,9 @@
 
 void *
 bml_get_dense(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j)
+    bml_matrix_dense_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_precision(A))
     {
@@ -33,7 +33,7 @@ bml_get_dense(
 void *
 bml_get_row_dense(
     bml_matrix_dense_t * A,
-    const int i)
+    int i)
 {
     switch (bml_get_precision(A))
     {

--- a/src/C-interface/dense/bml_getters_dense.h
+++ b/src/C-interface/dense/bml_getters_dense.h
@@ -8,49 +8,49 @@
 #include <complex.h>
 
 void *bml_get_dense(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 void *bml_get_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 void *bml_get_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 void *bml_get_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 void *bml_get_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j);
+    bml_matrix_dense_t * A,
+    int i,
+    int j);
 
 void *bml_get_row_dense(
     bml_matrix_dense_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_dense_single_real(
     bml_matrix_dense_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_dense_double_real(
     bml_matrix_dense_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_dense_single_complex(
     bml_matrix_dense_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_dense_double_complex(
     bml_matrix_dense_t * A,
-    const int i);
+    int i);
 
 void *bml_get_diagonal_dense(
     bml_matrix_dense_t * A);

--- a/src/C-interface/dense/bml_getters_dense_typed.c
+++ b/src/C-interface/dense/bml_getters_dense_typed.c
@@ -16,9 +16,9 @@
 
 void *TYPED_FUNC(
     bml_get_dense) (
-    const bml_matrix_dense_t * A,
-    const int i,
-    const int j)
+    bml_matrix_dense_t * A,
+    int i,
+    int j)
 {
     int N = bml_get_N(A);
 
@@ -44,7 +44,7 @@ void *TYPED_FUNC(
 void *TYPED_FUNC(
     bml_get_row_dense) (
     bml_matrix_dense_t * A,
-    const int i)
+    int i)
 {
     int N = bml_get_N(A);
 

--- a/src/C-interface/ellblock/bml_getters_ellblock.c
+++ b/src/C-interface/ellblock/bml_getters_ellblock.c
@@ -5,9 +5,9 @@
 
 void *
 bml_get_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_precision(A))
     {
@@ -33,7 +33,7 @@ bml_get_ellblock(
 void *
 bml_get_row_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i)
+    int i)
 {
     switch (bml_get_precision(A))
     {

--- a/src/C-interface/ellblock/bml_getters_ellblock.h
+++ b/src/C-interface/ellblock/bml_getters_ellblock.h
@@ -8,49 +8,49 @@
 #include <complex.h>
 
 void *bml_get_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j);
 
 void *bml_get_row_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const int i);
+    int i);
 
 void *bml_get_diagonal_ellblock(
     bml_matrix_ellblock_t * A);

--- a/src/C-interface/ellblock/bml_getters_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_getters_ellblock_typed.c
@@ -18,9 +18,9 @@
  */
 void *TYPED_FUNC(
     bml_get_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellblock_t * A,
+    int i,
+    int j)
 {
     static REAL_T MINUS_ONE = -1;
     static REAL_T ZERO = 0;
@@ -76,7 +76,7 @@ void *TYPED_FUNC(
 void *TYPED_FUNC(
     bml_get_row_ellblock) (
     bml_matrix_ellblock_t * A,
-    const int i)
+    int i)
 {
     int A_NB = A->NB;
     int A_MB = A->MB;

--- a/src/C-interface/ellpack/bml_getters_ellpack.c
+++ b/src/C-interface/ellpack/bml_getters_ellpack.c
@@ -5,9 +5,9 @@
 
 void *
 bml_get_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_precision(A))
     {
@@ -33,7 +33,7 @@ bml_get_ellpack(
 void *
 bml_get_row_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i)
+    int i)
 {
     switch (bml_get_precision(A))
     {

--- a/src/C-interface/ellpack/bml_getters_ellpack.h
+++ b/src/C-interface/ellpack/bml_getters_ellpack.h
@@ -8,49 +8,49 @@
 #include <complex.h>
 
 void *bml_get_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j);
 
 void *bml_get_row_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellpack_single_real(
     bml_matrix_ellpack_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellpack_double_real(
     bml_matrix_ellpack_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellpack_single_complex(
     bml_matrix_ellpack_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellpack_double_complex(
     bml_matrix_ellpack_t * A,
-    const int i);
+    int i);
 
 void *bml_get_diagonal_ellpack(
     bml_matrix_ellpack_t * A);

--- a/src/C-interface/ellpack/bml_getters_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_getters_ellpack_typed.c
@@ -17,9 +17,9 @@
  */
 void *TYPED_FUNC(
     bml_get_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellpack_t * A,
+    int i,
+    int j)
 {
     static REAL_T MINUS_ONE = -1;
     static REAL_T ZERO = 0;
@@ -57,7 +57,7 @@ void *TYPED_FUNC(
 void *TYPED_FUNC(
     bml_get_row_ellpack) (
     bml_matrix_ellpack_t * A,
-    const int i)
+    int i)
 {
     int ll;
     int A_N = A->N;

--- a/src/C-interface/ellsort/bml_getters_ellsort.c
+++ b/src/C-interface/ellsort/bml_getters_ellsort.c
@@ -5,9 +5,9 @@
 
 void *
 bml_get_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j)
 {
     switch (bml_get_precision(A))
     {
@@ -33,7 +33,7 @@ bml_get_ellsort(
 void *
 bml_get_row_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i)
+    int i)
 {
     switch (bml_get_precision(A))
     {

--- a/src/C-interface/ellsort/bml_getters_ellsort.h
+++ b/src/C-interface/ellsort/bml_getters_ellsort.h
@@ -8,49 +8,49 @@
 #include <complex.h>
 
 void *bml_get_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 void *bml_get_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j);
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j);
 
 void *bml_get_row_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellsort_single_real(
     bml_matrix_ellsort_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellsort_double_real(
     bml_matrix_ellsort_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellsort_single_complex(
     bml_matrix_ellsort_t * A,
-    const int i);
+    int i);
 
 void *bml_get_row_ellsort_double_complex(
     bml_matrix_ellsort_t * A,
-    const int i);
+    int i);
 
 void *bml_get_diagonal_ellsort(
     bml_matrix_ellsort_t * A);

--- a/src/C-interface/ellsort/bml_getters_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_getters_ellsort_typed.c
@@ -17,9 +17,9 @@
  */
 void *TYPED_FUNC(
     bml_get_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const int i,
-    const int j)
+    bml_matrix_ellsort_t * A,
+    int i,
+    int j)
 {
     static REAL_T MINUS_ONE = -1;
     static REAL_T ZERO = 0;
@@ -57,7 +57,7 @@ void *TYPED_FUNC(
 void *TYPED_FUNC(
     bml_get_row_ellsort) (
     bml_matrix_ellsort_t * A,
-    const int i)
+    int i)
 {
     int ll;
     int A_N = A->N;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_getter` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/286)
<!-- Reviewable:end -->
