### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_multiply.c
+++ b/src/C-interface/bml_multiply.c
@@ -23,12 +23,12 @@
  */
 void
 bml_multiply(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
     bml_matrix_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -62,9 +62,9 @@ bml_multiply(
  */
 void *
 bml_multiply_x2(
-    const bml_matrix_t * X,
+    bml_matrix_t * X,
     bml_matrix_t * X2,
-    const double threshold)
+    double threshold)
 {
     switch (bml_get_type(X))
     {
@@ -100,10 +100,10 @@ bml_multiply_x2(
  */
 void
 bml_multiply_AB(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
     bml_matrix_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -138,10 +138,10 @@ bml_multiply_AB(
  */
 void
 bml_multiply_adjust_AB(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
     bml_matrix_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_multiply.h
+++ b/src/C-interface/bml_multiply.h
@@ -7,31 +7,31 @@
 
 // Multiply - C = alpha * A * B + beta * C
 void bml_multiply(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
     bml_matrix_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 // Multiply X^2 - X2 = X * X
 void *bml_multiply_x2(
-    const bml_matrix_t * X,
+    bml_matrix_t * X,
     bml_matrix_t * X2,
-    const double threshold);
+    double threshold);
 
 // Multiply - C = A * B
 void bml_multiply_AB(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
     bml_matrix_t * C,
-    const double threshold);
+    double threshold);
 
 // Multiply with threshold adjustment - C = A * B
 void bml_multiply_adjust_AB(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
     bml_matrix_t * C,
-    const double threshold);
+    double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_multiply_dense.c
+++ b/src/C-interface/dense/bml_multiply_dense.c
@@ -21,11 +21,11 @@
  */
 void
 bml_multiply_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta)
+    double alpha,
+    double beta)
 {
     switch (A->matrix_precision)
     {
@@ -58,7 +58,7 @@ bml_multiply_dense(
  */
 void *
 bml_multiply_x2_dense(
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2)
 {
     switch (X->matrix_precision)
@@ -94,8 +94,8 @@ bml_multiply_x2_dense(
  */
 void
 bml_multiply_AB_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C)
 {
     switch (A->matrix_precision)
@@ -132,8 +132,8 @@ bml_multiply_AB_dense(
  */
 void
 bml_multiply_adjust_AB_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/dense/bml_multiply_dense.h
+++ b/src/C-interface/dense/bml_multiply_dense.h
@@ -5,108 +5,108 @@
 
 // Matrix multiply - C = alpha * A * B + beta * C
 void bml_multiply_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta);
+    double alpha,
+    double beta);
 
 void bml_multiply_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta);
+    double alpha,
+    double beta);
 
 void bml_multiply_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta);
+    double alpha,
+    double beta);
 
 void bml_multiply_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta);
+    double alpha,
+    double beta);
 
 void bml_multiply_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta);
+    double alpha,
+    double beta);
 
 void *bml_multiply_x2_dense(
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2);
 
 void *bml_multiply_x2_dense_single_real(
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2);
 
 void *bml_multiply_x2_dense_double_real(
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2);
 
 void *bml_multiply_x2_dense_single_complex(
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2);
 
 void *bml_multiply_x2_dense_double_complex(
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2);
 
 void bml_multiply_AB_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_AB_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_AB_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_AB_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_AB_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_adjust_AB_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_adjust_AB_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_adjust_AB_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_adjust_AB_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 void bml_multiply_adjust_AB_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C);
 
 #endif

