### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_scale.c
+++ b/src/C-interface/bml_scale.c
@@ -18,8 +18,8 @@
  */
 bml_matrix_t *
 bml_scale_new(
-    const void *scale_factor,
-    const bml_matrix_t * A)
+    void *scale_factor,
+    bml_matrix_t * A)
 {
     bml_matrix_t *B = NULL;
 
@@ -54,8 +54,8 @@ bml_scale_new(
  */
 void
 bml_scale(
-    const void *scale_factor,
-    const bml_matrix_t * A,
+    void *scale_factor,
+    bml_matrix_t * A,
     bml_matrix_t * B)
 {
     switch (bml_get_type(A))
@@ -87,7 +87,7 @@ bml_scale(
  */
 void
 bml_scale_inplace(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_t * A)
 {
     switch (bml_get_type(A))

--- a/src/C-interface/bml_scale.h
+++ b/src/C-interface/bml_scale.h
@@ -6,16 +6,16 @@
 #include "bml_types.h"
 
 bml_matrix_t *bml_scale_new(
-    const void *scale_factor,
-    const bml_matrix_t * A);
+    void *scale_factor,
+    bml_matrix_t * A);
 
 void bml_scale(
-    const void *scale_factor,
-    const bml_matrix_t * A,
+    void *scale_factor,
+    bml_matrix_t * A,
     bml_matrix_t * B);
 
 void bml_scale_inplace(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_t * A);
 
 #endif

--- a/src/C-interface/dense/bml_scale_dense.c
+++ b/src/C-interface/dense/bml_scale_dense.c
@@ -20,8 +20,8 @@
  */
 bml_matrix_dense_t *
 bml_scale_dense_new(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A)
+    void *scale_factor,
+    bml_matrix_dense_t * A)
 {
     bml_matrix_dense_t *B = NULL;
 
@@ -57,8 +57,8 @@ bml_scale_dense_new(
  */
 void
 bml_scale_dense(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A,
+    void *scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B)
 {
     assert(A != NULL);
@@ -85,7 +85,7 @@ bml_scale_dense(
 
 void
 bml_scale_inplace_dense(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_dense_t * A)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/dense/bml_scale_dense.h
+++ b/src/C-interface/dense/bml_scale_dense.h
@@ -6,68 +6,68 @@
 #include <complex.h>
 
 bml_matrix_dense_t *bml_scale_dense_new(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A);
+    void *scale_factor,
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_scale_dense_new_single_real(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A);
+    void *scale_factor,
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_scale_dense_new_double_real(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A);
+    void *scale_factor,
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_scale_dense_new_single_complex(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A);
+    void *scale_factor,
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_scale_dense_new_double_complex(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A);
+    void *scale_factor,
+    bml_matrix_dense_t * A);
 
 void bml_scale_dense(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A,
+    void *scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_scale_dense_single_real(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A,
+    void *scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_scale_dense_double_real(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A,
+    void *scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_scale_dense_single_complex(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A,
+    void *scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_scale_dense_double_complex(
-    const void *scale_factor,
-    const bml_matrix_dense_t * A,
+    void *scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B);
 
 void bml_scale_inplace_dense(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_dense_t * A);
 
 void bml_scale_inplace_dense_single_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_dense_t * A);
 
 void bml_scale_inplace_dense_double_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_dense_t * A);
 
 void bml_scale_inplace_dense_single_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_dense_t * A);
 
 void bml_scale_inplace_dense_double_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_dense_t * A);
 
 #endif

--- a/src/C-interface/dense/bml_scale_dense_typed.c
+++ b/src/C-interface/dense/bml_scale_dense_typed.c
@@ -31,11 +31,11 @@
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_scale_dense_new) (
-    const void *_scale_factor,
-    const bml_matrix_dense_t * A)
+    void *_scale_factor,
+    bml_matrix_dense_t * A)
 {
     bml_matrix_dense_t *B = TYPED_FUNC(bml_copy_dense_new) (A);
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T *B_matrix = B->matrix;
     int myRank = bml_getMyRank();
     int nElems = B->domain->localRowExtent[myRank] * B->ld;
@@ -65,8 +65,8 @@ bml_matrix_dense_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_dense) (
-    const void *_scale_factor,
-    const bml_matrix_dense_t * A,
+    void *_scale_factor,
+    bml_matrix_dense_t * A,
     bml_matrix_dense_t * B)
 {
     if (A != B)
@@ -74,7 +74,7 @@ void TYPED_FUNC(
         TYPED_FUNC(bml_copy_dense) (A, B);
     }
 
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T *B_matrix = B->matrix;
     int myRank = bml_getMyRank();
     int nElems = B->domain->localRowExtent[myRank] * B->ld;
@@ -96,11 +96,11 @@ void TYPED_FUNC(
 
 void TYPED_FUNC(
     bml_scale_inplace_dense) (
-    const void *_scale_factor,
+    void *_scale_factor,
     bml_matrix_dense_t * A)
 {
     REAL_T *A_matrix = A->matrix;
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     int myRank = bml_getMyRank();
     int number_elements = A->domain->localRowExtent[myRank] * A->ld;
     int startIndex = A->domain->localDispl[myRank];

--- a/src/C-interface/ellblock/bml_scale_ellblock.c
+++ b/src/C-interface/ellblock/bml_scale_ellblock.c
@@ -16,8 +16,8 @@
  */
 bml_matrix_ellblock_t *
 bml_scale_ellblock_new(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A)
+    void *scale_factor,
+    bml_matrix_ellblock_t * A)
 {
     bml_matrix_ellblock_t *B = NULL;
 
@@ -51,9 +51,9 @@ bml_scale_ellblock_new(
  */
 void
 bml_scale_ellblock(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    void *scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
     switch (A->matrix_precision)
     {
@@ -77,7 +77,7 @@ bml_scale_ellblock(
 
 void
 bml_scale_inplace_ellblock(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/ellblock/bml_scale_ellblock.h
+++ b/src/C-interface/ellblock/bml_scale_ellblock.h
@@ -6,68 +6,68 @@
 #include <complex.h>
 
 bml_matrix_ellblock_t *bml_scale_ellblock_new(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_scale_ellblock_new_single_real(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_scale_ellblock_new_double_real(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_scale_ellblock_new_single_complex(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_scale_ellblock_new_double_complex(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A);
 
 void bml_scale_ellblock(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_scale_ellblock_single_real(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_scale_ellblock_double_real(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_scale_ellblock_single_complex(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_scale_ellblock_double_complex(
-    const void *scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    void *scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 void bml_scale_inplace_ellblock(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A);
 
 void bml_scale_inplace_ellblock_single_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A);
 
 void bml_scale_inplace_ellblock_double_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A);
 
 void bml_scale_inplace_ellblock_single_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A);
 
 void bml_scale_inplace_ellblock_double_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A);
 
 #endif

--- a/src/C-interface/ellblock/bml_scale_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_scale_ellblock_typed.c
@@ -28,10 +28,10 @@
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_scale_ellblock_new) (
-    const void *_scale_factor,
-    const bml_matrix_ellblock_t * A)
+    void *_scale_factor,
+    bml_matrix_ellblock_t * A)
 {
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     bml_matrix_ellblock_t *B = TYPED_FUNC(bml_copy_ellblock_new) (A);
 
     TYPED_FUNC(bml_scale_ellblock) (scale_factor, A, B);
@@ -48,9 +48,9 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_ellblock) (
-    const void *_scale_factor,
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    void *_scale_factor,
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
 #ifdef NOBLAS
     LOG_ERROR("No BLAS library");
@@ -60,7 +60,7 @@ void TYPED_FUNC(
         TYPED_FUNC(bml_copy_ellblock) (A, B);
     }
 
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T **B_ptr_value = (REAL_T **) B->ptr_value;
     int inc = 1;
 
@@ -83,7 +83,7 @@ void TYPED_FUNC(
 
 void TYPED_FUNC(
     bml_scale_inplace_ellblock) (
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellblock_t * A)
 {
     TYPED_FUNC(bml_scale_ellblock) (scale_factor, A, A);

--- a/src/C-interface/ellpack/bml_scale_ellpack.c
+++ b/src/C-interface/ellpack/bml_scale_ellpack.c
@@ -16,8 +16,8 @@
  */
 bml_matrix_ellpack_t *
 bml_scale_ellpack_new(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A)
+    void *scale_factor,
+    bml_matrix_ellpack_t * A)
 {
     bml_matrix_ellpack_t *B = NULL;
 
@@ -51,9 +51,9 @@ bml_scale_ellpack_new(
  */
 void
 bml_scale_ellpack(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    void *scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
     switch (A->matrix_precision)
     {
@@ -77,7 +77,7 @@ bml_scale_ellpack(
 
 void
 bml_scale_inplace_ellpack(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellpack_t * A)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/ellpack/bml_scale_ellpack.h
+++ b/src/C-interface/ellpack/bml_scale_ellpack.h
@@ -6,68 +6,68 @@
 #include <complex.h>
 
 bml_matrix_ellpack_t *bml_scale_ellpack_new(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_scale_ellpack_new_single_real(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_scale_ellpack_new_double_real(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_scale_ellpack_new_single_complex(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_scale_ellpack_new_double_complex(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A);
 
 void bml_scale_ellpack(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_scale_ellpack_single_real(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_scale_ellpack_double_real(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_scale_ellpack_single_complex(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_scale_ellpack_double_complex(
-    const void *scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    void *scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 void bml_scale_inplace_ellpack(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellpack_t * A);
 
 void bml_scale_inplace_ellpack_single_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellpack_t * A);
 
 void bml_scale_inplace_ellpack_double_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellpack_t * A);
 
 void bml_scale_inplace_ellpack_single_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellpack_t * A);
 
 void bml_scale_inplace_ellpack_double_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellpack_t * A);
 
 #endif

--- a/src/C-interface/ellpack/bml_scale_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_scale_ellpack_typed.c
@@ -26,10 +26,10 @@
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_scale_ellpack_new) (
-    const void *_scale_factor,
-    const bml_matrix_ellpack_t * A)
+    void *_scale_factor,
+    bml_matrix_ellpack_t * A)
 {
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     bml_matrix_ellpack_t *B = TYPED_FUNC(bml_copy_ellpack_new) (A);
 
     REAL_T *B_value = B->value;
@@ -56,16 +56,16 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_ellpack) (
-    const void *_scale_factor,
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    void *_scale_factor,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
     if (A != B)
     {
         TYPED_FUNC(bml_copy_ellpack) (A, B);
     }
 
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T *B_value = B->value;
     int myRank = bml_getMyRank();
     int nElems = B->domain->localRowExtent[myRank] * B->M;
@@ -82,10 +82,10 @@ void TYPED_FUNC(
 
 void TYPED_FUNC(
     bml_scale_inplace_ellpack) (
-    const void *_scale_factor,
+    void *_scale_factor,
     bml_matrix_ellpack_t * A)
 {
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T *A_value = A->value;
 
     int myRank = bml_getMyRank();

--- a/src/C-interface/ellsort/bml_scale_ellsort.c
+++ b/src/C-interface/ellsort/bml_scale_ellsort.c
@@ -16,8 +16,8 @@
  */
 bml_matrix_ellsort_t *
 bml_scale_ellsort_new(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A)
+    void *scale_factor,
+    bml_matrix_ellsort_t * A)
 {
     bml_matrix_ellsort_t *B = NULL;
 
@@ -51,9 +51,9 @@ bml_scale_ellsort_new(
  */
 void
 bml_scale_ellsort(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    void *scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
     switch (A->matrix_precision)
     {
@@ -77,7 +77,7 @@ bml_scale_ellsort(
 
 void
 bml_scale_inplace_ellsort(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellsort_t * A)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/ellsort/bml_scale_ellsort.h
+++ b/src/C-interface/ellsort/bml_scale_ellsort.h
@@ -6,68 +6,68 @@
 #include <complex.h>
 
 bml_matrix_ellsort_t *bml_scale_ellsort_new(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_scale_ellsort_new_single_real(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_scale_ellsort_new_double_real(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_scale_ellsort_new_single_complex(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_scale_ellsort_new_double_complex(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A);
 
 void bml_scale_ellsort(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_scale_ellsort_single_real(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_scale_ellsort_double_real(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_scale_ellsort_single_complex(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_scale_ellsort_double_complex(
-    const void *scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    void *scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 void bml_scale_inplace_ellsort(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellsort_t * A);
 
 void bml_scale_inplace_ellsort_single_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellsort_t * A);
 
 void bml_scale_inplace_ellsort_double_real(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellsort_t * A);
 
 void bml_scale_inplace_ellsort_single_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellsort_t * A);
 
 void bml_scale_inplace_ellsort_double_complex(
-    const void *scale_factor,
+    void *scale_factor,
     bml_matrix_ellsort_t * A);
 
 #endif

--- a/src/C-interface/ellsort/bml_scale_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_scale_ellsort_typed.c
@@ -26,10 +26,10 @@
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_scale_ellsort_new) (
-    const void *_scale_factor,
-    const bml_matrix_ellsort_t * A)
+    void *_scale_factor,
+    bml_matrix_ellsort_t * A)
 {
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     bml_matrix_ellsort_t *B = TYPED_FUNC(bml_copy_ellsort_new) (A);
 
     REAL_T *B_value = B->value;
@@ -56,16 +56,16 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_scale_ellsort) (
-    const void *_scale_factor,
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    void *_scale_factor,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
     if (A != B)
     {
         TYPED_FUNC(bml_copy_ellsort) (A, B);
     }
 
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T *B_value = B->value;
     int myRank = bml_getMyRank();
     int nElems = B->domain->localRowExtent[myRank] * B->M;
@@ -82,10 +82,10 @@ void TYPED_FUNC(
 
 void TYPED_FUNC(
     bml_scale_inplace_ellsort) (
-    const void *_scale_factor,
+    void *_scale_factor,
     bml_matrix_ellsort_t * A)
 {
-    const REAL_T *scale_factor = _scale_factor;
+    REAL_T *scale_factor = _scale_factor;
     REAL_T *A_value = A->value;
 
     int myRank = bml_getMyRank();


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_scale` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/295)
<!-- Reviewable:end -->
