### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_norm.c
+++ b/src/C-interface/bml_norm.c
@@ -17,7 +17,7 @@
  */
 double
 bml_sum_squares(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -51,8 +51,8 @@ bml_sum_squares(
  */
 double
 bml_sum_squares_submatrix(
-    const bml_matrix_t * A,
-    const int core_size)
+    bml_matrix_t * A,
+    int core_size)
 {
     switch (bml_get_type(A))
     {
@@ -85,11 +85,11 @@ bml_sum_squares_submatrix(
  */
 double
 bml_sum_squares2(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -121,7 +121,7 @@ bml_sum_squares2(
  */
 double
 bml_fnorm(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -154,8 +154,8 @@ bml_fnorm(
  */
 double
 bml_fnorm2(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B)
+    bml_matrix_t * A,
+    bml_matrix_t * B)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_norm.h
+++ b/src/C-interface/bml_norm.h
@@ -7,30 +7,30 @@
 
 // Calculate the sum of squares of all the elements in A
 double bml_sum_squares(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 // Calculate the sum of squares of all the elements of
 // alpha * A + beta * B
 double bml_sum_squares2(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 // Calculate the sum of squares for submatrix core elements
 double bml_sum_squares_submatrix(
-    const bml_matrix_t * A,
-    const int core_size);
+    bml_matrix_t * A,
+    int core_size);
 
 // Calculate Frobenius norm for matrix A
 // sqrt(sum(A_ij*A_ij)
 double bml_fnorm(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 // Calculate Frobenius norm for 2 matrices
 double bml_fnorm2(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B);
+    bml_matrix_t * A,
+    bml_matrix_t * B);
 
 #endif

--- a/src/C-interface/dense/bml_norm_dense.c
+++ b/src/C-interface/dense/bml_norm_dense.c
@@ -19,7 +19,7 @@
  */
 double
 bml_sum_squares_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     switch (A->matrix_precision)
     {
@@ -53,8 +53,8 @@ bml_sum_squares_dense(
  */
 double
 bml_sum_squares_submatrix_dense(
-    const bml_matrix_dense_t * A,
-    const int core_size)
+    bml_matrix_dense_t * A,
+    int core_size)
 {
     switch (A->matrix_precision)
     {
@@ -93,11 +93,11 @@ bml_sum_squares_submatrix_dense(
  */
 double
 bml_sum_squares2_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -133,7 +133,7 @@ bml_sum_squares2_dense(
  */
 double
 bml_fnorm_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     switch (A->matrix_precision)
     {
@@ -166,8 +166,8 @@ bml_fnorm_dense(
  */
 double
 bml_fnorm2_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_norm_dense.h
+++ b/src/C-interface/dense/bml_norm_dense.h
@@ -4,108 +4,108 @@
 #include "bml_types_dense.h"
 
 double bml_sum_squares_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_sum_squares_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_sum_squares_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_sum_squares_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_sum_squares_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_sum_squares_submatrix_dense(
-    const bml_matrix_dense_t * A,
-    const int core_size);
+    bml_matrix_dense_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int core_size);
+    bml_matrix_dense_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int core_size);
+    bml_matrix_dense_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int core_size);
+    bml_matrix_dense_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int core_size);
+    bml_matrix_dense_t * A,
+    int core_size);
 
 double bml_sum_squares2_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_fnorm_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_fnorm_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_fnorm_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_fnorm_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_fnorm_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_fnorm2_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_fnorm2_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_fnorm2_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_fnorm2_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_fnorm2_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 #endif

--- a/src/C-interface/dense/bml_norm_dense_typed.c
+++ b/src/C-interface/dense/bml_norm_dense_typed.c
@@ -30,7 +30,7 @@
  */
 double TYPED_FUNC(
     bml_sum_squares_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     int N = A->N;
     REAL_T sum = 0.0;
@@ -90,8 +90,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares_submatrix_dense) (
-    const bml_matrix_dense_t * A,
-    const int core_size)
+    bml_matrix_dense_t * A,
+    int core_size)
 {
     int N = A->N;
 
@@ -160,11 +160,11 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares2_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int N = A->N;
 
@@ -230,7 +230,7 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     double sum = 0.0;
 //#ifdef BML_USE_MAGMA
@@ -263,8 +263,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm2_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B)
 {
     int N = A->N;
 

--- a/src/C-interface/ellblock/bml_norm_ellblock.c
+++ b/src/C-interface/ellblock/bml_norm_ellblock.c
@@ -16,7 +16,7 @@
  */
 double
 bml_sum_squares_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
 
     switch (A->matrix_precision)
@@ -53,11 +53,11 @@ bml_sum_squares_ellblock(
  */
 double
 bml_sum_squares2_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
 
     switch (A->matrix_precision)
@@ -94,7 +94,7 @@ bml_sum_squares2_ellblock(
  */
 double
 bml_fnorm_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
 
     switch (A->matrix_precision)
@@ -128,8 +128,8 @@ bml_fnorm_ellblock(
  */
 double
 bml_fnorm2_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellblock/bml_norm_ellblock.h
+++ b/src/C-interface/ellblock/bml_norm_ellblock.h
@@ -4,108 +4,108 @@
 #include "bml_types_ellblock.h"
 
 double bml_sum_squares_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_sum_squares_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_sum_squares_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_sum_squares_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_sum_squares_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_sum_squares_submatrix_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const int core_size);
+    bml_matrix_ellblock_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const int core_size);
+    bml_matrix_ellblock_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const int core_size);
+    bml_matrix_ellblock_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const int core_size);
+    bml_matrix_ellblock_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const int core_size);
+    bml_matrix_ellblock_t * A,
+    int core_size);
 
 double bml_sum_squares2_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_fnorm_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_fnorm_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_fnorm_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_fnorm_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_fnorm_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_fnorm2_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_fnorm2_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_fnorm2_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_fnorm2_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_fnorm2_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 #endif

--- a/src/C-interface/ellblock/bml_norm_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_norm_ellblock_typed.c
@@ -25,7 +25,7 @@
  */
 double TYPED_FUNC(
     bml_sum_squares_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     int NB = A->NB;
     int MB = A->MB;
@@ -69,11 +69,11 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares2_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int NB = A->NB;
     int MB = A->MB;
@@ -179,7 +179,7 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     double fnorm = TYPED_FUNC(bml_sum_squares_ellblock) (A);
 #ifdef DO_MPI
@@ -203,8 +203,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm2_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
     int NB = A->NB;
     int MB = A->MB;

--- a/src/C-interface/ellpack/bml_norm_ellpack.c
+++ b/src/C-interface/ellpack/bml_norm_ellpack.c
@@ -16,7 +16,7 @@
  */
 double
 bml_sum_squares_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
 
     switch (A->matrix_precision)
@@ -51,8 +51,8 @@ bml_sum_squares_ellpack(
  */
 double
 bml_sum_squares_submatrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int core_size)
+    bml_matrix_ellpack_t * A,
+    int core_size)
 {
     switch (A->matrix_precision)
     {
@@ -92,11 +92,11 @@ bml_sum_squares_submatrix_ellpack(
  */
 double
 bml_sum_squares2_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
 
     switch (A->matrix_precision)
@@ -133,7 +133,7 @@ bml_sum_squares2_ellpack(
  */
 double
 bml_fnorm_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
 
     switch (A->matrix_precision)
@@ -167,8 +167,8 @@ bml_fnorm_ellpack(
  */
 double
 bml_fnorm2_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellpack/bml_norm_ellpack.h
+++ b/src/C-interface/ellpack/bml_norm_ellpack.h
@@ -4,108 +4,108 @@
 #include "bml_types_ellpack.h"
 
 double bml_sum_squares_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_sum_squares_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_sum_squares_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_sum_squares_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_sum_squares_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_sum_squares_submatrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int core_size);
+    bml_matrix_ellpack_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int core_size);
+    bml_matrix_ellpack_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int core_size);
+    bml_matrix_ellpack_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int core_size);
+    bml_matrix_ellpack_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int core_size);
+    bml_matrix_ellpack_t * A,
+    int core_size);
 
 double bml_sum_squares2_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_fnorm_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_fnorm_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_fnorm_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_fnorm_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_fnorm_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_fnorm2_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_fnorm2_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_fnorm2_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_fnorm2_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_fnorm2_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 #endif

--- a/src/C-interface/ellpack/bml_norm_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_norm_ellpack_typed.c
@@ -24,7 +24,7 @@
  */
 double TYPED_FUNC(
     bml_sum_squares_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     int N = A->N;
     int M = A->M;
@@ -66,8 +66,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares_submatrix_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const int core_size)
+    bml_matrix_ellpack_t * A,
+    int core_size)
 {
     int N = A->N;
     int M = A->M;
@@ -109,11 +109,11 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares2_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -223,7 +223,7 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     double fnorm = TYPED_FUNC(bml_sum_squares_ellpack) (A);
 #ifdef DO_MPI
@@ -247,8 +247,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm2_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
     int N = A->N;
     int M = A->M;

--- a/src/C-interface/ellsort/bml_norm_ellsort.c
+++ b/src/C-interface/ellsort/bml_norm_ellsort.c
@@ -16,7 +16,7 @@
  */
 double
 bml_sum_squares_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
 
     switch (A->matrix_precision)
@@ -51,8 +51,8 @@ bml_sum_squares_ellsort(
  */
 double
 bml_sum_squares_submatrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int core_size)
+    bml_matrix_ellsort_t * A,
+    int core_size)
 {
     switch (A->matrix_precision)
     {
@@ -92,11 +92,11 @@ bml_sum_squares_submatrix_ellsort(
  */
 double
 bml_sum_squares2_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
 
     switch (A->matrix_precision)
@@ -133,7 +133,7 @@ bml_sum_squares2_ellsort(
  */
 double
 bml_fnorm_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
 
     switch (A->matrix_precision)
@@ -167,8 +167,8 @@ bml_fnorm_ellsort(
  */
 double
 bml_fnorm2_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellsort/bml_norm_ellsort.h
+++ b/src/C-interface/ellsort/bml_norm_ellsort.h
@@ -4,108 +4,108 @@
 #include "bml_types_ellsort.h"
 
 double bml_sum_squares_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_sum_squares_ellsort_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_sum_squares_ellsort_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_sum_squares_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_sum_squares_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_sum_squares_submatrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int core_size);
+    bml_matrix_ellsort_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int core_size);
+    bml_matrix_ellsort_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int core_size);
+    bml_matrix_ellsort_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int core_size);
+    bml_matrix_ellsort_t * A,
+    int core_size);
 
 double bml_sum_squares_submatrix_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int core_size);
+    bml_matrix_ellsort_t * A,
+    int core_size);
 
 double bml_sum_squares2_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_sum_squares2_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold);
 
 double bml_fnorm_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_fnorm_ellsort_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_fnorm_ellsort_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_fnorm_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_fnorm_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_fnorm2_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_fnorm2_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_fnorm2_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_fnorm2_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_fnorm2_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 #endif

--- a/src/C-interface/ellsort/bml_norm_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_norm_ellsort_typed.c
@@ -24,7 +24,7 @@
  */
 double TYPED_FUNC(
     bml_sum_squares_ellsort) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     int N = A->N;
     int M = A->M;
@@ -67,8 +67,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares_submatrix_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const int core_size)
+    bml_matrix_ellsort_t * A,
+    int core_size)
 {
     int N = A->N;
     int M = A->M;
@@ -110,11 +110,11 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_sum_squares2_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const double alpha,
-    const double beta,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    double alpha,
+    double beta,
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -225,7 +225,7 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm_ellsort) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     double fnorm = TYPED_FUNC(bml_sum_squares_ellsort) (A);
 #ifdef DO_MPI
@@ -249,8 +249,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_fnorm2_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
     int N = A->N;
     int M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_norm` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/294)
<!-- Reviewable:end -->