--- a/src/C-interface/dense/bml_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_multiply_dense_typed.c
@@ -49,11 +49,11 @@
  */
 void TYPED_FUNC(
     bml_multiply_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C,
-    const double alpha,
-    const double beta)
+    double alpha,
+    double beta)
 {
 #ifdef BML_USE_MAGMA
     MAGMA_T alpha_ = MAGMACOMPLEX(MAKE) (alpha, 0.);
@@ -83,7 +83,7 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_multiply_x2_dense) (
-    const bml_matrix_dense_t * X,
+    bml_matrix_dense_t * X,
     bml_matrix_dense_t * X2)
 {
     double *trace = bml_allocate_memory(sizeof(double) * 2);
@@ -107,8 +107,8 @@ void *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_AB_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C)
 {
     TYPED_FUNC(bml_multiply_dense) (A, B, C, 1.0, 0.0);
@@ -128,8 +128,8 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_adjust_AB_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
     bml_matrix_dense_t * C)
 {
     REAL_T alpha = (REAL_T) 1.0;

--- a/src/C-interface/ellblock/bml_multiply_ellblock.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock.c
@@ -25,12 +25,12 @@
  */
 void
 bml_multiply_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -68,9 +68,9 @@ bml_multiply_ellblock(
  */
 void *
 bml_multiply_x2_ellblock(
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold)
+    double threshold)
 {
     switch (X->matrix_precision)
     {
@@ -106,10 +106,10 @@ bml_multiply_x2_ellblock(
  */
 void
 bml_multiply_AB_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -144,10 +144,10 @@ bml_multiply_AB_ellblock(
  */
 void
 bml_multiply_adjust_AB_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_multiply_ellblock.h
+++ b/src/C-interface/ellblock/bml_multiply_ellblock.h
@@ -4,128 +4,128 @@
 #include "bml_types_ellblock.h"
 
 void bml_multiply_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void *bml_multiply_x2_ellblock(
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellblock_single_real(
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellblock_double_real(
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellblock_single_complex(
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellblock_double_complex(
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold);
+    double threshold);
 
 #endif

--- a/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
@@ -40,15 +40,15 @@
  */
 void TYPED_FUNC(
     bml_multiply_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
-    const double ONE = 1.0;
-    const double ZERO = 0.0;
+    double ONE = 1.0;
+    double ZERO = 0.0;
 
     if (A == NULL || B == NULL)
     {
@@ -99,9 +99,9 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_multiply_x2_ellblock) (
-    const bml_matrix_ellblock_t * X,
+    bml_matrix_ellblock_t * X,
     bml_matrix_ellblock_t * X2,
-    const double threshold)
+    double threshold)
 {
     int NB = X->NB;
     int MB = X->MB;
@@ -240,10 +240,10 @@ void *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_AB_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold)
+    double threshold)
 {
     assert(A->NB == B->NB);
     assert(A->NB == C->NB);
@@ -371,10 +371,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_adjust_AB_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
     bml_matrix_ellblock_t * C,
-    const double threshold)
+    double threshold)
 {
     int NB = A->NB;
     int MB = A->MB;

--- a/src/C-interface/ellpack/bml_multiply_ellpack.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack.c
@@ -25,12 +25,12 @@
  */
 void
 bml_multiply_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -66,9 +66,9 @@ bml_multiply_ellpack(
  */
 void *
 bml_multiply_x2_ellpack(
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold)
+    double threshold)
 {
     switch (X->matrix_precision)
     {
@@ -104,10 +104,10 @@ bml_multiply_x2_ellpack(
  */
 void
 bml_multiply_AB_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -142,10 +142,10 @@ bml_multiply_AB_ellpack(
  */
 void
 bml_multiply_adjust_AB_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_multiply_ellpack.h
+++ b/src/C-interface/ellpack/bml_multiply_ellpack.h
@@ -4,128 +4,128 @@
 #include "bml_types_ellpack.h"
 
 void bml_multiply_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void *bml_multiply_x2_ellpack(
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellpack_single_real(
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellpack_double_real(
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellpack_single_complex(
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellpack_double_complex(
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold);
+    double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -36,15 +36,15 @@
  */
 void TYPED_FUNC(
     bml_multiply_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
-    const double ONE = 1.0;
-    const double ZERO = 0.0;
+    double ONE = 1.0;
+    double ZERO = 0.0;
 
     if (A == NULL || B == NULL)
     {
@@ -96,9 +96,9 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_multiply_x2_ellpack) (
-    const bml_matrix_ellpack_t * X,
+    bml_matrix_ellpack_t * X,
     bml_matrix_ellpack_t * X2,
-    const double threshold)
+    double threshold)
 {
     int *X_localRowMin = X->domain->localRowMin;
     int *X_localRowMax = X->domain->localRowMax;
@@ -232,10 +232,10 @@ void *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_AB_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold)
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -362,10 +362,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_adjust_AB_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
     bml_matrix_ellpack_t * C,
-    const double threshold)
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellsort/bml_multiply_ellsort.c
+++ b/src/C-interface/ellsort/bml_multiply_ellsort.c
@@ -25,12 +25,12 @@
  */
 void
 bml_multiply_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -66,9 +66,9 @@ bml_multiply_ellsort(
  */
 void *
 bml_multiply_x2_ellsort(
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold)
+    double threshold)
 {
     switch (X->matrix_precision)
     {
@@ -104,10 +104,10 @@ bml_multiply_x2_ellsort(
  */
 void
 bml_multiply_AB_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -142,10 +142,10 @@ bml_multiply_AB_ellsort(
  */
 void
 bml_multiply_adjust_AB_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_multiply_ellsort.h
+++ b/src/C-interface/ellsort/bml_multiply_ellsort.h
@@ -4,128 +4,128 @@
 #include "bml_types_ellsort.h"
 
 void bml_multiply_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void bml_multiply_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    double alpha,
+    double beta,
+    double threshold);
 
 void *bml_multiply_x2_ellsort(
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellsort_single_real(
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellsort_double_real(
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellsort_single_complex(
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold);
+    double threshold);
 
 void *bml_multiply_x2_ellsort_double_complex(
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_AB_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 void bml_multiply_adjust_AB_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold);
+    double threshold);
 
 #endif

--- a/src/C-interface/ellsort/bml_multiply_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_multiply_ellsort_typed.c
@@ -36,15 +36,15 @@
  */
 void TYPED_FUNC(
     bml_multiply_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    double alpha,
+    double beta,
+    double threshold)
 {
-    const double ONE = 1.0;
-    const double ZERO = 0.0;
+    double ONE = 1.0;
+    double ZERO = 0.0;
 
     if (A == NULL || B == NULL)
     {
@@ -96,9 +96,9 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_multiply_x2_ellsort) (
-    const bml_matrix_ellsort_t * X,
+    bml_matrix_ellsort_t * X,
     bml_matrix_ellsort_t * X2,
-    const double threshold)
+    double threshold)
 {
     int *X_localRowMin = X->domain->localRowMin;
     int *X_localRowMax = X->domain->localRowMax;
@@ -232,10 +232,10 @@ void *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_AB_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold)
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -363,10 +363,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_multiply_adjust_AB_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
     bml_matrix_ellsort_t * C,
-    const double threshold)
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_multiply` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/292)
<!-- Reviewable:end -->
