### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_inverse.c
+++ b/src/C-interface/bml_inverse.c
@@ -9,7 +9,7 @@
 
 bml_matrix_t *
 bml_inverse(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     bml_matrix_t *B = NULL;
 

--- a/src/C-interface/bml_inverse.h
+++ b/src/C-interface/bml_inverse.h
@@ -4,6 +4,6 @@
 #include "bml_types.h"
 
 bml_matrix_t *bml_inverse(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 #endif

--- a/src/C-interface/dense/bml_inverse_dense.c
+++ b/src/C-interface/dense/bml_inverse_dense.c
@@ -16,7 +16,7 @@
  */
 bml_matrix_dense_t *
 bml_inverse_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
 
     bml_matrix_dense_t *B = NULL;

--- a/src/C-interface/dense/bml_inverse_dense.h
+++ b/src/C-interface/dense/bml_inverse_dense.h
@@ -4,19 +4,19 @@
 #include "bml_types_dense.h"
 
 bml_matrix_dense_t *bml_inverse_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_inverse_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_inverse_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_inverse_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_inverse_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void bml_inverse_inplace_dense(
     bml_matrix_dense_t * A);

--- a/src/C-interface/dense/bml_inverse_dense_typed.c
+++ b/src/C-interface/dense/bml_inverse_dense_typed.c
@@ -33,7 +33,7 @@
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_inverse_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     bml_matrix_dense_t *B = TYPED_FUNC(bml_copy_dense_new) (A);
 

--- a/src/C-interface/ellblock/bml_inverse_ellblock.c
+++ b/src/C-interface/ellblock/bml_inverse_ellblock.c
@@ -12,7 +12,7 @@
 
 bml_matrix_ellblock_t *
 bml_inverse_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
 
     bml_matrix_ellblock_t *B = NULL;

--- a/src/C-interface/ellblock/bml_inverse_ellblock.h
+++ b/src/C-interface/ellblock/bml_inverse_ellblock.h
@@ -4,18 +4,18 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_ellblock_t *bml_inverse_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_inverse_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_inverse_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_inverse_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_inverse_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 #endif

--- a/src/C-interface/ellblock/bml_inverse_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_inverse_ellblock_typed.c
@@ -34,7 +34,7 @@
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_inverse_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     double threshold = 0.0;
     bml_matrix_dense_t *D;

--- a/src/C-interface/ellpack/bml_inverse_ellpack.c
+++ b/src/C-interface/ellpack/bml_inverse_ellpack.c
@@ -12,7 +12,7 @@
 
 bml_matrix_ellpack_t *
 bml_inverse_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
 
     bml_matrix_ellpack_t *B = NULL;

--- a/src/C-interface/ellpack/bml_inverse_ellpack.h
+++ b/src/C-interface/ellpack/bml_inverse_ellpack.h
@@ -4,18 +4,18 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_ellpack_t *bml_inverse_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_inverse_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_inverse_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_inverse_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_inverse_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 #endif

--- a/src/C-interface/ellpack/bml_inverse_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_inverse_ellpack_typed.c
@@ -34,7 +34,7 @@
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_inverse_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     double threshold = 0.0;
     bml_matrix_dense_t *D;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_inverse` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/289)
<!-- Reviewable:end -->
