### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_setters.c
+++ b/src/C-interface/bml_setters.c
@@ -9,9 +9,9 @@
 void
 bml_set_element_new(
     bml_matrix_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_type(A))
     {
@@ -37,9 +37,9 @@ bml_set_element_new(
 void
 bml_set_element(
     bml_matrix_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_type(A))
     {
@@ -64,9 +64,9 @@ bml_set_element(
 void
 bml_set_row(
     bml_matrix_t * A,
-    const int i,
-    const void *row,
-    const double threshold)
+    int i,
+    void *row,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -91,8 +91,8 @@ bml_set_row(
 void
 bml_set_diagonal(
     bml_matrix_t * A,
-    const void *diagonal,
-    const double threshold)
+    void *diagonal,
+    double threshold)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_setters.h
+++ b/src/C-interface/bml_setters.h
@@ -7,25 +7,25 @@
 
 void bml_set_element_new(
     bml_matrix_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element(
     bml_matrix_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_row(
     bml_matrix_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_diagonal(
     bml_matrix_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_setters_dense.c
+++ b/src/C-interface/dense/bml_setters_dense.c
@@ -6,9 +6,9 @@
 void
 bml_set_element_dense(
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -33,8 +33,8 @@ bml_set_element_dense(
 void
 bml_set_row_dense(
     bml_matrix_dense_t * A,
-    const int i,
-    const void *row)
+    int i,
+    void *row)
 {
     switch (bml_get_precision(A))
     {
@@ -64,7 +64,7 @@ bml_set_row_dense(
 void
 bml_set_diagonal_dense(
     bml_matrix_dense_t * A,
-    const void *diagonal)
+    void *diagonal)
 {
     switch (bml_get_precision(A))
     {

--- a/src/C-interface/dense/bml_setters_dense.h
+++ b/src/C-interface/dense/bml_setters_dense.h
@@ -9,77 +9,77 @@
 
 void bml_set_element_dense(
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_dense_single_real(
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_dense_double_real(
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_dense_single_complex(
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_dense_double_complex(
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_row_dense(
     bml_matrix_dense_t * A,
-    const int i,
-    const void *row);
+    int i,
+    void *row);
 
 void bml_set_row_dense_single_real(
     bml_matrix_dense_t * A,
-    const int i,
-    const void *row);
+    int i,
+    void *row);
 
 void bml_set_row_dense_double_real(
     bml_matrix_dense_t * A,
-    const int i,
-    const void *row);
+    int i,
+    void *row);
 
 void bml_set_row_dense_single_complex(
     bml_matrix_dense_t * A,
-    const int i,
-    const void *row);
+    int i,
+    void *row);
 
 void bml_set_row_dense_double_complex(
     bml_matrix_dense_t * A,
-    const int i,
-    const void *row);
+    int i,
+    void *row);
 
 void bml_set_diagonal_dense(
     bml_matrix_dense_t * A,
-    const void *diagonal);
+    void *diagonal);
 
 void bml_set_diagonal_dense_single_real(
     bml_matrix_dense_t * A,
-    const void *diagonal);
+    void *diagonal);
 
 void bml_set_diagonal_dense_double_real(
     bml_matrix_dense_t * A,
-    const void *diagonal);
+    void *diagonal);
 
 void bml_set_diagonal_dense_single_complex(
     bml_matrix_dense_t * A,
-    const void *diagonal);
+    void *diagonal);
 
 void bml_set_diagonal_dense_double_complex(
     bml_matrix_dense_t * A,
-    const void *diagonal);
+    void *diagonal);
 
 #endif

--- a/src/C-interface/dense/bml_setters_dense_typed.c
+++ b/src/C-interface/dense/bml_setters_dense_typed.c
@@ -16,9 +16,9 @@
 void TYPED_FUNC(
     bml_set_element_dense) (
     bml_matrix_dense_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     int N = bml_get_N(A);
 
@@ -34,10 +34,10 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_row_dense) (
     bml_matrix_dense_t * A,
-    const int i,
-    const void *_row)
+    int i,
+    void *_row)
 {
-    const REAL_T *row = _row;
+    REAL_T *row = _row;
     int N = bml_get_N(A);
 
     if (N < 0)
@@ -60,9 +60,9 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_diagonal_dense) (
     bml_matrix_dense_t * A,
-    const void *_diagonal)
+    void *_diagonal)
 {
-    const REAL_T *diagonal = _diagonal;
+    REAL_T *diagonal = _diagonal;
     int N = bml_get_N(A);
 
     if (N < 0)

--- a/src/C-interface/ellblock/bml_setters_ellblock.c
+++ b/src/C-interface/ellblock/bml_setters_ellblock.c
@@ -7,9 +7,9 @@
 void
 bml_set_element_new_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -35,9 +35,9 @@ bml_set_element_new_ellblock(
 void
 bml_set_element_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -62,9 +62,9 @@ bml_set_element_ellblock(
 void
 bml_set_row_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *row,
-    const double threshold)
+    int i,
+    void *row,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -89,8 +89,8 @@ bml_set_row_ellblock(
 void
 bml_set_diagonal_ellblock(
     bml_matrix_ellblock_t * A,
-    const void *diagonal,
-    const double threshold)
+    void *diagonal,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -115,9 +115,9 @@ bml_set_diagonal_ellblock(
 void
 bml_set_block_ellblock(
     bml_matrix_ellblock_t * A,
-    const int ib,
-    const int jb,
-    const void *values)
+    int ib,
+    int jb,
+    void *values)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_setters_ellblock.h
+++ b/src/C-interface/ellblock/bml_setters_ellblock.h
@@ -9,141 +9,141 @@
 
 void bml_set_element_new_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_row_ellblock(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_diagonal_ellblock(
     bml_matrix_ellblock_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_block_ellblock_single_real(
     bml_matrix_ellblock_t * A,
-    const int ib,
-    const int jb,
-    const void *values);
+    int ib,
+    int jb,
+    void *values);
 
 void bml_set_block_ellblock_double_real(
     bml_matrix_ellblock_t * A,
-    const int ib,
-    const int jb,
-    const void *values);
+    int ib,
+    int jb,
+    void *values);
 
 void bml_set_block_ellblock_single_complex(
     bml_matrix_ellblock_t * A,
-    const int ib,
-    const int jb,
-    const void *values);
+    int ib,
+    int jb,
+    void *values);
 
 void bml_set_block_ellblock_double_complex(
     bml_matrix_ellblock_t * A,
-    const int ib,
-    const int jb,
-    const void *values);
+    int ib,
+    int jb,
+    void *values);
 
 #endif

--- a/src/C-interface/ellblock/bml_setters_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_setters_ellblock_typed.c
@@ -30,11 +30,11 @@
 void TYPED_FUNC(
     bml_set_element_new_ellblock) (
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *_element)
+    int i,
+    int j,
+    void *_element)
 {
-    const REAL_T *element = _element;
+    REAL_T *element = _element;
     REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
     int *A_indexb = A->indexb;
     int *A_nnzb = A->nnzb;
@@ -95,9 +95,9 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_element_ellblock) (
     bml_matrix_ellblock_t * A,
-    const int i,
-    const int j,
-    const void *element)
+    int i,
+    int j,
+    void *element)
 {
     TYPED_FUNC(bml_set_element_new_ellblock) (A, i, j, element);
 }
@@ -115,11 +115,11 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_row_ellblock) (
     bml_matrix_ellblock_t * A,
-    const int i,
-    const void *_row,
-    const double threshold)
+    int i,
+    void *_row,
+    double threshold)
 {
-    const REAL_T *row = _row;
+    REAL_T *row = _row;
     int A_N = A->N;
 
     REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
@@ -191,10 +191,10 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_diagonal_ellblock) (
     bml_matrix_ellblock_t * A,
-    const void *_diagonal,
-    const double threshold)
+    void *_diagonal,
+    double threshold)
 {
-    const REAL_T *diagonal = _diagonal;
+    REAL_T *diagonal = _diagonal;
     int A_NB = A->NB;
     int A_MB = A->MB;
 
@@ -268,14 +268,14 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_block_ellblock) (
     bml_matrix_ellblock_t * A,
-    const int ib,
-    const int jb,
-    const void *_elements)
+    int ib,
+    int jb,
+    void *_elements)
 {
     assert(ib < A->NB);
     assert(jb < A->NB);
 
-    const REAL_T *elements = _elements;
+    REAL_T *elements = _elements;
 
     int data_copied = 0;
     for (int jp = 0; jp < A->nnzb[ib]; jp++)

--- a/src/C-interface/ellpack/bml_setters_ellpack.c
+++ b/src/C-interface/ellpack/bml_setters_ellpack.c
@@ -7,9 +7,9 @@
 void
 bml_set_element_new_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -35,9 +35,9 @@ bml_set_element_new_ellpack(
 void
 bml_set_element_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -62,9 +62,9 @@ bml_set_element_ellpack(
 void
 bml_set_row_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *row,
-    const double threshold)
+    int i,
+    void *row,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -89,8 +89,8 @@ bml_set_row_ellpack(
 void
 bml_set_diagonal_ellpack(
     bml_matrix_ellpack_t * A,
-    const void *diagonal,
-    const double threshold)
+    void *diagonal,
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_setters_ellpack.h
+++ b/src/C-interface/ellpack/bml_setters_ellpack.h
@@ -9,117 +9,117 @@
 
 void bml_set_element_new_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellpack_single_real(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellpack_double_real(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellpack_single_complex(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellpack_double_complex(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellpack_single_real(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellpack_double_real(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellpack_single_complex(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellpack_double_complex(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_row_ellpack(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellpack_single_real(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellpack_double_real(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellpack_single_complex(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellpack_double_complex(
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_diagonal_ellpack(
     bml_matrix_ellpack_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellpack_single_real(
     bml_matrix_ellpack_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellpack_double_real(
     bml_matrix_ellpack_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellpack_single_complex(
     bml_matrix_ellpack_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellpack_double_complex(
     bml_matrix_ellpack_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_setters_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_setters_ellpack_typed.c
@@ -26,9 +26,9 @@
 void TYPED_FUNC(
     bml_set_element_new_ellpack) (
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *element)
+    int i,
+    int j,
+    void *element)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -62,9 +62,9 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_element_ellpack) (
     bml_matrix_ellpack_t * A,
-    const int i,
-    const int j,
-    const void *element)
+    int i,
+    int j,
+    void *element)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -115,11 +115,11 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_row_ellpack) (
     bml_matrix_ellpack_t * A,
-    const int i,
-    const void *_row,
-    const double threshold)
+    int i,
+    void *_row,
+    double threshold)
 {
-    const REAL_T *row = _row;
+    REAL_T *row = _row;
     int A_N = A->N;
     int A_M = A->M;
 
@@ -156,10 +156,10 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_diagonal_ellpack) (
     bml_matrix_ellpack_t * A,
-    const void *_diagonal,
-    const double threshold)
+    void *_diagonal,
+    double threshold)
 {
-    const REAL_T *diagonal = _diagonal;
+    REAL_T *diagonal = _diagonal;
     int A_N = A->N;
     int A_M = A->M;
 

--- a/src/C-interface/ellsort/bml_setters_ellsort.c
+++ b/src/C-interface/ellsort/bml_setters_ellsort.c
@@ -7,9 +7,9 @@
 void
 bml_set_element_new_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -35,9 +35,9 @@ bml_set_element_new_ellsort(
 void
 bml_set_element_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value)
+    int i,
+    int j,
+    void *value)
 {
     switch (bml_get_precision(A))
     {
@@ -62,9 +62,9 @@ bml_set_element_ellsort(
 void
 bml_set_row_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *row,
-    const double threshold)
+    int i,
+    void *row,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -89,8 +89,8 @@ bml_set_row_ellsort(
 void
 bml_set_diagonal_ellsort(
     bml_matrix_ellsort_t * A,
-    const void *diagonal,
-    const double threshold)
+    void *diagonal,
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_setters_ellsort.h
+++ b/src/C-interface/ellsort/bml_setters_ellsort.h
@@ -9,117 +9,117 @@
 
 void bml_set_element_new_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellsort_single_real(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellsort_double_real(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellsort_single_complex(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_new_ellsort_double_complex(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellsort_single_real(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellsort_double_real(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellsort_single_complex(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_element_ellsort_double_complex(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *value);
+    int i,
+    int j,
+    void *value);
 
 void bml_set_row_ellsort(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellsort_single_real(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellsort_double_real(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellsort_single_complex(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_row_ellsort_double_complex(
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *row,
-    const double threshold);
+    int i,
+    void *row,
+    double threshold);
 
 void bml_set_diagonal_ellsort(
     bml_matrix_ellsort_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellsort_single_real(
     bml_matrix_ellsort_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellsort_double_real(
     bml_matrix_ellsort_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellsort_single_complex(
     bml_matrix_ellsort_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 void bml_set_diagonal_ellsort_double_complex(
     bml_matrix_ellsort_t * A,
-    const void *diagonal,
-    const double threshold);
+    void *diagonal,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellsort/bml_setters_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_setters_ellsort_typed.c
@@ -26,9 +26,9 @@
 void TYPED_FUNC(
     bml_set_element_new_ellsort) (
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *element)
+    int i,
+    int j,
+    void *element)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -62,9 +62,9 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_element_ellsort) (
     bml_matrix_ellsort_t * A,
-    const int i,
-    const int j,
-    const void *element)
+    int i,
+    int j,
+    void *element)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -115,11 +115,11 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_row_ellsort) (
     bml_matrix_ellsort_t * A,
-    const int i,
-    const void *_row,
-    const double threshold)
+    int i,
+    void *_row,
+    double threshold)
 {
-    const REAL_T *row = _row;
+    REAL_T *row = _row;
 
     int A_N = A->N;
     int A_M = A->M;
@@ -158,10 +158,10 @@ void TYPED_FUNC(
 void TYPED_FUNC(
     bml_set_diagonal_ellsort) (
     bml_matrix_ellsort_t * A,
-    const void *_diagonal,
-    const double threshold)
+    void *_diagonal,
+    double threshold)
 {
-    const REAL_T *diagonal = _diagonal;
+    REAL_T *diagonal = _diagonal;
 
     int A_N = A->N;
     int A_M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_setters` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/296)
<!-- Reviewable:end -->
