### PR TITLE
Remove `const` qualifiers

### DIFF
--- a/src/C-interface/bml_utilities.c
+++ b/src/C-interface/bml_utilities.c
@@ -20,9 +20,9 @@
  */
 void
 bml_print_bml_vector(
-    const bml_vector_t * v,
-    const int i_l,
-    const int i_u)
+    bml_vector_t * v,
+    int i_l,
+    int i_u)
 {
     LOG_ERROR("[FIXME]\n");
 }
@@ -37,11 +37,11 @@ bml_print_bml_vector(
  */
 void
 bml_print_bml_matrix(
-    const bml_matrix_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u)
+    bml_matrix_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u)
 {
     switch (bml_get_type(A))
     {
@@ -196,14 +196,14 @@ bml_print_bml_matrix(
  */
 void
 bml_print_dense_matrix(
-    const int N,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const void *A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u)
+    int N,
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    void *A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u)
 {
     if (N < 0)
     {
@@ -213,7 +213,7 @@ bml_print_dense_matrix(
     {
         case single_real:
         {
-            const float *A_typed = A;
+            float *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -244,7 +244,7 @@ bml_print_dense_matrix(
         }
         case double_real:
         {
-            const double *A_typed = A;
+            double *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -275,7 +275,7 @@ bml_print_dense_matrix(
         }
         case single_complex:
         {
-            const float complex *A_typed = A;
+            float complex *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -310,7 +310,7 @@ bml_print_dense_matrix(
         }
         case double_complex:
         {
-            const double complex *A_typed = A;
+            double complex *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -359,18 +359,18 @@ bml_print_dense_matrix(
  */
 void
 bml_print_dense_vector(
-    const int N,
+    int N,
     bml_matrix_precision_t matrix_precision,
-    const void *v,
-    const int i_l,
-    const int i_u)
+    void *v,
+    int i_l,
+    int i_u)
 {
     LOG_DEBUG("printing vector [%d:%d]\n", i_l, i_u);
     switch (matrix_precision)
     {
         case single_real:
         {
-            const float *v_typed = v;
+            float *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f", v_typed[i]);
@@ -380,7 +380,7 @@ bml_print_dense_vector(
         }
         case double_real:
         {
-            const double *v_typed = v;
+            double *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f", v_typed[i]);
@@ -390,7 +390,7 @@ bml_print_dense_vector(
         }
         case single_complex:
         {
-            const float complex *v_typed = v;
+            float complex *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f%+1.3fi", creal(v_typed[i]),
@@ -401,7 +401,7 @@ bml_print_dense_vector(
         }
         case double_complex:
         {
-            const double complex *v_typed = v;
+            double complex *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f%+1.3fi", creal(v_typed[i]),
@@ -423,8 +423,8 @@ bml_print_dense_vector(
  */
 void
 bml_read_bml_matrix(
-    const bml_matrix_t * A,
-    const char *filename)
+    bml_matrix_t * A,
+    char *filename)
 {
     switch (bml_get_type(A))
     {
@@ -453,8 +453,8 @@ bml_read_bml_matrix(
  */
 void
 bml_write_bml_matrix(
-    const bml_matrix_t * A,
-    const char *filename)
+    bml_matrix_t * A,
+    char *filename)
 {
     switch (bml_get_type(A))
     {

--- a/src/C-interface/bml_utilities.h
+++ b/src/C-interface/bml_utilities.h
@@ -6,40 +6,40 @@
 #include "bml_types.h"
 
 void bml_print_dense_matrix(
-    const int N,
-    const bml_matrix_precision_t matrix_precision,
-    const bml_dense_order_t order,
-    const void *A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    int N,
+    bml_matrix_precision_t matrix_precision,
+    bml_dense_order_t order,
+    void *A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_print_dense_vector(
-    const int N,
+    int N,
     bml_matrix_precision_t matrix_precision,
-    const void *v,
-    const int i_l,
-    const int i_u);
+    void *v,
+    int i_l,
+    int i_u);
 
 void bml_print_bml_vector(
-    const bml_vector_t * v,
-    const int i_l,
-    const int i_u);
+    bml_vector_t * v,
+    int i_l,
+    int i_u);
 
 void bml_print_bml_matrix(
-    const bml_matrix_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    bml_matrix_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_read_bml_matrix(
-    const bml_matrix_t * A,
-    const char *filename);
+    bml_matrix_t * A,
+    char *filename);
 
 void bml_write_bml_matrix(
-    const bml_matrix_t * A,
-    const char *filename);
+    bml_matrix_t * A,
+    char *filename);
 
 #endif

--- a/src/C-interface/dense/bml_utilities_dense.c
+++ b/src/C-interface/dense/bml_utilities_dense.c
@@ -5,8 +5,8 @@
 
 void
 bml_read_bml_matrix_dense(
-    const bml_matrix_dense_t * A,
-    const char *filename)
+    bml_matrix_dense_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {
@@ -30,8 +30,8 @@ bml_read_bml_matrix_dense(
 
 void
 bml_write_bml_matrix_dense(
-    const bml_matrix_dense_t * A,
-    const char *filename)
+    bml_matrix_dense_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {
@@ -55,11 +55,11 @@ bml_write_bml_matrix_dense(
 
 void
 bml_print_bml_matrix_dense(
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u)
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/dense/bml_utilities_dense.h
+++ b/src/C-interface/dense/bml_utilities_dense.h
@@ -9,78 +9,78 @@
 #include <stdlib.h>
 
 void bml_print_bml_matrix_dense(
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_print_bml_matrix_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_print_bml_matrix_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_print_bml_matrix_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_print_bml_matrix_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u);
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u);
 
 void bml_read_bml_matrix_dense(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_dense(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_dense_single_real(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_dense_double_real(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_dense_single_complex(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_dense_double_complex(
-    const bml_matrix_dense_t * A,
-    const char *filename);
+    bml_matrix_dense_t * A,
+    char *filename);
 
 #endif

--- a/src/C-interface/dense/bml_utilities_dense_typed.c
+++ b/src/C-interface/dense/bml_utilities_dense_typed.c
@@ -24,8 +24,8 @@
  */
 void TYPED_FUNC(
     bml_read_bml_matrix_dense) (
-    const bml_matrix_dense_t * A,
-    const char *filename)
+    bml_matrix_dense_t * A,
+    char *filename)
 {
     FILE *hFile;
     char header1[20], header2[20], header3[20], header4[20], header5[20];
@@ -95,8 +95,8 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_write_bml_matrix_dense) (
-    const bml_matrix_dense_t * A,
-    const char *filename)
+    bml_matrix_dense_t * A,
+    char *filename)
 {
     FILE *mFile;
 
@@ -128,11 +128,11 @@ void TYPED_FUNC(
 
 void TYPED_FUNC(
     bml_print_bml_matrix_dense) (
-    const bml_matrix_dense_t * A,
-    const int i_l,
-    const int i_u,
-    const int j_l,
-    const int j_u)
+    bml_matrix_dense_t * A,
+    int i_l,
+    int i_u,
+    int j_l,
+    int j_u)
 {
 #ifdef BML_USE_MAGMA
     MAGMAGPU(print) (A->N, A->N, A->matrix, A->ld, A->queue);

--- a/src/C-interface/ellblock/bml_utilities_ellblock.c
+++ b/src/C-interface/ellblock/bml_utilities_ellblock.c
@@ -5,8 +5,8 @@
 
 void
 bml_read_bml_matrix_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const char *filename)
+    bml_matrix_ellblock_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {
@@ -30,8 +30,8 @@ bml_read_bml_matrix_ellblock(
 
 void
 bml_write_bml_matrix_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const char *filename)
+    bml_matrix_ellblock_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellblock/bml_utilities_ellblock.h
+++ b/src/C-interface/ellblock/bml_utilities_ellblock.h
@@ -10,98 +10,98 @@
 #include <complex.h>
 
 void bml_read_bml_matrix_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellblock(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellblock_single_real(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellblock_double_real(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellblock_single_complex(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellblock_double_complex(
-    const bml_matrix_ellblock_t * A,
-    const char *filename);
+    bml_matrix_ellblock_t * A,
+    char *filename);
 
 double bml_sum_squares_single_real(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 double bml_sum_squares_double_real(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 double bml_sum_squares_single_complex(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 double bml_sum_squares_double_complex(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 
 double bml_norm_inf_single_real(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 double bml_norm_inf_double_real(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 double bml_norm_inf_single_complex(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 double bml_norm_inf_double_complex(
-    const void *v,
-    const int,
-    const int,
-    const int);
+    void *v,
+    int,
+    int,
+    int);
 
 double bml_norm_inf_fast_single_real(
-    const void *v,
-    const int);
+    void *v,
+    int);
 double bml_norm_inf_fast_double_real(
-    const void *v,
-    const int);
+    void *v,
+    int);
 double bml_norm_inf_fast_single_complex(
-    const void *v,
-    const int);
+    void *v,
+    int);
 double bml_norm_inf_fast_double_complex(
-    const void *v,
-    const int);
+    void *v,
+    int);
 
 #endif

--- a/src/C-interface/ellblock/bml_utilities_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_utilities_ellblock_typed.c
@@ -22,8 +22,8 @@
  */
 void TYPED_FUNC(
     bml_read_bml_matrix_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const char *filename)
+    bml_matrix_ellblock_t * A,
+    char *filename)
 {
     //for(int i=0;i<A->NB;i++)printf("bsize=%d\n",A->bsize[i]);
     assert(A->bsize[0] < 1e6);
@@ -169,8 +169,8 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_write_bml_matrix_ellblock) (
-    const bml_matrix_ellblock_t * A,
-    const char *filename)
+    bml_matrix_ellblock_t * A,
+    char *filename)
 {
     FILE *mFile;
     int msum;
@@ -240,12 +240,12 @@ void TYPED_FUNC(
 
 double TYPED_FUNC(
     bml_norm_inf) (
-    const void *_v,
-    const int nrows,
-    const int ncols,
-    const int ld)
+    void *_v,
+    int nrows,
+    int ncols,
+    int ld)
 {
-    const REAL_T *v = _v;
+    REAL_T *v = _v;
     double norm = 0.;
     for (int i = 0; i < nrows; i++)
         for (int j = 0; j < ncols; j++)
@@ -259,10 +259,10 @@ double TYPED_FUNC(
 
 double TYPED_FUNC(
     bml_norm_inf_fast) (
-    const void *_v,
-    const int n)
+    void *_v,
+    int n)
 {
-    const REAL_T *v = _v;
+    REAL_T *v = _v;
     double norm = 0.;
     for (int i = 0; i < n; i++)
     {
@@ -275,12 +275,12 @@ double TYPED_FUNC(
 
 double TYPED_FUNC(
     bml_sum_squares) (
-    const void *_v,
-    const int nrows,
-    const int ncols,
-    const int ld)
+    void *_v,
+    int nrows,
+    int ncols,
+    int ld)
 {
-    const REAL_T *v = _v;
+    REAL_T *v = _v;
     double n2 = 0.;
     for (int i = 0; i < nrows; i++)
         for (int j = 0; j < ncols; j++)

--- a/src/C-interface/ellpack/bml_utilities_ellpack.c
+++ b/src/C-interface/ellpack/bml_utilities_ellpack.c
@@ -5,8 +5,8 @@
 
 void
 bml_read_bml_matrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const char *filename)
+    bml_matrix_ellpack_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {
@@ -30,8 +30,8 @@ bml_read_bml_matrix_ellpack(
 
 void
 bml_write_bml_matrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const char *filename)
+    bml_matrix_ellpack_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellpack/bml_utilities_ellpack.h
+++ b/src/C-interface/ellpack/bml_utilities_ellpack.h
@@ -9,43 +9,43 @@
 #include <stdlib.h>
 
 void bml_read_bml_matrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellpack(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellpack_single_real(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellpack_double_real(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellpack_single_complex(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellpack_double_complex(
-    const bml_matrix_ellpack_t * A,
-    const char *filename);
+    bml_matrix_ellpack_t * A,
+    char *filename);
 
 #endif

--- a/src/C-interface/ellpack/bml_utilities_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_utilities_ellpack_typed.c
@@ -21,8 +21,8 @@
  */
 void TYPED_FUNC(
     bml_read_bml_matrix_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const char *filename)
+    bml_matrix_ellpack_t * A,
+    char *filename)
 {
     FILE *hFile;
     char header1[20], header2[20], header3[20], header4[20], header5[20];
@@ -108,8 +108,8 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_write_bml_matrix_ellpack) (
-    const bml_matrix_ellpack_t * A,
-    const char *filename)
+    bml_matrix_ellpack_t * A,
+    char *filename)
 {
     FILE *mFile;
     int msum;

--- a/src/C-interface/ellsort/bml_utilities_ellsort.c
+++ b/src/C-interface/ellsort/bml_utilities_ellsort.c
@@ -5,8 +5,8 @@
 
 void
 bml_read_bml_matrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const char *filename)
+    bml_matrix_ellsort_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {
@@ -30,8 +30,8 @@ bml_read_bml_matrix_ellsort(
 
 void
 bml_write_bml_matrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const char *filename)
+    bml_matrix_ellsort_t * A,
+    char *filename)
 {
     switch (A->matrix_precision)
     {

--- a/src/C-interface/ellsort/bml_utilities_ellsort.h
+++ b/src/C-interface/ellsort/bml_utilities_ellsort.h
@@ -9,43 +9,43 @@
 #include <stdlib.h>
 
 void bml_read_bml_matrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_read_bml_matrix_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellsort(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellsort_single_real(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellsort_double_real(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellsort_single_complex(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 void bml_write_bml_matrix_ellsort_double_complex(
-    const bml_matrix_ellsort_t * A,
-    const char *filename);
+    bml_matrix_ellsort_t * A,
+    char *filename);
 
 #endif

--- a/src/C-interface/ellsort/bml_utilities_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_utilities_ellsort_typed.c
@@ -21,8 +21,8 @@
  */
 void TYPED_FUNC(
     bml_read_bml_matrix_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const char *filename)
+    bml_matrix_ellsort_t * A,
+    char *filename)
 {
     FILE *hFile;
     char header1[20], header2[20], header3[20], header4[20], header5[20];
@@ -108,8 +108,8 @@ void TYPED_FUNC(
  */
 void TYPED_FUNC(
     bml_write_bml_matrix_ellsort) (
-    const bml_matrix_ellsort_t * A,
-    const char *filename)
+    bml_matrix_ellsort_t * A,
+    char *filename)
 {
     FILE *mFile;
     int msum;


### PR DESCRIPTION
This change removes the `const` qualifiers for the `bml_utilities`
type functions.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/301)
<!-- Reviewable:end -->
