### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_import.c
+++ b/src/C-interface/bml_import.c
@@ -23,14 +23,14 @@
  */
 bml_matrix_t *
 bml_import_from_dense(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const int M,
-    const void *A,
-    const double threshold,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    int M,
+    void *A,
+    double threshold,
+    bml_distribution_mode_t distrib_mode)
 {
     LOG_DEBUG("importing dense matrix\n");
     switch (matrix_type)

--- a/src/C-interface/bml_import.h
+++ b/src/C-interface/bml_import.h
@@ -6,13 +6,13 @@
 #include "bml_types.h"
 
 bml_matrix_t *bml_import_from_dense(
-    const bml_matrix_type_t matrix_type,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const int M,
-    const void *A,
-    const double threshold,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    int M,
+    void *A,
+    double threshold,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/dense/bml_import_dense.c
+++ b/src/C-interface/dense/bml_import_dense.c
@@ -20,12 +20,12 @@
  */
 bml_matrix_dense_t *
 bml_import_from_dense_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dense_t *A_bml = NULL;
 

--- a/src/C-interface/dense/bml_import_dense.h
+++ b/src/C-interface/dense/bml_import_dense.h
@@ -4,55 +4,55 @@
 #include "bml_types_dense.h"
 
 bml_matrix_dense_t *bml_import_from_dense_dense(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_import_from_dense_dense_single_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_import_from_dense_dense_double_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_import_from_dense_dense_single_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_dense_t *bml_import_from_dense_dense_double_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    bml_distribution_mode_t distrib_mode);
 
 void *bml_export_to_dense_dense(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_dense_order_t order);
+    bml_matrix_dense_t * A,
+    bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/dense/bml_import_dense_typed.c
+++ b/src/C-interface/dense/bml_import_dense_typed.c
@@ -27,10 +27,10 @@
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_import_from_dense_dense) (
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const bml_distribution_mode_t distrib_mode)
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_dimension_t matrix_dimension = { N, N, N };
     bml_matrix_dense_t *A_bml =

--- a/src/C-interface/ellblock/bml_import_ellblock.c
+++ b/src/C-interface/ellblock/bml_import_ellblock.c
@@ -20,13 +20,13 @@
  */
 bml_matrix_ellblock_t *
 bml_import_from_dense_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_import_ellblock.h
+++ b/src/C-interface/ellblock/bml_import_ellblock.h
@@ -4,44 +4,44 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_ellblock_t *bml_import_from_dense_ellblock(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_import_from_dense_ellblock_single_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_import_from_dense_ellblock_double_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_import_from_dense_ellblock_single_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellblock_t *bml_import_from_dense_ellblock_double_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/ellblock/bml_import_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_import_ellblock_typed.c
@@ -29,12 +29,12 @@
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_import_from_dense_ellblock) (
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellblock_t *A_bml =
         TYPED_FUNC(bml_zero_matrix_ellblock) (N, M, distrib_mode);

--- a/src/C-interface/ellpack/bml_import_ellpack.c
+++ b/src/C-interface/ellpack/bml_import_ellpack.c
@@ -20,13 +20,13 @@
  */
 bml_matrix_ellpack_t *
 bml_import_from_dense_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_import_ellpack.h
+++ b/src/C-interface/ellpack/bml_import_ellpack.h
@@ -4,44 +4,44 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_ellpack_t *bml_import_from_dense_ellpack(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_import_from_dense_ellpack_single_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_import_from_dense_ellpack_double_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_import_from_dense_ellpack_single_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellpack_t *bml_import_from_dense_ellpack_double_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/ellpack/bml_import_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_import_ellpack_typed.c
@@ -27,12 +27,12 @@
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_import_from_dense_ellpack) (
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellpack_t *A_bml =
         TYPED_FUNC(bml_zero_matrix_ellpack) (N, M, distrib_mode);

--- a/src/C-interface/ellsort/bml_import_ellsort.c
+++ b/src/C-interface/ellsort/bml_import_ellsort.c
@@ -20,13 +20,13 @@
  */
 bml_matrix_ellsort_t *
 bml_import_from_dense_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     switch (matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_import_ellsort.h
+++ b/src/C-interface/ellsort/bml_import_ellsort.h
@@ -4,44 +4,44 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_ellsort_t *bml_import_from_dense_ellsort(
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_import_from_dense_ellsort_single_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_import_from_dense_ellsort_double_real(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_import_from_dense_ellsort_single_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 bml_matrix_ellsort_t *bml_import_from_dense_ellsort_double_complex(
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode);
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode);
 
 #endif

--- a/src/C-interface/ellsort/bml_import_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_import_ellsort_typed.c
@@ -27,12 +27,12 @@
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_import_from_dense_ellsort) (
-    const bml_dense_order_t order,
-    const int N,
-    const void *A,
-    const double threshold,
-    const int M,
-    const bml_distribution_mode_t distrib_mode)
+    bml_dense_order_t order,
+    int N,
+    void *A,
+    double threshold,
+    int M,
+    bml_distribution_mode_t distrib_mode)
 {
     bml_matrix_ellsort_t *A_bml =
         TYPED_FUNC(bml_zero_matrix_ellsort) (N, M, distrib_mode);


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_import` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/287)
<!-- Reviewable:end -->
