### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_introspection.c
+++ b/src/C-interface/bml_introspection.c
@@ -17,9 +17,9 @@
  */
 bml_matrix_type_t
 bml_get_type(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
-    const bml_matrix_type_t *matrix_type = A;
+    bml_matrix_type_t *matrix_type = A;
     if (A != NULL)
     {
         return *matrix_type;
@@ -38,7 +38,7 @@ bml_get_type(
  */
 bml_matrix_precision_t
 bml_get_precision(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -71,7 +71,7 @@ bml_get_precision(
  */
 int
 bml_get_N(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -104,7 +104,7 @@ bml_get_N(
  */
 int
 bml_get_M(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -132,7 +132,7 @@ bml_get_M(
 
 int
 bml_get_NB(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -166,8 +166,8 @@ bml_get_NB(
  */
 int
 bml_get_row_bandwidth(
-    const bml_matrix_t * A,
-    const int i)
+    bml_matrix_t * A,
+    int i)
 {
     if (i < 0 || i >= bml_get_N(A))
     {
@@ -198,7 +198,7 @@ bml_get_row_bandwidth(
  */
 int
 bml_get_bandwidth(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -225,7 +225,7 @@ bml_get_bandwidth(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -253,8 +253,8 @@ bml_get_distribution_mode(
  */
 double
 bml_get_sparsity(
-    const bml_matrix_t * A,
-    const double threshold)
+    bml_matrix_t * A,
+    double threshold)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_introspection.h
+++ b/src/C-interface/bml_introspection.h
@@ -6,32 +6,32 @@
 #include "bml_types.h"
 
 bml_matrix_type_t bml_get_type(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 bml_matrix_precision_t bml_get_precision(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 int bml_get_N(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 int bml_get_M(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 int bml_get_NB(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 int bml_get_row_bandwidth(
-    const bml_matrix_t * A,
-    const int i);
+    bml_matrix_t * A,
+    int i);
 
 int bml_get_bandwidth(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 double bml_get_sparsity(
-    const bml_matrix_t * A,
-    const double threshold);
+    bml_matrix_t * A,
+    double threshold);
 
 bml_distribution_mode_t bml_get_distribution_mode(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 #endif

--- a/src/C-interface/dense/bml_introspection_dense.c
+++ b/src/C-interface/dense/bml_introspection_dense.c
@@ -10,7 +10,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -29,7 +29,7 @@ bml_get_precision_dense(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -48,7 +48,7 @@ bml_get_distribution_mode_dense(
  */
 int
 bml_get_N_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -67,7 +67,7 @@ bml_get_N_dense(
  */
 int
 bml_get_M_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -87,8 +87,8 @@ bml_get_M_dense(
  */
 int
 bml_get_row_bandwidth_dense(
-    const bml_matrix_dense_t * A,
-    const int i)
+    bml_matrix_dense_t * A,
+    int i)
 {
     switch (bml_get_precision_dense(A))
     {
@@ -121,7 +121,7 @@ bml_get_row_bandwidth_dense(
  */
 int
 bml_get_bandwidth_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     switch (bml_get_precision_dense(A))
     {
@@ -161,8 +161,8 @@ bml_get_bandwidth_dense(
  */
 double
 bml_get_sparsity_dense(
-    const bml_matrix_dense_t * A,
-    const double threshold)
+    bml_matrix_dense_t * A,
+    double threshold)
 {
     switch (bml_get_precision_dense(A))
     {

--- a/src/C-interface/dense/bml_introspection_dense.h
+++ b/src/C-interface/dense/bml_introspection_dense.h
@@ -4,71 +4,71 @@
 #include "bml_types_dense.h"
 
 bml_matrix_precision_t bml_get_precision_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_N_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_M_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_row_bandwidth_dense(
-    const bml_matrix_dense_t * A,
-    const int i);
+    bml_matrix_dense_t * A,
+    int i);
 
 bml_distribution_mode_t bml_get_distribution_mode_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_row_bandwidth_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int i);
+    bml_matrix_dense_t * A,
+    int i);
 
 int bml_get_row_bandwidth_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int i);
+    bml_matrix_dense_t * A,
+    int i);
 
 int bml_get_row_bandwidth_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int i);
+    bml_matrix_dense_t * A,
+    int i);
 
 int bml_get_row_bandwidth_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int i);
+    bml_matrix_dense_t * A,
+    int i);
 
 int bml_get_bandwidth_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 // Get the sparsity of a bml matrix
 double bml_get_sparsity_dense(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 double bml_get_sparsity_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 double bml_get_sparsity_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 double bml_get_sparsity_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 double bml_get_sparsity_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_introspection_dense_typed.c
+++ b/src/C-interface/dense/bml_introspection_dense_typed.c
@@ -17,8 +17,8 @@
  */
 int TYPED_FUNC(
     bml_get_row_bandwidth_dense) (
-    const bml_matrix_dense_t * A,
-    const int i)
+    bml_matrix_dense_t * A,
+    int i)
 {
     assert(A != NULL);
 
@@ -42,7 +42,7 @@ int TYPED_FUNC(
  */
 int TYPED_FUNC(
     bml_get_bandwidth_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     assert(A != NULL);
 
@@ -76,8 +76,8 @@ int TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_get_sparsity_dense) (
-    const bml_matrix_dense_t * A,
-    const double threshold)
+    bml_matrix_dense_t * A,
+    double threshold)
 {
 
 #ifdef BML_USE_MAGMA

--- a/src/C-interface/ellblock/bml_introspection_ellblock.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -37,7 +37,7 @@ bml_get_precision_ellblock(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -56,7 +56,7 @@ bml_get_distribution_mode_ellblock(
  */
 int
 bml_get_N_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -75,7 +75,7 @@ bml_get_N_ellblock(
  */
 int
 bml_get_M_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -89,7 +89,7 @@ bml_get_M_ellblock(
 
 int
 bml_get_NB_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -109,8 +109,8 @@ bml_get_NB_ellblock(
  */
 int
 bml_get_row_bandwidth_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const int i)
+    bml_matrix_ellblock_t * A,
+    int i)
 {
     //determine block index and index within block
     int ib = 0;
@@ -136,7 +136,7 @@ bml_get_row_bandwidth_ellblock(
  */
 int
 bml_get_bandwidth_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     int max_bandwidth = 0;
     int offset = 0;
@@ -164,8 +164,8 @@ bml_get_bandwidth_ellblock(
  */
 double
 bml_get_sparsity_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double threshold)
 {
     switch (bml_get_precision_ellblock(A))
     {

--- a/src/C-interface/ellblock/bml_introspection_ellblock.h
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.h
@@ -4,46 +4,46 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_precision_t bml_get_precision_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_distribution_mode_t bml_get_distribution_mode_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 int bml_get_N_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 int bml_get_M_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 int bml_get_NB_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 int bml_get_row_bandwidth_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const int i);
+    bml_matrix_ellblock_t * A,
+    int i);
 
 int bml_get_bandwidth_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
     // Get the sparsity of a bml matrix
 double bml_get_sparsity_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellblock/bml_introspection_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock_typed.c
@@ -25,8 +25,8 @@
  */
 double TYPED_FUNC(
     bml_get_sparsity_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double threshold)
 {
     int nnzs = 0;
     double sparsity;

--- a/src/C-interface/ellpack/bml_introspection_ellpack.c
+++ b/src/C-interface/ellpack/bml_introspection_ellpack.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -37,7 +37,7 @@ bml_get_precision_ellpack(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -56,7 +56,7 @@ bml_get_distribution_mode_ellpack(
  */
 int
 bml_get_N_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -75,7 +75,7 @@ bml_get_N_ellpack(
  */
 int
 bml_get_M_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -95,8 +95,8 @@ bml_get_M_ellpack(
  */
 int
 bml_get_row_bandwidth_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int i)
+    bml_matrix_ellpack_t * A,
+    int i)
 {
     return A->nnz[i];
 }
@@ -108,7 +108,7 @@ bml_get_row_bandwidth_ellpack(
  */
 int
 bml_get_bandwidth_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     int max_bandwidth = 0;
     for (int i = 0; i < A->N; i++)
@@ -134,8 +134,8 @@ bml_get_bandwidth_ellpack(
  */
 double
 bml_get_sparsity_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double threshold)
 {
     switch (bml_get_precision_ellpack(A))
     {

--- a/src/C-interface/ellpack/bml_introspection_ellpack.h
+++ b/src/C-interface/ellpack/bml_introspection_ellpack.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_precision_t bml_get_precision_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_distribution_mode_t bml_get_distribution_mode_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 int bml_get_N_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 int bml_get_M_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 int bml_get_row_bandwidth_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int i);
+    bml_matrix_ellpack_t * A,
+    int i);
 
 int bml_get_bandwidth_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
     // Get the sparsity of a bml matrix
 double bml_get_sparsity_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_introspection_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_introspection_ellpack_typed.c
@@ -24,8 +24,8 @@
  */
 double TYPED_FUNC(
     bml_get_sparsity_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double threshold)
 {
     int nnzs = 0;
     int i;

--- a/src/C-interface/ellsort/bml_introspection_ellsort.c
+++ b/src/C-interface/ellsort/bml_introspection_ellsort.c
@@ -17,7 +17,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -36,7 +36,7 @@ bml_get_precision_ellsort(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -55,7 +55,7 @@ bml_get_distribution_mode_ellsort(
  */
 int
 bml_get_N_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -74,7 +74,7 @@ bml_get_N_ellsort(
  */
 int
 bml_get_M_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -94,8 +94,8 @@ bml_get_M_ellsort(
  */
 int
 bml_get_row_bandwidth_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int i)
+    bml_matrix_ellsort_t * A,
+    int i)
 {
     return A->nnz[i];
 }
@@ -107,7 +107,7 @@ bml_get_row_bandwidth_ellsort(
  */
 int
 bml_get_bandwidth_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     int max_bandwidth = 0;
     for (int i = 0; i < A->N; i++)
@@ -132,8 +132,8 @@ bml_get_bandwidth_ellsort(
  */
 double
 bml_get_sparsity_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double threshold)
 {
     double sparsity;
     switch (bml_get_precision_ellsort(A))

--- a/src/C-interface/ellsort/bml_introspection_ellsort.h
+++ b/src/C-interface/ellsort/bml_introspection_ellsort.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_precision_t bml_get_precision_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_distribution_mode_t bml_get_distribution_mode_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 int bml_get_N_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 int bml_get_M_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 int bml_get_row_bandwidth_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int i);
+    bml_matrix_ellsort_t * A,
+    int i);
 
 int bml_get_bandwidth_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
     // Get the sparsity of a bml matrix
 double bml_get_sparsity_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 double bml_get_sparsity_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellsort/bml_introspection_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_introspection_ellsort_typed.c
@@ -24,8 +24,8 @@
  */
 double TYPED_FUNC(
     bml_get_sparsity_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double threshold)
 {
     int nnzs = 0;
     int i;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_introspection`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/288)
<!-- Reviewable:end -->
