### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_transpose.c
+++ b/src/C-interface/bml_transpose.c
@@ -17,7 +17,7 @@
  */
 bml_matrix_t *
 bml_transpose_new(
-    const bml_matrix_t * A)
+    bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_transpose.h
+++ b/src/C-interface/bml_transpose.h
@@ -7,7 +7,7 @@
 
 // Transpose A - B = A^T
 bml_matrix_t *bml_transpose_new(
-    const bml_matrix_t * A);
+    bml_matrix_t * A);
 
 void bml_transpose(
     bml_matrix_t * A);

--- a/src/C-interface/dense/bml_transpose_dense.c
+++ b/src/C-interface/dense/bml_transpose_dense.c
@@ -20,7 +20,7 @@
  */
 bml_matrix_dense_t *
 bml_transpose_new_dense(
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_transpose_dense.h
+++ b/src/C-interface/dense/bml_transpose_dense.h
@@ -4,19 +4,19 @@
 #include "bml_types_dense.h"
 
 bml_matrix_dense_t *bml_transpose_new_dense(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_transpose_new_dense_single_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_transpose_new_dense_double_real(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_transpose_new_dense_single_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 bml_matrix_dense_t *bml_transpose_new_dense_double_complex(
-    const bml_matrix_dense_t * A);
+    bml_matrix_dense_t * A);
 
 void bml_transpose_dense(
     bml_matrix_dense_t * A);

--- a/src/C-interface/dense/bml_transpose_dense_typed.c
+++ b/src/C-interface/dense/bml_transpose_dense_typed.c
@@ -30,7 +30,7 @@
  */
 bml_matrix_dense_t *TYPED_FUNC(
     bml_transpose_new_dense) (
-    const bml_matrix_dense_t * A)
+    bml_matrix_dense_t * A)
 {
     int N = A->N;
 

--- a/src/C-interface/ellblock/bml_transpose_ellblock.c
+++ b/src/C-interface/ellblock/bml_transpose_ellblock.c
@@ -14,8 +14,9 @@
  *  \param A The matrix to be transposeed
  *  \return the transposeed A
  */
-bml_matrix_ellblock_t
-    * bml_transpose_new_ellblock(const bml_matrix_ellblock_t * A)
+bml_matrix_ellblock_t *
+bml_transpose_new_ellblock(
+    bml_matrix_ellblock_t * A)
 {
     bml_matrix_ellblock_t *B = NULL;
 
@@ -49,7 +50,7 @@ bml_matrix_ellblock_t
  */
 void
 bml_transpose_ellblock(
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellblock/bml_transpose_ellblock.h
+++ b/src/C-interface/ellblock/bml_transpose_ellblock.h
@@ -4,33 +4,33 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_ellblock_t *bml_transpose_new_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_transpose_new_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_transpose_new_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_transpose_new_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 bml_matrix_ellblock_t *bml_transpose_new_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void bml_transpose_ellblock(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void bml_transpose_ellblock_single_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void bml_transpose_ellblock_double_real(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void bml_transpose_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 void bml_transpose_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A);
+    bml_matrix_ellblock_t * A);
 
 #endif

--- a/src/C-interface/ellblock/bml_transpose_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_transpose_ellblock_typed.c
@@ -27,7 +27,7 @@
  */
 bml_matrix_ellblock_t *TYPED_FUNC(
     bml_transpose_new_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     int NB = A->NB;
     int MB = A->MB;
@@ -82,7 +82,7 @@ bml_matrix_ellblock_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_transpose_ellblock) (
-    const bml_matrix_ellblock_t * A)
+    bml_matrix_ellblock_t * A)
 {
     int NB = A->NB;
     int MB = A->MB;

--- a/src/C-interface/ellpack/bml_transpose_ellpack.c
+++ b/src/C-interface/ellpack/bml_transpose_ellpack.c
@@ -14,8 +14,9 @@
  *  \param A The matrix to be transposeed
  *  \return the transposeed A
  */
-bml_matrix_ellpack_t
-    * bml_transpose_new_ellpack(const bml_matrix_ellpack_t * A)
+bml_matrix_ellpack_t *
+bml_transpose_new_ellpack(
+    bml_matrix_ellpack_t * A)
 {
     bml_matrix_ellpack_t *B = NULL;
 
@@ -49,7 +50,7 @@ bml_matrix_ellpack_t
  */
 void
 bml_transpose_ellpack(
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellpack/bml_transpose_ellpack.h
+++ b/src/C-interface/ellpack/bml_transpose_ellpack.h
@@ -4,33 +4,33 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_ellpack_t *bml_transpose_new_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_transpose_new_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_transpose_new_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_transpose_new_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 bml_matrix_ellpack_t *bml_transpose_new_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void bml_transpose_ellpack(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void bml_transpose_ellpack_single_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void bml_transpose_ellpack_double_real(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void bml_transpose_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 void bml_transpose_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A);
+    bml_matrix_ellpack_t * A);
 
 #endif

--- a/src/C-interface/ellpack/bml_transpose_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_transpose_ellpack_typed.c
@@ -26,7 +26,7 @@
  */
 bml_matrix_ellpack_t *TYPED_FUNC(
     bml_transpose_new_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     bml_matrix_dimension_t matrix_dimension = { A->N, A->N, A->M };
 
@@ -128,7 +128,7 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_transpose_ellpack) (
-    const bml_matrix_ellpack_t * A)
+    bml_matrix_ellpack_t * A)
 {
     int N = A->N;
     int M = A->M;

--- a/src/C-interface/ellsort/bml_transpose_ellsort.c
+++ b/src/C-interface/ellsort/bml_transpose_ellsort.c
@@ -14,8 +14,9 @@
  *  \param A The matrix to be transposeed
  *  \return the transposeed A
  */
-bml_matrix_ellsort_t
-    * bml_transpose_new_ellsort(const bml_matrix_ellsort_t * A)
+bml_matrix_ellsort_t *
+bml_transpose_new_ellsort(
+    bml_matrix_ellsort_t * A)
 {
     bml_matrix_ellsort_t *B = NULL;
 
@@ -49,7 +50,7 @@ bml_matrix_ellsort_t
  */
 void
 bml_transpose_ellsort(
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
 
     switch (A->matrix_precision)

--- a/src/C-interface/ellsort/bml_transpose_ellsort.h
+++ b/src/C-interface/ellsort/bml_transpose_ellsort.h
@@ -4,33 +4,33 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_ellsort_t *bml_transpose_new_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_transpose_new_ellsort_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_transpose_new_ellsort_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_transpose_new_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 bml_matrix_ellsort_t *bml_transpose_new_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void bml_transpose_ellsort(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void bml_transpose_ellsort_single_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void bml_transpose_ellsort_double_real(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void bml_transpose_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 void bml_transpose_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A);
+    bml_matrix_ellsort_t * A);
 
 #endif

--- a/src/C-interface/ellsort/bml_transpose_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_transpose_ellsort_typed.c
@@ -26,7 +26,7 @@
  */
 bml_matrix_ellsort_t *TYPED_FUNC(
     bml_transpose_new_ellsort) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     bml_matrix_dimension_t matrix_dimension = { A->N, A->N, A->M };
     bml_matrix_ellsort_t *B =
@@ -127,7 +127,7 @@ bml_matrix_ellsort_t *TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_transpose_ellsort) (
-    const bml_matrix_ellsort_t * A)
+    bml_matrix_ellsort_t * A)
 {
     int N = A->N;
     int M = A->M;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_transpose`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/300)
<!-- Reviewable:end -->
