### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_submatrix.c
+++ b/src/C-interface/bml_submatrix.c
@@ -21,13 +21,13 @@
  */
 void
 bml_matrix2submatrix_index(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     switch (bml_get_type(A))
     {
@@ -68,12 +68,12 @@ bml_matrix2submatrix_index(
  */
 void
 bml_matrix2submatrix_index_graph(
-    const bml_matrix_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     switch (bml_get_type(B))
     {
@@ -112,10 +112,10 @@ bml_matrix2submatrix_index_graph(
  */
 bml_matrix_t *
 bml_group_matrix(
-    const bml_matrix_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold)
+    bml_matrix_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -150,10 +150,10 @@ bml_group_matrix(
  */
 void
 bml_matrix2submatrix(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     bml_matrix_t * B,
-    const int *core_halo_index,
-    const int lsize)
+    int *core_halo_index,
+    int lsize)
 {
     switch (bml_get_type(A))
     {
@@ -188,12 +188,12 @@ bml_matrix2submatrix(
  */
 void
 bml_submatrix2matrix(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     bml_matrix_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold)
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold)
 {
     switch (bml_get_type(B))
     {
@@ -230,10 +230,10 @@ bml_submatrix2matrix(
 */
 void
 bml_adjacency(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     int *xadj,
     int *adjncy,
-    const int base_flag)
+    int base_flag)
 {
 
     switch (bml_get_type(A))
@@ -270,12 +270,12 @@ bml_adjacency(
  */
 void
 bml_adjacency_group(
-    const bml_matrix_t * A,
-    const int *hindex,
-    const int nnodes,
+    bml_matrix_t * A,
+    int *hindex,
+    int nnodes,
     int *xadj,
     int *adjncy,
-    const int base_flag)
+    int base_flag)
 {
 
     switch (bml_get_type(A))

--- a/src/C-interface/bml_submatrix.h
+++ b/src/C-interface/bml_submatrix.h
@@ -7,60 +7,60 @@
 
 // Determine element indeces for submatrix, given a set of nodes.
 void bml_matrix2submatrix_index(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 // Determine core+halo indeces from graph only
 void bml_matrix2submatrix_index_graph(
-    const bml_matrix_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 // Create contracted submatrix from a set of element indeces.
 void bml_matrix2submatrix(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     bml_matrix_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 // Assemble a contracted submatrix into the final matrix.
 void bml_submatrix2matrix(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     bml_matrix_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 // Return adjacency based on rows
 void bml_adjacency(
-    const bml_matrix_t * A,
+    bml_matrix_t * A,
     int *xadj,
     int *adjncy,
-    const int base_flag);
+    int base_flag);
 
 // Return adjacency based on groups of rows (ex. atom)
 void bml_adjacency_group(
-    const bml_matrix_t * A,
-    const int *hindex,
-    const int nnodes,
+    bml_matrix_t * A,
+    int *hindex,
+    int nnodes,
     int *xadj,
     int *adjncy,
-    const int base_flag);
+    int base_flag);
 
 // Return a group-based matrix from a matrix
 bml_matrix_t *bml_group_matrix(
-    const bml_matrix_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_submatrix_ellpack.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack.c
@@ -29,13 +29,13 @@
  */
 void
 bml_matrix2submatrix_index_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     switch (A->matrix_precision)
     {
@@ -86,12 +86,12 @@ bml_matrix2submatrix_index_ellpack(
  */
 void
 bml_matrix2submatrix_index_graph_ellpack(
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     switch (B->matrix_precision)
     {
@@ -142,10 +142,10 @@ bml_matrix2submatrix_index_graph_ellpack(
  */
 void
 bml_matrix2submatrix_ellpack(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize)
+    int *core_halo_index,
+    int lsize)
 {
     switch (A->matrix_precision)
     {
@@ -184,12 +184,12 @@ bml_matrix2submatrix_ellpack(
  */
 void
 bml_submatrix2matrix_ellpack(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold)
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -231,10 +231,10 @@ bml_submatrix2matrix_ellpack(
  */
 void *
 bml_getVector_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt)
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt)
 {
     switch (A->matrix_precision)
     {
@@ -268,10 +268,10 @@ bml_getVector_ellpack(
  */
 bml_matrix_ellpack_t *
 bml_group_matrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -300,8 +300,8 @@ bml_group_matrix_ellpack(
 
 int
 sortById(
-    const void *a,
-    const void *b)
+    void *a,
+    void *b)
 {
     int aId = *((int *) a);
     int bId = *((int *) b);
@@ -325,10 +325,10 @@ sortById(
  */
 void
 bml_adjacency_ellpack(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     int *xadj,
     int *adjncy,
-    const int base_flag)
+    int base_flag)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -418,12 +418,12 @@ bml_adjacency_ellpack(
  */
 void
 bml_adjacency_group_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int nnodes,
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int nnodes,
     int *xadj,
     int *adjncy,
-    const int base_flag)
+    int base_flag)
 {
     int A_N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellpack/bml_submatrix_ellpack.h
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack.h
@@ -7,232 +7,232 @@
 #include <complex.h>
 
 void bml_matrix2submatrix_index_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellpack(
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellpack_single_real(
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellpack_double_real(
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellpack_single_complex(
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellpack_double_complex(
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_ellpack(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_submatrix2matrix_ellpack(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellpack_single_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellpack_double_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellpack_single_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellpack_double_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void *bml_getVector_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 bml_matrix_ellpack_t *bml_group_matrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_group_matrix_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_group_matrix_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_group_matrix_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_group_matrix_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 void bml_adjacency_ellpack(
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     int *xadj,
     int *adjncy,
-    const int base_flag);
+    int base_flag);
 
 void bml_adjacency_group_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int nnodes,
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int nnodes,
     int *xadj,
     int *adjncy,
-    const int base_flag);
+    int base_flag);
 
 #endif

--- a/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
@@ -37,13 +37,13 @@
  */
 void TYPED_FUNC(
     bml_matrix2submatrix_index_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     int l, ll, ii, ls, k;
     int A_N = A->N;
@@ -149,12 +149,12 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_matrix2submatrix_index_graph_ellpack) (
-    const bml_matrix_ellpack_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellpack_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     int l, ll, ii, ls, k;
     int B_N = B->N;
@@ -234,10 +234,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_matrix2submatrix_ellpack) (
-    const bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize)
+    int *core_halo_index,
+    int lsize)
 {
     REAL_T *rvalue;
 
@@ -283,12 +283,12 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_submatrix2matrix_ellpack) (
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellpack_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold)
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold)
 {
     int A_N = A->N;
 #ifdef BML_USE_MAGMA
@@ -342,12 +342,12 @@ void TYPED_FUNC(
 // Get matching vector of values
 void *TYPED_FUNC(
     bml_getVector_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt)
+    bml_matrix_ellpack_t * A,
+    int *jj,
+    int irow,
+    int colCnt)
 {
-    const REAL_T ZERO = 0.0;
+    REAL_T ZERO = 0.0;
 
     int A_N = A->N;
     int A_M = A->M;
@@ -382,10 +382,10 @@ void *TYPED_FUNC(
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_group_matrix_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellsort/bml_submatrix_ellsort.c
+++ b/src/C-interface/ellsort/bml_submatrix_ellsort.c
@@ -28,13 +28,13 @@
  */
 void
 bml_matrix2submatrix_index_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     switch (A->matrix_precision)
     {
@@ -85,12 +85,12 @@ bml_matrix2submatrix_index_ellsort(
  */
 void
 bml_matrix2submatrix_index_graph_ellsort(
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     switch (B->matrix_precision)
     {
@@ -141,10 +141,10 @@ bml_matrix2submatrix_index_graph_ellsort(
  */
 void
 bml_matrix2submatrix_ellsort(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize)
+    int *core_halo_index,
+    int lsize)
 {
     switch (A->matrix_precision)
     {
@@ -183,12 +183,12 @@ bml_matrix2submatrix_ellsort(
  */
 void
 bml_submatrix2matrix_ellsort(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold)
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -230,10 +230,10 @@ bml_submatrix2matrix_ellsort(
  */
 void *
 bml_getVector_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt)
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt)
 {
     switch (A->matrix_precision)
     {
@@ -267,10 +267,10 @@ bml_getVector_ellsort(
  */
 bml_matrix_ellsort_t *
 bml_group_matrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -308,10 +308,10 @@ bml_group_matrix_ellsort(
  */
 void
 bml_adjacency_ellsort(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     int *xadj,
     int *adjncy,
-    const int base_flag)
+    int base_flag)
 {
     int A_N = A->N;
     int A_M = A->M;
@@ -366,12 +366,12 @@ bml_adjacency_ellsort(
  */
 void
 bml_adjacency_group_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int nnodes,
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int nnodes,
     int *xadj,
     int *adjncy,
-    const int base_flag)
+    int base_flag)
 {
     int A_N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellsort/bml_submatrix_ellsort.h
+++ b/src/C-interface/ellsort/bml_submatrix_ellsort.h
@@ -7,232 +7,232 @@
 #include <complex.h>
 
 void bml_matrix2submatrix_index_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellsort(
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellsort_single_real(
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellsort_double_real(
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellsort_single_complex(
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_index_graph_ellsort_double_complex(
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag);
+    int double_jump_flag);
 
 void bml_matrix2submatrix_ellsort(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_matrix2submatrix_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize);
+    int *core_halo_index,
+    int lsize);
 
 void bml_submatrix2matrix_ellsort(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellsort_single_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellsort_double_real(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellsort_single_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void bml_submatrix2matrix_ellsort_double_complex(
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold);
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold);
 
 void *bml_getVector_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 void *bml_getVector_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt);
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt);
 
 bml_matrix_ellsort_t *bml_group_matrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_group_matrix_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_group_matrix_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_group_matrix_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_group_matrix_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold);
 
 void bml_adjacency_ellsort(
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     int *xadj,
     int *adjncy,
-    const int base_flag);
+    int base_flag);
 
 void bml_adjacency_group_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int nnodes,
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int nnodes,
     int *xadj,
     int *adjncy,
-    const int base_flag);
+    int base_flag);
 
 #endif

--- a/src/C-interface/ellsort/bml_submatrix_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_submatrix_ellsort_typed.c
@@ -37,13 +37,13 @@
  */
 void TYPED_FUNC(
     bml_matrix2submatrix_index_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     int l, ll, ii, ls, k;
     int A_N = A->N;
@@ -149,12 +149,12 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_matrix2submatrix_index_graph_ellsort) (
-    const bml_matrix_ellsort_t * B,
-    const int *nodelist,
-    const int nsize,
+    bml_matrix_ellsort_t * B,
+    int *nodelist,
+    int nsize,
     int *core_halo_index,
     int *vsize,
-    const int double_jump_flag)
+    int double_jump_flag)
 {
     int l, ll, ii, ls, k;
     int B_N = B->N;
@@ -234,10 +234,10 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_matrix2submatrix_ellsort) (
-    const bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * A,
     bml_matrix_dense_t * B,
-    const int *core_halo_index,
-    const int lsize)
+    int *core_halo_index,
+    int lsize)
 {
     REAL_T *rvalue;
 
@@ -283,12 +283,12 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_submatrix2matrix_ellsort) (
-    const bml_matrix_dense_t * A,
+    bml_matrix_dense_t * A,
     bml_matrix_ellsort_t * B,
-    const int *core_halo_index,
-    const int lsize,
-    const int llsize,
-    const double threshold)
+    int *core_halo_index,
+    int lsize,
+    int llsize,
+    double threshold)
 {
     int A_N = A->N;
 #ifdef BML_USE_MAGMA
@@ -342,12 +342,12 @@ void TYPED_FUNC(
 // Get matching vector of values
 void *TYPED_FUNC(
     bml_getVector_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const int *jj,
-    const int irow,
-    const int colCnt)
+    bml_matrix_ellsort_t * A,
+    int *jj,
+    int irow,
+    int colCnt)
 {
-    const REAL_T ZERO = 0.0;
+    REAL_T ZERO = 0.0;
 
     int A_N = A->N;
     int A_M = A->M;
@@ -382,10 +382,10 @@ void *TYPED_FUNC(
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_group_matrix_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const int *hindex,
-    const int ngroups,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    int *hindex,
+    int ngroups,
+    double threshold)
 {
     int A_N = A->N;
     int A_M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_submatrix`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/297)
<!-- Reviewable:end -->
