### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_logger.c
+++ b/src/C-interface/bml_logger.c
@@ -92,8 +92,8 @@ print_backtrace(
  */
 void
 bml_log_real(
-    const bml_log_level_t log_level,
-    const char *format,
+    bml_log_level_t log_level,
+    char *format,
     va_list ap)
 {
     char new_format[FMT_LENGTH];
@@ -125,8 +125,8 @@ bml_log_real(
  */
 void
 bml_log(
-    const bml_log_level_t log_level,
-    const char *format,
+    bml_log_level_t log_level,
+    char *format,
     ...)
 {
     va_list ap;
@@ -145,10 +145,10 @@ bml_log(
  */
 void
 bml_log_location(
-    const bml_log_level_t log_level,
-    const char *filename,
-    const int linenumber,
-    const char *format,
+    bml_log_level_t log_level,
+    char *filename,
+    int linenumber,
+    char *format,
     ...)
 {
     va_list ap;

--- a/src/C-interface/bml_logger.h
+++ b/src/C-interface/bml_logger.h
@@ -21,15 +21,15 @@ typedef enum
 } bml_log_level_t;
 
 void bml_log(
-    const bml_log_level_t log_level,
-    const char *format,
+    bml_log_level_t log_level,
+    char *format,
     ...);
 
 void bml_log_location(
-    const bml_log_level_t log_level,
-    const char *filename,
-    const int linenumber,
-    const char *format,
+    bml_log_level_t log_level,
+    char *filename,
+    int linenumber,
+    char *format,
     ...);
 
 /** Convenience macro to write a BML_LOG_DEBUG level message. */


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_logger` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/291)
<!-- Reviewable:end -->
