### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_threshold.c
+++ b/src/C-interface/bml_threshold.c
@@ -18,8 +18,8 @@
  */
 bml_matrix_t *
 bml_threshold_new(
-    const bml_matrix_t * A,
-    const double threshold)
+    bml_matrix_t * A,
+    double threshold)
 {
     switch (bml_get_type(A))
     {
@@ -53,7 +53,7 @@ bml_threshold_new(
 void
 bml_threshold(
     bml_matrix_t * A,
-    const double threshold)
+    double threshold)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_threshold.h
+++ b/src/C-interface/bml_threshold.h
@@ -6,11 +6,11 @@
 #include "bml_types.h"
 
 bml_matrix_t *bml_threshold_new(
-    const bml_matrix_t * A,
-    const double threshold);
+    bml_matrix_t * A,
+    double threshold);
 
 void bml_threshold(
     bml_matrix_t * A,
-    const double threshold);
+    double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_threshold_dense.c
+++ b/src/C-interface/dense/bml_threshold_dense.c
@@ -21,8 +21,8 @@
  */
 bml_matrix_dense_t *
 bml_threshold_new_dense(
-    const bml_matrix_dense_t * A,
-    const double threshold)
+    bml_matrix_dense_t * A,
+    double threshold)
 {
     switch (A->matrix_precision)
     {
@@ -56,7 +56,7 @@ bml_threshold_new_dense(
 void
 bml_threshold_dense(
     bml_matrix_dense_t * A,
-    const double threshold)
+    double threshold)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_threshold_dense.h
+++ b/src/C-interface/dense/bml_threshold_dense.h
@@ -4,43 +4,43 @@
 #include "bml_types_dense.h"
 
 bml_matrix_dense_t *bml_threshold_new_dense(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 bml_matrix_dense_t *bml_threshold_new_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 bml_matrix_dense_t *bml_threshold_new_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 bml_matrix_dense_t *bml_threshold_new_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 bml_matrix_dense_t *bml_threshold_new_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const double threshold);
+    bml_matrix_dense_t * A,
+    double threshold);
 
 void bml_threshold_dense(
     bml_matrix_dense_t * A,
-    const double threshold);
+    double threshold);
 
 void bml_threshold_dense_single_real(
     bml_matrix_dense_t * A,
-    const double threshold);
+    double threshold);
 
 void bml_threshold_dense_double_real(
     bml_matrix_dense_t * A,
-    const double threshold);
+    double threshold);
 
 void bml_threshold_dense_single_complex(
     bml_matrix_dense_t * A,
-    const double threshold);
+    double threshold);
 
 void bml_threshold_dense_double_complex(
     bml_matrix_dense_t * A,
-    const double threshold);
+    double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_threshold_dense_typed.c
+++ b/src/C-interface/dense/bml_threshold_dense_typed.c
@@ -27,8 +27,8 @@
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_threshold_new_dense) (
-    const bml_matrix_dense_t * A,
-    const double threshold)
+    bml_matrix_dense_t * A,
+    double threshold)
 {
 #ifdef BML_USE_MAGMA
     LOG_ERROR
@@ -74,7 +74,7 @@ bml_matrix_dense_t *TYPED_FUNC(
 void TYPED_FUNC(
     bml_threshold_dense) (
     bml_matrix_dense_t * A,
-    const double threshold)
+    double threshold)
 {
 #ifdef BML_USE_MAGMA
     LOG_ERROR("bml_threshold_dense() not implemented for MAGMA matrices\n");

--- a/src/C-interface/ellblock/bml_threshold_ellblock.c
+++ b/src/C-interface/ellblock/bml_threshold_ellblock.c
@@ -16,8 +16,7 @@
  *  \return the thresholded A
  */
 bml_matrix_ellblock_t
-    * bml_threshold_new_ellblock(const bml_matrix_ellblock_t * A,
-                                 const double threshold)
+    * bml_threshold_new_ellblock(bml_matrix_ellblock_t * A, double threshold)
 {
     bml_matrix_ellblock_t *B = NULL;
 
@@ -52,8 +51,8 @@ bml_matrix_ellblock_t
  */
 void
 bml_threshold_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double threshold)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellblock/bml_threshold_ellblock.h
+++ b/src/C-interface/ellblock/bml_threshold_ellblock.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_ellblock_t *bml_threshold_new_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 bml_matrix_ellblock_t *bml_threshold_new_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 bml_matrix_ellblock_t *bml_threshold_new_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 bml_matrix_ellblock_t *bml_threshold_new_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 bml_matrix_ellblock_t *bml_threshold_new_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 void bml_threshold_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 void bml_threshold_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 void bml_threshold_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 void bml_threshold_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 void bml_threshold_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const double threshold);
+    bml_matrix_ellblock_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellblock/bml_threshold_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_threshold_ellblock_typed.c
@@ -28,8 +28,8 @@
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_threshold_new_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double threshold)
 {
     int NB = A->NB;
     int MB = A->MB;
@@ -93,8 +93,8 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_threshold_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const double threshold)
+    bml_matrix_ellblock_t * A,
+    double threshold)
 {
     int NB = A->NB;
     int MB = A->MB;

--- a/src/C-interface/ellpack/bml_threshold_ellpack.c
+++ b/src/C-interface/ellpack/bml_threshold_ellpack.c
@@ -16,8 +16,7 @@
  *  \return the thresholded A
  */
 bml_matrix_ellpack_t
-    * bml_threshold_new_ellpack(const bml_matrix_ellpack_t * A,
-                                const double threshold)
+    * bml_threshold_new_ellpack(bml_matrix_ellpack_t * A, double threshold)
 {
     bml_matrix_ellpack_t *B = NULL;
 
@@ -52,8 +51,8 @@ bml_matrix_ellpack_t
  */
 void
 bml_threshold_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double threshold)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellpack/bml_threshold_ellpack.h
+++ b/src/C-interface/ellpack/bml_threshold_ellpack.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_ellpack_t *bml_threshold_new_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_threshold_new_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_threshold_new_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_threshold_new_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 bml_matrix_ellpack_t *bml_threshold_new_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 void bml_threshold_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 void bml_threshold_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 void bml_threshold_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 void bml_threshold_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 void bml_threshold_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const double threshold);
+    bml_matrix_ellpack_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_threshold_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_threshold_ellpack_typed.c
@@ -27,8 +27,8 @@
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_threshold_new_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double threshold)
 {
     int N = A->N;
     int M = A->M;
@@ -81,8 +81,8 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_threshold_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const double threshold)
+    bml_matrix_ellpack_t * A,
+    double threshold)
 {
     int N = A->N;
     int M = A->M;

--- a/src/C-interface/ellsort/bml_threshold_ellsort.c
+++ b/src/C-interface/ellsort/bml_threshold_ellsort.c
@@ -16,8 +16,7 @@
  *  \return the thresholded A
  */
 bml_matrix_ellsort_t
-    * bml_threshold_new_ellsort(const bml_matrix_ellsort_t * A,
-                                const double threshold)
+    * bml_threshold_new_ellsort(bml_matrix_ellsort_t * A, double threshold)
 {
     bml_matrix_ellsort_t *B = NULL;
 
@@ -52,8 +51,8 @@ bml_matrix_ellsort_t
  */
 void
 bml_threshold_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double threshold)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellsort/bml_threshold_ellsort.h
+++ b/src/C-interface/ellsort/bml_threshold_ellsort.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_ellsort_t *bml_threshold_new_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_threshold_new_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_threshold_new_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_threshold_new_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 bml_matrix_ellsort_t *bml_threshold_new_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 void bml_threshold_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 void bml_threshold_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 void bml_threshold_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 void bml_threshold_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 void bml_threshold_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const double threshold);
+    bml_matrix_ellsort_t * A,
+    double threshold);
 
 #endif

--- a/src/C-interface/ellsort/bml_threshold_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_threshold_ellsort_typed.c
@@ -27,8 +27,8 @@
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_threshold_new_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double threshold)
 {
     int N = A->N;
     int M = A->M;
@@ -81,8 +81,8 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_threshold_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const double threshold)
+    bml_matrix_ellsort_t * A,
+    double threshold)
 {
     int N = A->N;
     int M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_threshold`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/298)
<!-- Reviewable:end -->
