### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_trace.c
+++ b/src/C-interface/bml_trace.c
@@ -17,7 +17,7 @@
  */
 double
 bml_trace(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -50,8 +50,8 @@ bml_trace(
  */
 double
 bml_traceMult(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B)
+    bml_matrix_t * A,
+    bml_matrix_t * B)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_trace.h
+++ b/src/C-interface/bml_trace.h
@@ -7,11 +7,11 @@
 
 // Calculate trace of A
 double bml_trace(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 // Calculate trace of matrix mult
 double bml_tracemult(
-    const bml_matrix_t * A,
-    const bml_matrix_t * B);
+    bml_matrix_t * A,
+    bml_matrix_t * B);
 
 #endif

--- a/src/C-interface/dense/bml_trace_dense.c
+++ b/src/C-interface/dense/bml_trace_dense.c
@@ -20,7 +20,7 @@
  */
 double
 bml_trace_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     switch (A->matrix_precision)
     {
@@ -54,8 +54,8 @@ bml_trace_dense(
  */
 double
 bml_traceMult_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_trace_dense.h
+++ b/src/C-interface/dense/bml_trace_dense.h
@@ -4,38 +4,38 @@
 #include "bml_types_dense.h"
 
 double bml_trace_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_trace_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_trace_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_trace_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_trace_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 double bml_traceMult_dense(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_traceMult_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_traceMult_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_traceMult_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 double bml_traceMult_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B);
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B);
 
 #endif

--- a/src/C-interface/dense/bml_trace_dense_typed.c
+++ b/src/C-interface/dense/bml_trace_dense_typed.c
@@ -29,7 +29,7 @@
  */
 double TYPED_FUNC(
     bml_trace_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     int N = A->N;
 
@@ -88,8 +88,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_traceMult_dense) (
-    const bml_matrix_dense_t * A,
-    const bml_matrix_dense_t * B)
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B)
 {
     int N = A->N;
 

--- a/src/C-interface/ellblock/bml_trace_ellblock.c
+++ b/src/C-interface/ellblock/bml_trace_ellblock.c
@@ -16,7 +16,7 @@
  */
 double
 bml_trace_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     double trace = 0.0;
 
@@ -52,8 +52,8 @@ bml_trace_ellblock(
  */
 double
 bml_traceMult_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
     double trace = 0.0;
 

--- a/src/C-interface/ellblock/bml_trace_ellblock.h
+++ b/src/C-interface/ellblock/bml_trace_ellblock.h
@@ -4,38 +4,38 @@
 #include "bml_types_ellblock.h"
 
 double bml_trace_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_trace_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_trace_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_trace_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_trace_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 double bml_traceMult_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_traceMult_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_traceMult_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_traceMult_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 double bml_traceMult_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B);
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B);
 
 #endif

--- a/src/C-interface/ellblock/bml_trace_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_trace_ellblock_typed.c
@@ -26,7 +26,7 @@
  */
 double TYPED_FUNC(
     bml_trace_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     int NB = A->NB;
     int MB = A->MB;
@@ -68,8 +68,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_traceMult_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const bml_matrix_ellblock_t * B)
+    bml_matrix_ellblock_t * A,
+    bml_matrix_ellblock_t * B)
 {
     int NB = A->NB;
     int MB = A->MB;

--- a/src/C-interface/ellpack/bml_trace_ellpack.c
+++ b/src/C-interface/ellpack/bml_trace_ellpack.c
@@ -16,7 +16,7 @@
  */
 double
 bml_trace_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     double trace = 0.0;
 
@@ -52,8 +52,8 @@ bml_trace_ellpack(
  */
 double
 bml_traceMult_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
     double trace = 0.0;
 

--- a/src/C-interface/ellpack/bml_trace_ellpack.h
+++ b/src/C-interface/ellpack/bml_trace_ellpack.h
@@ -4,38 +4,38 @@
 #include "bml_types_ellpack.h"
 
 double bml_trace_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_trace_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_trace_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_trace_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_trace_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 double bml_traceMult_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_traceMult_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_traceMult_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_traceMult_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 double bml_traceMult_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B);
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B);
 
 #endif

--- a/src/C-interface/ellpack/bml_trace_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_trace_ellpack_typed.c
@@ -27,7 +27,7 @@
  */
 double TYPED_FUNC(
     bml_trace_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     int N = A->N;
     int M = A->M;
@@ -73,8 +73,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_traceMult_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const bml_matrix_ellpack_t * B)
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B)
 {
     int A_N = A->N;
     int A_M = A->M;

--- a/src/C-interface/ellsort/bml_trace_ellsort.c
+++ b/src/C-interface/ellsort/bml_trace_ellsort.c
@@ -16,7 +16,7 @@
  */
 double
 bml_trace_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     double trace = 0.0;
 
@@ -52,8 +52,8 @@ bml_trace_ellsort(
  */
 double
 bml_traceMult_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
     double trace = 0.0;
 

--- a/src/C-interface/ellsort/bml_trace_ellsort.h
+++ b/src/C-interface/ellsort/bml_trace_ellsort.h
@@ -4,38 +4,38 @@
 #include "bml_types_ellsort.h"
 
 double bml_trace_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_trace_ellsort_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_trace_ellsort_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_trace_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_trace_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 double bml_traceMult_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_traceMult_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_traceMult_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_traceMult_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 double bml_traceMult_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B);
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B);
 
 #endif

--- a/src/C-interface/ellsort/bml_trace_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_trace_ellsort_typed.c
@@ -27,7 +27,7 @@
  */
 double TYPED_FUNC(
     bml_trace_ellsort) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     int N = A->N;
     int M = A->M;
@@ -73,8 +73,8 @@ double TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_traceMult_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const bml_matrix_ellsort_t * B)
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B)
 {
     int A_N = A->N;
     int A_M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_trace` type
functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/299)
<!-- Reviewable:end -->
