### PR TITLE
Split valgrind testing for improved performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ env:
     - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=no  BML_INTERNAL_BLAS=yes
     - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=no
     - CC=gcc-4.7 CXX=g++-4.7 FC=gfortran-4.7 BUILD_SHARED_LIBS=yes BML_OPENMP=yes BML_INTERNAL_BLAS=yes
-    - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  BML_VALGRIND=yes packages="valgrind"
+    - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  TESTING_EXTRA_ARGS="-R .*-single_real"    BML_VALGRIND=yes packages="valgrind"
+    - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  TESTING_EXTRA_ARGS="-R .*-double_real"    BML_VALGRIND=yes packages="valgrind"
+    - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  TESTING_EXTRA_ARGS="-R .*-single_complex" BML_VALGRIND=yes packages="valgrind"
+    - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=no  TESTING_EXTRA_ARGS="-R .*-double_complex" BML_VALGRIND=yes packages="valgrind"
     - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=no  BML_INTERNAL_BLAS=yes
     - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=yes BML_INTERNAL_BLAS=no
     - CC=gcc-9   CXX=g++-9   FC=gfortran-9   BUILD_SHARED_LIBS=no  BML_OPENMP=yes BML_INTERNAL_BLAS=yes

--- a/build.sh
+++ b/build.sh
@@ -12,9 +12,10 @@ fi
 
 : ${BUILD_DIR:=${TOP_DIR}/build}
 : ${INSTALL_DIR:=${TOP_DIR}/install}
-LOG_FILE="${TOP_DIR}/build.log"
-: ${VERBOSE_MAKEFILE:=no}
 : ${PARALLEL_TEST_JOBS:=1}
+: ${TESTING_EXTRA_ARGS:=}
+: ${VERBOSE_MAKEFILE:=no}
+LOG_FILE="${TOP_DIR}/build.log"
 
 help() {
     cat <<EOF
@@ -192,7 +193,10 @@ install() {
 
 testing() {
     cd "${BUILD_DIR}"
-    ctest --output-on-failure --parallel ${PARALLEL_TEST_JOBS} 2>&1 | tee -a "${LOG_FILE}"
+    ctest --output-on-failure \
+      --parallel ${PARALLEL_TEST_JOBS} \
+      ${TESTING_EXTRA_ARGS} \
+      2>&1 | tee -a "${LOG_FILE}"
     check_pipe_error
     cd "${TOP_DIR}"
 }


### PR DESCRIPTION
This change splits the valgrind tests, which take by far the longest,
into four smaller test jobs to speed up testing on Travis-CI. This
speedup relies on the fact that Travis-CI runs the test matrix in
parallel.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/304)
<!-- Reviewable:end -->
