### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_normalize.c
+++ b/src/C-interface/bml_normalize.c
@@ -19,8 +19,8 @@
 void
 bml_normalize(
     bml_matrix_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     switch (bml_get_type(A))
     {
@@ -52,7 +52,7 @@ bml_normalize(
  */
 void *
 bml_gershgorin(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -86,8 +86,8 @@ bml_gershgorin(
  */
 void *
 bml_gershgorin_partial(
-    const bml_matrix_t * A,
-    const int nrows)
+    bml_matrix_t * A,
+    int nrows)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_normalize.h
+++ b/src/C-interface/bml_normalize.h
@@ -8,16 +8,16 @@
 // Normalize
 void bml_normalize(
     bml_matrix_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 // Calculate Gershgorin bounds
 void *bml_gershgorin(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 // Calcualte Gershgorin bounds for partial matrix
 void *bml_gershgorin_partial(
-    const bml_matrix_t * A,
-    const int nrows);
+    bml_matrix_t * A,
+    int nrows);
 
 #endif

--- a/src/C-interface/dense/bml_normalize_dense.c
+++ b/src/C-interface/dense/bml_normalize_dense.c
@@ -21,8 +21,8 @@
 void
 bml_normalize_dense(
     bml_matrix_dense_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     assert(A != NULL);
 
@@ -56,7 +56,7 @@ bml_normalize_dense(
  */
 void *
 bml_gershgorin_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     assert(A != NULL);
 
@@ -92,8 +92,8 @@ bml_gershgorin_dense(
  */
 void *
 bml_gershgorin_partial_dense(
-    const bml_matrix_dense_t * A,
-    const int nrows)
+    bml_matrix_dense_t * A,
+    int nrows)
 {
     assert(A != NULL);
 

--- a/src/C-interface/dense/bml_normalize_dense.h
+++ b/src/C-interface/dense/bml_normalize_dense.h
@@ -29,38 +29,38 @@ void bml_normalize_dense_double_complex(
     double maxeval);
 
 void *bml_gershgorin_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void *bml_gershgorin_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void *bml_gershgorin_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void *bml_gershgorin_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void *bml_gershgorin_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void *bml_gershgorin_partial_dense(
-    const bml_matrix_dense_t * A,
-    const int nrows);
+    bml_matrix_dense_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int nrows);
+    bml_matrix_dense_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int nrows);
+    bml_matrix_dense_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int nrows);
+    bml_matrix_dense_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int nrows);
+    bml_matrix_dense_t * A,
+    int nrows);
 
 #endif

--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -37,8 +37,8 @@
 void TYPED_FUNC(
     bml_normalize_dense) (
     bml_matrix_dense_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     double maxminusmin = maxeval - mineval;
     double beta = maxeval / maxminusmin;
@@ -57,7 +57,7 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     REAL_T radius, dvalue, absham;
 
@@ -146,8 +146,8 @@ void *TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_partial_dense) (
-    const bml_matrix_dense_t * A,
-    const int nrows)
+    bml_matrix_dense_t * A,
+    int nrows)
 {
     REAL_T radius, dvalue, absham;
 

--- a/src/C-interface/ellblock/bml_normalize_ellblock.c
+++ b/src/C-interface/ellblock/bml_normalize_ellblock.c
@@ -18,8 +18,8 @@
 void
 bml_normalize_ellblock(
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     switch (A->matrix_precision)
     {
@@ -51,7 +51,7 @@ bml_normalize_ellblock(
  */
 void *
 bml_gershgorin_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_normalize_ellblock.h
+++ b/src/C-interface/ellblock/bml_normalize_ellblock.h
@@ -5,42 +5,42 @@
 
 void bml_normalize_ellblock(
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void *bml_gershgorin_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void *bml_gershgorin_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void *bml_gershgorin_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void *bml_gershgorin_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void *bml_gershgorin_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 #endif

--- a/src/C-interface/ellblock/bml_normalize_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_normalize_ellblock_typed.c
@@ -33,8 +33,8 @@
 void TYPED_FUNC(
     bml_normalize_ellblock) (
     bml_matrix_ellblock_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     double maxminusmin = maxeval - mineval;
     double gershfact = maxeval / maxminusmin;
@@ -56,7 +56,7 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     double emin = DBL_MAX;
     double emax = DBL_MIN;

--- a/src/C-interface/ellpack/bml_normalize_ellpack.c
+++ b/src/C-interface/ellpack/bml_normalize_ellpack.c
@@ -18,8 +18,8 @@
 void
 bml_normalize_ellpack(
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     switch (A->matrix_precision)
     {
@@ -51,7 +51,7 @@ bml_normalize_ellpack(
  */
 void *
 bml_gershgorin_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     switch (A->matrix_precision)
     {
@@ -85,8 +85,8 @@ bml_gershgorin_ellpack(
  */
 void *
 bml_gershgorin_partial_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int nrows)
+    bml_matrix_ellpack_t * A,
+    int nrows)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_normalize_ellpack.h
+++ b/src/C-interface/ellpack/bml_normalize_ellpack.h
@@ -5,62 +5,62 @@
 
 void bml_normalize_ellpack(
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellpack_single_real(
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellpack_double_real(
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellpack_single_complex(
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellpack_double_complex(
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void *bml_gershgorin_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void *bml_gershgorin_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void *bml_gershgorin_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void *bml_gershgorin_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void *bml_gershgorin_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void *bml_gershgorin_partial_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int nrows);
+    bml_matrix_ellpack_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int nrows);
+    bml_matrix_ellpack_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int nrows);
+    bml_matrix_ellpack_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int nrows);
+    bml_matrix_ellpack_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int nrows);
+    bml_matrix_ellpack_t * A,
+    int nrows);
 
 #endif

--- a/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_normalize_ellpack_typed.c
@@ -32,8 +32,8 @@
 void TYPED_FUNC(
     bml_normalize_ellpack) (
     bml_matrix_ellpack_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     double maxminusmin = maxeval - mineval;
     double gershfact = maxeval / maxminusmin;
@@ -55,7 +55,7 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     REAL_T radius, absham, dvalue;
 
@@ -155,8 +155,8 @@ void *TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_partial_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const int nrows)
+    bml_matrix_ellpack_t * A,
+    int nrows)
 {
     REAL_T radius, absham, dvalue;
 

--- a/src/C-interface/ellsort/bml_normalize_ellsort.c
+++ b/src/C-interface/ellsort/bml_normalize_ellsort.c
@@ -18,8 +18,8 @@
 void
 bml_normalize_ellsort(
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     switch (A->matrix_precision)
     {
@@ -51,7 +51,7 @@ bml_normalize_ellsort(
  */
 void *
 bml_gershgorin_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     switch (A->matrix_precision)
     {
@@ -85,8 +85,8 @@ bml_gershgorin_ellsort(
  */
 void *
 bml_gershgorin_partial_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int nrows)
+    bml_matrix_ellsort_t * A,
+    int nrows)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_normalize_ellsort.h
+++ b/src/C-interface/ellsort/bml_normalize_ellsort.h
@@ -5,62 +5,62 @@
 
 void bml_normalize_ellsort(
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellsort_single_real(
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellsort_double_real(
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellsort_single_complex(
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void bml_normalize_ellsort_double_complex(
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval);
+    double mineval,
+    double maxeval);
 
 void *bml_gershgorin_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void *bml_gershgorin_ellsort_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void *bml_gershgorin_ellsort_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void *bml_gershgorin_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void *bml_gershgorin_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void *bml_gershgorin_partial_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int nrows);
+    bml_matrix_ellsort_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int nrows);
+    bml_matrix_ellsort_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int nrows);
+    bml_matrix_ellsort_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int nrows);
+    bml_matrix_ellsort_t * A,
+    int nrows);
 
 void *bml_gershgorin_partial_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int nrows);
+    bml_matrix_ellsort_t * A,
+    int nrows);
 
 #endif

--- a/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_normalize_ellsort_typed.c
@@ -32,8 +32,8 @@
 void TYPED_FUNC(
     bml_normalize_ellsort) (
     bml_matrix_ellsort_t * A,
-    const double mineval,
-    const double maxeval)
+    double mineval,
+    double maxeval)
 {
     double maxminusmin = maxeval - mineval;
     double gershfact = maxeval / maxminusmin;
@@ -55,7 +55,7 @@ void TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_ellsort) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     REAL_T radius, absham, dvalue;
 
@@ -153,8 +153,8 @@ void *TYPED_FUNC(
  */
 void *TYPED_FUNC(
     bml_gershgorin_partial_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const int nrows)
+    bml_matrix_ellsort_t * A,
+    int nrows)
 {
     REAL_T radius, absham, dvalue;
 


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_normalize`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/293)
<!-- Reviewable:end -->
