### PR TITLE
Add indentation checks for Fortran sources

### DIFF
--- a/indent.sh
+++ b/indent.sh
@@ -46,7 +46,9 @@ done
 for f in "${FORTRAN_FILES[@]}"; do
   ${EMACS} --batch \
     "${f}" \
-    --eval "(describe-variable major-mode)" \
+    --eval "(setq f90-do-indent 2)" \
+    --eval "(setq f90-if-indent 2)" \
+    --eval "(setq f90-type-indent 2)" \
     --eval "(indent-region (minibuffer-prompt-end) (point-max) nil)" \
     -f save-buffer
 done

--- a/src/Fortran-interface/bml_add_m.F90
+++ b/src/Fortran-interface/bml_add_m.F90
@@ -11,16 +11,16 @@ module bml_add_m
 
   !> Add two matrices.
   interface bml_add
-     module procedure add_two
+    module procedure add_two
   end interface bml_add
 
   interface bml_add_deprecated
-     module procedure add_two_deprecated
+    module procedure add_two_deprecated
   end interface bml_add_deprecated
 
   !> Add identity matrix to a matrix.
   interface bml_add_identity
-     module procedure add_identity_one
+    module procedure add_identity_one
   end interface bml_add_identity
   !> @}
 
@@ -55,9 +55,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0.0_C_DOUBLE
+      threshold_ = 0.0_C_DOUBLE
     end if
     call bml_add_C(a%ptr, b%ptr, alpha, beta, threshold_)
 
@@ -86,9 +86,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0.0_C_DOUBLE
+      threshold_ = 0.0_C_DOUBLE
     end if
     call add_two(a, b, alpha, beta, threshold_)
 
@@ -118,9 +118,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0.0_C_DOUBLE
+      threshold_ = 0.0_C_DOUBLE
     end if
 
     trnorm = bml_add_norm_C(a%ptr, b%ptr, alpha, beta, threshold_)

--- a/src/Fortran-interface/bml_allocate_m.F90
+++ b/src/Fortran-interface/bml_allocate_m.F90
@@ -60,9 +60,9 @@ contains
     aflag = bml_allocated_C(a%ptr)
 
     if (aflag .gt. 0) then
-       bml_allocated = .true.
+      bml_allocated = .true.
     else
-       bml_allocated = .false.
+      bml_allocated = .false.
     end if
 
   end function bml_allocated
@@ -90,9 +90,9 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     call bml_deallocate(a)
@@ -115,9 +115,9 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     call bml_deallocate(a)
@@ -151,9 +151,9 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     call bml_deallocate(a)
@@ -186,9 +186,9 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     call bml_deallocate(a)
@@ -221,9 +221,9 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     call bml_deallocate(a)
@@ -256,9 +256,9 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     call bml_deallocate(a)

--- a/src/Fortran-interface/bml_c_interface_m.F90
+++ b/src/Fortran-interface/bml_c_interface_m.F90
@@ -21,572 +21,572 @@ module bml_c_interface_m
 
   interface
 
-     subroutine bml_add_C(a, b, alpha, beta, threshold) bind(C, name="bml_add")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       real(C_DOUBLE), value, intent(in) :: alpha
-       real(C_DOUBLE), value, intent(in) :: beta
-       real(C_DOUBLE), value, intent(in) :: threshold
-     end subroutine bml_add_C
-
-     function bml_add_norm_C(a, b, alpha, beta, threshold) &
-          & bind(C, name="bml_add_norm")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       real(C_DOUBLE), value, intent(in) :: alpha
-       real(C_DOUBLE), value, intent(in) :: beta
-       real(C_DOUBLE), value, intent(in) :: threshold
-       real(C_DOUBLE) :: bml_add_norm_C
-     end function bml_add_norm_C
-
-     function bml_allocated_C(a) &
-          & bind(C, name="bml_allocated")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_allocated_C
-     end function bml_allocated_C
-
-     subroutine bml_add_identity_C(a, beta, threshold) &
-          & bind(C, name="bml_add_identity")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value :: a
-       real(C_DOUBLE), value, intent(in) :: beta
-       real(C_DOUBLE), value, intent(in) :: threshold
-     end subroutine bml_add_identity_C
-
-     subroutine bml_scale_add_identity_C(a, alpha, beta, threshold) &
-          & bind(C, name="bml_scale_add_identity")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value :: a
-       real(C_DOUBLE), value, intent(in) :: alpha
-       real(C_DOUBLE), value, intent(in) :: beta
-       real(C_DOUBLE), value, intent(in) :: threshold
-     end subroutine bml_scale_add_identity_C
-
-     subroutine bml_allGatherVParallel_C(a) &
-          & bind(C, name="bml_allGatherVParallel")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-     end subroutine bml_allGatherVParallel_C
-
-     subroutine bml_adjungate_triangle_C(a, triangle) &
-          & bind(C, name="bml_adjungate_triangle")
-       import :: C_PTR, C_CHAR
-       type(C_PTR), value :: a
-       character(C_CHAR), intent(in) :: triangle(*)
-     end subroutine bml_adjungate_triangle_C
-
-     subroutine bml_transpose_triangle_C(a, triangle) &
-          & bind(C, name="bml_transpose_triangle")
-       import :: C_PTR, C_CHAR
-       type(C_PTR), value :: a
-       character(C_CHAR), value, intent(in) :: triangle
-     end subroutine bml_transpose_triangle_C
-
-     function bml_banded_matrix_C(matrix_type, matrix_precision, n, m, &
-          & distrib_mode) bind(C, name="bml_banded_matrix")
-       import :: C_INT, C_PTR
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: n
-       integer(C_INT), value, intent(in) :: m
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_banded_matrix_C
-     end function bml_banded_matrix_C
-
-     function bml_import_from_dense_C(matrix_type, matrix_precision, order, &
-          & n, m, a, threshold, distrib_mode) &
-          bind(C, name="bml_import_from_dense")
-       import :: C_INT, C_PTR, C_DOUBLE
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: order
-       integer(C_INT), value, intent(in) :: n, m
-       type(C_PTR), value, intent(in) :: a
-       real(C_DOUBLE), value, intent(in) :: threshold
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_import_from_dense_C
-     end function bml_import_from_dense_C
-
-     function bml_export_to_dense_C(a, order) &
-          & bind(C, name="bml_export_to_dense")
-       import :: C_INT, C_PTR
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: order
-       type(C_PTR) :: bml_export_to_dense_C
-     end function bml_export_to_dense_C
-
-     subroutine bml_copy_C(a, b) bind(C, name="bml_copy")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-     end subroutine bml_copy_C
-
-     function bml_copy_new_C(a) bind(C, name="bml_copy_new")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR) :: bml_copy_new_C
-     end function bml_copy_new_C
-
-     subroutine bml_reorder_C(a, perm) bind(C, name="bml_reorder")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: perm
-     end subroutine bml_reorder_C
-
-     subroutine bml_save_domain_C(a) bind(C, name="bml_save_domain")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-     end subroutine bml_save_domain_C
-
-     subroutine bml_restore_domain_C(a) bind(C, name="bml_restore_domain")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-     end subroutine bml_restore_domain_C
-
-     subroutine bml_update_domain_C(a, globalPartMin, globalPartMax, &
-          nnodesInPart) bind(C, name="bml_update_domain")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: globalPartMin
-       type(C_PTR), value, intent(in) :: globalPartMax
-       type(C_PTR), value, intent(in) :: nnodesInPart
-     end subroutine bml_update_domain_C
-
-     subroutine bml_diagonalize_C(a, eigenvalues, eigenvectors) &
-          & bind(C, name="bml_diagonalize")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value :: eigenvalues
-       type(C_PTR), value :: eigenvectors
-     end subroutine bml_diagonalize_C
-
-     subroutine bml_deallocate_C(a) bind(C, name="bml_deallocate")
-       import :: C_PTR
-       type(C_PTR) :: a
-     end subroutine bml_deallocate_C
-
-     subroutine bml_clear_C(a) bind(C, name="bml_clear")
-       import :: C_PTR
-       type(C_PTR) :: a
-     end subroutine bml_clear_C
-
-     subroutine bml_free_C(cptr) bind(C, name="bml_free_ptr")
-       import :: C_PTR
-       type(C_PTR), intent(inout) :: cptr
-     end subroutine bml_free_C
-
-     function bml_get_C(a, i, j) bind(C, name="bml_get")
-       import :: C_PTR, C_INT, C_FLOAT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i
-       integer(C_INT), value, intent(in) :: j
-       type(C_PTR) :: bml_get_C
-     end function bml_get_C
-
-     function bml_get_N_C(a) bind(C, name="bml_get_N")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_get_N_C
-     end function bml_get_N_C
-
-     function bml_get_M_C(a) bind(C, name="bml_get_M")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_get_M_C
-     end function bml_get_M_C
-
-     function bml_get_type_C(a) bind(C, name="bml_get_type")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_get_type_C
-     end function bml_get_type_C
-
-     function bml_get_precision_C(a) bind(C, name="bml_get_precision")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_get_precision_C
-     end function bml_get_precision_C
-
-     function bml_get_distribution_mode_C(a) &
-          & bind(C, name="bml_get_distribution_mode")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_get_distribution_mode_C
-     end function bml_get_distribution_mode_C
-
-     function bml_get_row_C(a, i) result(row) bind(C, name="bml_get_row")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i
-       type(C_PTR) :: row
-     end function bml_get_row_C
-
-     function bml_get_diagonal_C(a) result(diagonal) bind(C, name="bml_get_diagonal")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR) :: diagonal
-     end function bml_get_diagonal_C
-
-     subroutine bml_initF_C(fcomm) bind(C, name="bml_initF")
-       import :: C_PTR, C_INT
-       integer(C_INT), value, intent(in) :: fcomm
-     end subroutine bml_initF_C
-
-     subroutine bml_shutdownF_C() bind(C, name="bml_shutdownF")
-     end subroutine bml_shutdownF_C
-
-     function bml_sum_squares_C(a) bind(C, name="bml_sum_squares")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       real(C_DOUBLE) :: bml_sum_squares_C
-     end function bml_sum_squares_C
-
-     function bml_sum_squares_submatrix_C(a, core_size) &
-          bind(C, name="bml_sum_squares_submatrix")
-       import :: C_PTR, C_DOUBLE, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: core_size
-       real(C_DOUBLE) :: bml_sum_squares_submatrix_C
-     end function bml_sum_squares_submatrix_C
-
-     function bml_sum_squares2_C(a, b, alpha, beta, threshold) &
-          bind(C, name="bml_sum_squares2")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       real(C_DOUBLE), value, intent(in) :: alpha
-       real(C_DOUBLE), value, intent(in) :: beta
-       real(C_DOUBLE), value, intent(in) :: threshold
-       real(C_DOUBLE) :: bml_sum_squares2_C
-     end function bml_sum_squares2_C
-
-     function bml_fnorm_C(a) bind(C, name="bml_fnorm")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       real(C_DOUBLE) :: bml_fnorm_C
-     end function bml_fnorm_C
-
-     function bml_fnorm2_C(a, b) bind(C, name="bml_fnorm2")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       real(C_DOUBLE) :: bml_fnorm2_C
-     end function bml_fnorm2_C
-
-     subroutine bml_normalize_C(a, mineval, maxeval) &
-          bind(C, name="bml_normalize")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value :: a
-       real(C_DOUBLE), value, intent(in) :: mineval
-       real(C_DOUBLE), value, intent(in) :: maxeval
-     end subroutine bml_normalize_C
-
-     function bml_gershgorin_C(a) bind(C, name="bml_gershgorin")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR) :: bml_gershgorin_C
-     end function bml_gershgorin_C
-
-     function bml_gershgorin_partial_C(a, nrows) bind(C, name="bml_gershgorin_partial")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: nrows
-       type(C_PTR) :: bml_gershgorin_partial_C
-     end function bml_gershgorin_partial_C
-
-     function bml_get_row_bandwidth_C(a, i) &
-          & bind(C, name="bml_get_row_bandwidth")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i
-       integer(C_INT) :: bml_get_row_bandwidth_C
-     end function bml_get_row_bandwidth_C
-
-     function bml_get_bandwidth_C(a) bind(C, name="bml_get_bandwidth")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT) :: bml_get_bandwidth_C
-     end function bml_get_bandwidth_C
-
-     function bml_get_sparsity_C(a, threshold) bind(C, name="bml_get_sparsity")
-       import :: C_PTR, C_DOUBLE, C_INT
-       type(C_PTR), value, intent(in) :: a
-       real(C_DOUBLE), value, intent(in) :: threshold
-       real(C_DOUBLE) :: bml_get_sparsity_C
-     end function bml_get_sparsity_C
-
-     function bml_identity_matrix_C(matrix_type, matrix_precision, n, m, &
-          & distrib_mode) bind(C, name="bml_identity_matrix")
-       import :: C_INT, C_PTR
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: n
-       integer(C_INT), value, intent(in) :: m
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_identity_matrix_C
-     end function bml_identity_matrix_C
-
-     function bml_inverse_C(a) bind(C, name="bml_inverse")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR) :: bml_inverse_C
-     end function bml_inverse_C
-
-     subroutine bml_multiply_C(a, b, c, alpha, beta, threshold) &
-          & bind(C, name="bml_multiply")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       type(C_PTR), value, intent(in) :: c
-       real(C_DOUBLE), value, intent(in) :: alpha
-       real(C_DOUBLE), value, intent(in) :: beta
-       real(C_DOUBLE), value, intent(in) :: threshold
-     end subroutine bml_multiply_C
-
-     function bml_multiply_x2_C(x, x2, threshold) &
-          & bind(C, name="bml_multiply_x2")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: x
-       type(C_PTR), value, intent(in) :: x2
-       real(C_DOUBLE), value, intent(in) :: threshold
-       type(C_PTR) :: bml_multiply_x2_C
-     end function bml_multiply_x2_C
-
-     function bml_random_matrix_C(matrix_type, matrix_precision, n, m, &
-          & distrib_mode) bind(C, name="bml_random_matrix")
-       import :: C_INT, C_PTR
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: n
-       integer(C_INT), value, intent(in) :: m
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_random_matrix_C
-     end function bml_random_matrix_C
-
-     subroutine bml_scale_C(alpha, a, b) bind(C, name="bml_scale")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: alpha
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value :: b
-     end subroutine bml_scale_C
-
-     subroutine bml_scale_inplace_C(alpha, a) bind(C, name="bml_scale_inplace")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: alpha
-       type(C_PTR), value :: a
-     end subroutine bml_scale_inplace_C
-
-     subroutine bml_set_row_C(a, i, row, threshold) bind(C, name="bml_set_row")
-       import :: C_PTR, C_INT, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i
-       type(C_PTR), value :: row
-       real(C_DOUBLE), value :: threshold
-     end subroutine bml_set_row_C
-
-     subroutine bml_set_element_C(a, i, j, element) bind(C, name="bml_set_element")
-       import :: C_PTR, C_INT, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i
-       integer(C_INT), value, intent(in) :: j
-       type(C_PTR), value :: element
-     end subroutine bml_set_element_C
-
-     subroutine bml_set_element_new_C(a, i, j, element) bind(C, name="bml_set_element_new")
-       import :: C_PTR, C_INT, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i
-       integer(C_INT), value, intent(in) :: j
-       type(C_PTR), value :: element
-     end subroutine bml_set_element_new_C
-
-
-     subroutine bml_set_diagonal_C(a, diagonal, threshold) bind(C, name="bml_set_diagonal")
-       import :: C_PTR, C_INT, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value :: diagonal
-       real(C_DOUBLE), value :: threshold
-     end subroutine bml_set_diagonal_C
-
-     subroutine bml_matrix2submatrix_index_C(a, b, nodelist, nsize, &
-          chlist, vsize, dj_flag) bind(C, name="bml_matrix2submatrix_index")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       type(C_PTR), value, intent(in) :: nodelist
-       integer(C_INT), value, intent(in) :: nsize
-       type(C_PTR), value, intent(in) :: chlist
-       type(C_PTR), value, intent(in) :: vsize
-       integer(C_INT), value, intent(in) :: dj_flag
-     end subroutine bml_matrix2submatrix_index_C
-
-     subroutine bml_matrix2submatrix_index_graph_C(b, nodelist, nsize, &
-          chlist, vsize, dj_flag) bind(C, name="bml_matrix2submatrix_index_graph")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: b
-       type(C_PTR), value, intent(in) :: nodelist
-       integer(C_INT), value, intent(in) :: nsize
-       type(C_PTR), value, intent(in) :: chlist
-       type(C_PTR), value, intent(in) :: vsize
-       integer(C_INT), value, intent(in) :: dj_flag
-     end subroutine bml_matrix2submatrix_index_graph_C
-
-     subroutine bml_matrix2submatrix_C(a, b, chlist, lsize) &
-          bind(C, name="bml_matrix2submatrix")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       type(C_PTR), value, intent(in) :: chlist
-       integer(C_INT), value, intent(in) :: lsize
-     end subroutine bml_matrix2submatrix_C
-
-     subroutine bml_submatrix2matrix_C(a, b, chlist, lsize, llsize, &
-          threshold) bind(C, name="bml_submatrix2matrix")
-       import :: C_PTR, C_INT, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       type(C_PTR), value, intent(in) :: chlist
-       integer(C_INT), value, intent(in) :: lsize
-       integer(C_INT), value, intent(in) :: llsize
-       real(C_DOUBLE), value :: threshold
-     end subroutine bml_submatrix2matrix_C
-
-     subroutine bml_adjacency_C(a, xadj, adjncy, base_flag) &
-          bind(C, name="bml_adjacency")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: xadj
-       type(C_PTR), value, intent(in) :: adjncy
-       integer(C_INT), value, intent(in) :: base_flag
-     end subroutine bml_adjacency_C
-
-     subroutine bml_adjacency_group_C(a, hindex, nnodes, xadj, adjncy, base_flag) &
-          bind(C, name="bml_adjacency_group")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: hindex
-       integer(C_INT), value, intent(in) :: nnodes
-       type(C_PTR), value, intent(in) :: xadj
-       type(C_PTR), value, intent(in) :: adjncy
-       integer(C_INT), value, intent(in) :: base_flag
-     end subroutine bml_adjacency_group_C
-
-     function bml_group_matrix_C(a, hindex, ngroups, threshold) &
-          bind(C, name="bml_group_matrix")
-       import :: C_PTR, C_INT, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: hindex
-       integer(C_INT), value, intent(in) :: ngroups
-       real(C_DOUBLE), value, intent(in) :: threshold
-       type(C_PTR) :: bml_group_matrix_C
-     end function bml_group_matrix_C
-
-     subroutine bml_threshold_C(a, threshold) bind(C, name="bml_threshold")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value :: a
-       real(C_DOUBLE), value, intent(in) :: threshold
-     end subroutine bml_threshold_C
-
-     subroutine bml_print_bml_vector_C(v, i_l, i_u) &
-          & bind(C, name="bml_print_bml_vector")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: v
-       integer(C_INT), value, intent(in) :: i_l
-       integer(C_INT), value, intent(in) :: i_u
-     end subroutine bml_print_bml_vector_C
-
-     subroutine bml_print_bml_matrix_C(a, i_l, i_u, j_l, j_u) &
-          & bind(C, name="bml_print_bml_matrix")
-       import :: C_PTR, C_INT
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i_l
-       integer(C_INT), value, intent(in) :: i_u
-       integer(C_INT), value, intent(in) :: j_l
-       integer(C_INT), value, intent(in) :: j_u
-     end subroutine bml_print_bml_matrix_C
-
-     subroutine bml_print_dense_matrix_C(n, matrix_precision, order, a, i_l, &
-          & i_u, j_l, j_u) bind(C, name="bml_print_dense_matrix")
-       import :: C_PTR, C_INT
-       integer(C_INT), value, intent(in) :: n
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: order
-       type(C_PTR), value, intent(in) :: a
-       integer(C_INT), value, intent(in) :: i_l
-       integer(C_INT), value, intent(in) :: i_u
-       integer(C_INT), value, intent(in) :: j_l
-       integer(C_INT), value, intent(in) :: j_u
-     end subroutine bml_print_dense_matrix_C
-
-     subroutine bml_read_bml_matrix_C(a, filename) &
-          & bind(C, name="bml_read_bml_matrix")
-       import :: C_PTR, C_CHAR
-       type(C_PTR), value, intent(in) :: a
-       character(C_CHAR), intent(in) :: filename(*)
-     end subroutine bml_read_bml_matrix_C
-
-     function bml_trace_C(a) bind(C, name="bml_trace")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       real(C_DOUBLE) :: bml_trace_C
-     end function bml_trace_C
-
-     function bml_traceMult_C(a, b) bind(C, name="bml_traceMult")
-       import :: C_PTR, C_DOUBLE
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR), value, intent(in) :: b
-       real(C_DOUBLE) :: bml_traceMult_C
-     end function bml_traceMult_C
-
-     function bml_transpose_new_C(a) bind(C, name="bml_transpose_new")
-       import :: C_PTR
-       type(C_PTR), value, intent(in) :: a
-       type(C_PTR) :: bml_transpose_new_C
-     end function bml_transpose_new_C
-
-     subroutine bml_write_bml_matrix_C(a, filename) &
-          & bind(C, name="bml_write_bml_matrix")
-       import :: C_PTR, C_CHAR
-       type(C_PTR), value, intent(in) :: a
-       character(C_CHAR), intent(in) :: filename(*)
-     end subroutine bml_write_bml_matrix_C
-
-     function bml_zero_matrix_C(matrix_type, matrix_precision, n, m, &
-          & distrib_mode) bind(C, name="bml_zero_matrix")
-       import :: C_INT, C_PTR
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: n
-       integer(C_INT), value, intent(in) :: m
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_zero_matrix_C
-     end function bml_zero_matrix_C
-
-     function bml_block_matrix_C(matrix_type, matrix_precision, nb, mb, bsizes, &
-          & distrib_mode) bind(C, name="bml_block_matrix")
-       import :: C_INT, C_PTR
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: nb
-       integer(C_INT), value, intent(in) :: mb
-       integer(C_INT), intent(in), dimension(*) :: bsizes
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_block_matrix_C
-     end function bml_block_matrix_C
-
-     function bml_noinit_matrix_C(matrix_type, matrix_precision, n, m, &
-          & distrib_mode) bind(C, name="bml_noinit_matrix")
-       import :: C_INT, C_PTR
-       integer(C_INT), value, intent(in) :: matrix_type
-       integer(C_INT), value, intent(in) :: matrix_precision
-       integer(C_INT), value, intent(in) :: n
-       integer(C_INT), value, intent(in) :: m
-       integer(C_INT), value, intent(in) :: distrib_mode
-       type(C_PTR) :: bml_noinit_matrix_C
-     end function bml_noinit_matrix_C
+    subroutine bml_add_C(a, b, alpha, beta, threshold) bind(C, name="bml_add")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      real(C_DOUBLE), value, intent(in) :: alpha
+      real(C_DOUBLE), value, intent(in) :: beta
+      real(C_DOUBLE), value, intent(in) :: threshold
+    end subroutine bml_add_C
+
+    function bml_add_norm_C(a, b, alpha, beta, threshold) &
+         & bind(C, name="bml_add_norm")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      real(C_DOUBLE), value, intent(in) :: alpha
+      real(C_DOUBLE), value, intent(in) :: beta
+      real(C_DOUBLE), value, intent(in) :: threshold
+      real(C_DOUBLE) :: bml_add_norm_C
+    end function bml_add_norm_C
+
+    function bml_allocated_C(a) &
+         & bind(C, name="bml_allocated")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_allocated_C
+    end function bml_allocated_C
+
+    subroutine bml_add_identity_C(a, beta, threshold) &
+         & bind(C, name="bml_add_identity")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value :: a
+      real(C_DOUBLE), value, intent(in) :: beta
+      real(C_DOUBLE), value, intent(in) :: threshold
+    end subroutine bml_add_identity_C
+
+    subroutine bml_scale_add_identity_C(a, alpha, beta, threshold) &
+         & bind(C, name="bml_scale_add_identity")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value :: a
+      real(C_DOUBLE), value, intent(in) :: alpha
+      real(C_DOUBLE), value, intent(in) :: beta
+      real(C_DOUBLE), value, intent(in) :: threshold
+    end subroutine bml_scale_add_identity_C
+
+    subroutine bml_allGatherVParallel_C(a) &
+         & bind(C, name="bml_allGatherVParallel")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+    end subroutine bml_allGatherVParallel_C
+
+    subroutine bml_adjungate_triangle_C(a, triangle) &
+         & bind(C, name="bml_adjungate_triangle")
+      import :: C_PTR, C_CHAR
+      type(C_PTR), value :: a
+      character(C_CHAR), intent(in) :: triangle(*)
+    end subroutine bml_adjungate_triangle_C
+
+    subroutine bml_transpose_triangle_C(a, triangle) &
+         & bind(C, name="bml_transpose_triangle")
+      import :: C_PTR, C_CHAR
+      type(C_PTR), value :: a
+      character(C_CHAR), value, intent(in) :: triangle
+    end subroutine bml_transpose_triangle_C
+
+    function bml_banded_matrix_C(matrix_type, matrix_precision, n, m, &
+         & distrib_mode) bind(C, name="bml_banded_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: n
+      integer(C_INT), value, intent(in) :: m
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_banded_matrix_C
+    end function bml_banded_matrix_C
+
+    function bml_import_from_dense_C(matrix_type, matrix_precision, order, &
+         & n, m, a, threshold, distrib_mode) &
+         bind(C, name="bml_import_from_dense")
+      import :: C_INT, C_PTR, C_DOUBLE
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: order
+      integer(C_INT), value, intent(in) :: n, m
+      type(C_PTR), value, intent(in) :: a
+      real(C_DOUBLE), value, intent(in) :: threshold
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_import_from_dense_C
+    end function bml_import_from_dense_C
+
+    function bml_export_to_dense_C(a, order) &
+         & bind(C, name="bml_export_to_dense")
+      import :: C_INT, C_PTR
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: order
+      type(C_PTR) :: bml_export_to_dense_C
+    end function bml_export_to_dense_C
+
+    subroutine bml_copy_C(a, b) bind(C, name="bml_copy")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+    end subroutine bml_copy_C
+
+    function bml_copy_new_C(a) bind(C, name="bml_copy_new")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR) :: bml_copy_new_C
+    end function bml_copy_new_C
+
+    subroutine bml_reorder_C(a, perm) bind(C, name="bml_reorder")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: perm
+    end subroutine bml_reorder_C
+
+    subroutine bml_save_domain_C(a) bind(C, name="bml_save_domain")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+    end subroutine bml_save_domain_C
+
+    subroutine bml_restore_domain_C(a) bind(C, name="bml_restore_domain")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+    end subroutine bml_restore_domain_C
+
+    subroutine bml_update_domain_C(a, globalPartMin, globalPartMax, &
+         nnodesInPart) bind(C, name="bml_update_domain")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: globalPartMin
+      type(C_PTR), value, intent(in) :: globalPartMax
+      type(C_PTR), value, intent(in) :: nnodesInPart
+    end subroutine bml_update_domain_C
+
+    subroutine bml_diagonalize_C(a, eigenvalues, eigenvectors) &
+         & bind(C, name="bml_diagonalize")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value :: eigenvalues
+      type(C_PTR), value :: eigenvectors
+    end subroutine bml_diagonalize_C
+
+    subroutine bml_deallocate_C(a) bind(C, name="bml_deallocate")
+      import :: C_PTR
+      type(C_PTR) :: a
+    end subroutine bml_deallocate_C
+
+    subroutine bml_clear_C(a) bind(C, name="bml_clear")
+      import :: C_PTR
+      type(C_PTR) :: a
+    end subroutine bml_clear_C
+
+    subroutine bml_free_C(cptr) bind(C, name="bml_free_ptr")
+      import :: C_PTR
+      type(C_PTR), intent(inout) :: cptr
+    end subroutine bml_free_C
+
+    function bml_get_C(a, i, j) bind(C, name="bml_get")
+      import :: C_PTR, C_INT, C_FLOAT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i
+      integer(C_INT), value, intent(in) :: j
+      type(C_PTR) :: bml_get_C
+    end function bml_get_C
+
+    function bml_get_N_C(a) bind(C, name="bml_get_N")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_get_N_C
+    end function bml_get_N_C
+
+    function bml_get_M_C(a) bind(C, name="bml_get_M")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_get_M_C
+    end function bml_get_M_C
+
+    function bml_get_type_C(a) bind(C, name="bml_get_type")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_get_type_C
+    end function bml_get_type_C
+
+    function bml_get_precision_C(a) bind(C, name="bml_get_precision")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_get_precision_C
+    end function bml_get_precision_C
+
+    function bml_get_distribution_mode_C(a) &
+         & bind(C, name="bml_get_distribution_mode")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_get_distribution_mode_C
+    end function bml_get_distribution_mode_C
+
+    function bml_get_row_C(a, i) result(row) bind(C, name="bml_get_row")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i
+      type(C_PTR) :: row
+    end function bml_get_row_C
+
+    function bml_get_diagonal_C(a) result(diagonal) bind(C, name="bml_get_diagonal")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR) :: diagonal
+    end function bml_get_diagonal_C
+
+    subroutine bml_initF_C(fcomm) bind(C, name="bml_initF")
+      import :: C_PTR, C_INT
+      integer(C_INT), value, intent(in) :: fcomm
+    end subroutine bml_initF_C
+
+    subroutine bml_shutdownF_C() bind(C, name="bml_shutdownF")
+    end subroutine bml_shutdownF_C
+
+    function bml_sum_squares_C(a) bind(C, name="bml_sum_squares")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      real(C_DOUBLE) :: bml_sum_squares_C
+    end function bml_sum_squares_C
+
+    function bml_sum_squares_submatrix_C(a, core_size) &
+         bind(C, name="bml_sum_squares_submatrix")
+      import :: C_PTR, C_DOUBLE, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: core_size
+      real(C_DOUBLE) :: bml_sum_squares_submatrix_C
+    end function bml_sum_squares_submatrix_C
+
+    function bml_sum_squares2_C(a, b, alpha, beta, threshold) &
+         bind(C, name="bml_sum_squares2")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      real(C_DOUBLE), value, intent(in) :: alpha
+      real(C_DOUBLE), value, intent(in) :: beta
+      real(C_DOUBLE), value, intent(in) :: threshold
+      real(C_DOUBLE) :: bml_sum_squares2_C
+    end function bml_sum_squares2_C
+
+    function bml_fnorm_C(a) bind(C, name="bml_fnorm")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      real(C_DOUBLE) :: bml_fnorm_C
+    end function bml_fnorm_C
+
+    function bml_fnorm2_C(a, b) bind(C, name="bml_fnorm2")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      real(C_DOUBLE) :: bml_fnorm2_C
+    end function bml_fnorm2_C
+
+    subroutine bml_normalize_C(a, mineval, maxeval) &
+         bind(C, name="bml_normalize")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value :: a
+      real(C_DOUBLE), value, intent(in) :: mineval
+      real(C_DOUBLE), value, intent(in) :: maxeval
+    end subroutine bml_normalize_C
+
+    function bml_gershgorin_C(a) bind(C, name="bml_gershgorin")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR) :: bml_gershgorin_C
+    end function bml_gershgorin_C
+
+    function bml_gershgorin_partial_C(a, nrows) bind(C, name="bml_gershgorin_partial")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: nrows
+      type(C_PTR) :: bml_gershgorin_partial_C
+    end function bml_gershgorin_partial_C
+
+    function bml_get_row_bandwidth_C(a, i) &
+         & bind(C, name="bml_get_row_bandwidth")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i
+      integer(C_INT) :: bml_get_row_bandwidth_C
+    end function bml_get_row_bandwidth_C
+
+    function bml_get_bandwidth_C(a) bind(C, name="bml_get_bandwidth")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT) :: bml_get_bandwidth_C
+    end function bml_get_bandwidth_C
+
+    function bml_get_sparsity_C(a, threshold) bind(C, name="bml_get_sparsity")
+      import :: C_PTR, C_DOUBLE, C_INT
+      type(C_PTR), value, intent(in) :: a
+      real(C_DOUBLE), value, intent(in) :: threshold
+      real(C_DOUBLE) :: bml_get_sparsity_C
+    end function bml_get_sparsity_C
+
+    function bml_identity_matrix_C(matrix_type, matrix_precision, n, m, &
+         & distrib_mode) bind(C, name="bml_identity_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: n
+      integer(C_INT), value, intent(in) :: m
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_identity_matrix_C
+    end function bml_identity_matrix_C
+
+    function bml_inverse_C(a) bind(C, name="bml_inverse")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR) :: bml_inverse_C
+    end function bml_inverse_C
+
+    subroutine bml_multiply_C(a, b, c, alpha, beta, threshold) &
+         & bind(C, name="bml_multiply")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      type(C_PTR), value, intent(in) :: c
+      real(C_DOUBLE), value, intent(in) :: alpha
+      real(C_DOUBLE), value, intent(in) :: beta
+      real(C_DOUBLE), value, intent(in) :: threshold
+    end subroutine bml_multiply_C
+
+    function bml_multiply_x2_C(x, x2, threshold) &
+         & bind(C, name="bml_multiply_x2")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: x
+      type(C_PTR), value, intent(in) :: x2
+      real(C_DOUBLE), value, intent(in) :: threshold
+      type(C_PTR) :: bml_multiply_x2_C
+    end function bml_multiply_x2_C
+
+    function bml_random_matrix_C(matrix_type, matrix_precision, n, m, &
+         & distrib_mode) bind(C, name="bml_random_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: n
+      integer(C_INT), value, intent(in) :: m
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_random_matrix_C
+    end function bml_random_matrix_C
+
+    subroutine bml_scale_C(alpha, a, b) bind(C, name="bml_scale")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: alpha
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value :: b
+    end subroutine bml_scale_C
+
+    subroutine bml_scale_inplace_C(alpha, a) bind(C, name="bml_scale_inplace")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: alpha
+      type(C_PTR), value :: a
+    end subroutine bml_scale_inplace_C
+
+    subroutine bml_set_row_C(a, i, row, threshold) bind(C, name="bml_set_row")
+      import :: C_PTR, C_INT, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i
+      type(C_PTR), value :: row
+      real(C_DOUBLE), value :: threshold
+    end subroutine bml_set_row_C
+
+    subroutine bml_set_element_C(a, i, j, element) bind(C, name="bml_set_element")
+      import :: C_PTR, C_INT, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i
+      integer(C_INT), value, intent(in) :: j
+      type(C_PTR), value :: element
+    end subroutine bml_set_element_C
+
+    subroutine bml_set_element_new_C(a, i, j, element) bind(C, name="bml_set_element_new")
+      import :: C_PTR, C_INT, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i
+      integer(C_INT), value, intent(in) :: j
+      type(C_PTR), value :: element
+    end subroutine bml_set_element_new_C
+
+
+    subroutine bml_set_diagonal_C(a, diagonal, threshold) bind(C, name="bml_set_diagonal")
+      import :: C_PTR, C_INT, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value :: diagonal
+      real(C_DOUBLE), value :: threshold
+    end subroutine bml_set_diagonal_C
+
+    subroutine bml_matrix2submatrix_index_C(a, b, nodelist, nsize, &
+         chlist, vsize, dj_flag) bind(C, name="bml_matrix2submatrix_index")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      type(C_PTR), value, intent(in) :: nodelist
+      integer(C_INT), value, intent(in) :: nsize
+      type(C_PTR), value, intent(in) :: chlist
+      type(C_PTR), value, intent(in) :: vsize
+      integer(C_INT), value, intent(in) :: dj_flag
+    end subroutine bml_matrix2submatrix_index_C
+
+    subroutine bml_matrix2submatrix_index_graph_C(b, nodelist, nsize, &
+         chlist, vsize, dj_flag) bind(C, name="bml_matrix2submatrix_index_graph")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: b
+      type(C_PTR), value, intent(in) :: nodelist
+      integer(C_INT), value, intent(in) :: nsize
+      type(C_PTR), value, intent(in) :: chlist
+      type(C_PTR), value, intent(in) :: vsize
+      integer(C_INT), value, intent(in) :: dj_flag
+    end subroutine bml_matrix2submatrix_index_graph_C
+
+    subroutine bml_matrix2submatrix_C(a, b, chlist, lsize) &
+         bind(C, name="bml_matrix2submatrix")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      type(C_PTR), value, intent(in) :: chlist
+      integer(C_INT), value, intent(in) :: lsize
+    end subroutine bml_matrix2submatrix_C
+
+    subroutine bml_submatrix2matrix_C(a, b, chlist, lsize, llsize, &
+         threshold) bind(C, name="bml_submatrix2matrix")
+      import :: C_PTR, C_INT, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      type(C_PTR), value, intent(in) :: chlist
+      integer(C_INT), value, intent(in) :: lsize
+      integer(C_INT), value, intent(in) :: llsize
+      real(C_DOUBLE), value :: threshold
+    end subroutine bml_submatrix2matrix_C
+
+    subroutine bml_adjacency_C(a, xadj, adjncy, base_flag) &
+         bind(C, name="bml_adjacency")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: xadj
+      type(C_PTR), value, intent(in) :: adjncy
+      integer(C_INT), value, intent(in) :: base_flag
+    end subroutine bml_adjacency_C
+
+    subroutine bml_adjacency_group_C(a, hindex, nnodes, xadj, adjncy, base_flag) &
+         bind(C, name="bml_adjacency_group")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: hindex
+      integer(C_INT), value, intent(in) :: nnodes
+      type(C_PTR), value, intent(in) :: xadj
+      type(C_PTR), value, intent(in) :: adjncy
+      integer(C_INT), value, intent(in) :: base_flag
+    end subroutine bml_adjacency_group_C
+
+    function bml_group_matrix_C(a, hindex, ngroups, threshold) &
+         bind(C, name="bml_group_matrix")
+      import :: C_PTR, C_INT, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: hindex
+      integer(C_INT), value, intent(in) :: ngroups
+      real(C_DOUBLE), value, intent(in) :: threshold
+      type(C_PTR) :: bml_group_matrix_C
+    end function bml_group_matrix_C
+
+    subroutine bml_threshold_C(a, threshold) bind(C, name="bml_threshold")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value :: a
+      real(C_DOUBLE), value, intent(in) :: threshold
+    end subroutine bml_threshold_C
+
+    subroutine bml_print_bml_vector_C(v, i_l, i_u) &
+         & bind(C, name="bml_print_bml_vector")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: v
+      integer(C_INT), value, intent(in) :: i_l
+      integer(C_INT), value, intent(in) :: i_u
+    end subroutine bml_print_bml_vector_C
+
+    subroutine bml_print_bml_matrix_C(a, i_l, i_u, j_l, j_u) &
+         & bind(C, name="bml_print_bml_matrix")
+      import :: C_PTR, C_INT
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i_l
+      integer(C_INT), value, intent(in) :: i_u
+      integer(C_INT), value, intent(in) :: j_l
+      integer(C_INT), value, intent(in) :: j_u
+    end subroutine bml_print_bml_matrix_C
+
+    subroutine bml_print_dense_matrix_C(n, matrix_precision, order, a, i_l, &
+         & i_u, j_l, j_u) bind(C, name="bml_print_dense_matrix")
+      import :: C_PTR, C_INT
+      integer(C_INT), value, intent(in) :: n
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: order
+      type(C_PTR), value, intent(in) :: a
+      integer(C_INT), value, intent(in) :: i_l
+      integer(C_INT), value, intent(in) :: i_u
+      integer(C_INT), value, intent(in) :: j_l
+      integer(C_INT), value, intent(in) :: j_u
+    end subroutine bml_print_dense_matrix_C
+
+    subroutine bml_read_bml_matrix_C(a, filename) &
+         & bind(C, name="bml_read_bml_matrix")
+      import :: C_PTR, C_CHAR
+      type(C_PTR), value, intent(in) :: a
+      character(C_CHAR), intent(in) :: filename(*)
+    end subroutine bml_read_bml_matrix_C
+
+    function bml_trace_C(a) bind(C, name="bml_trace")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      real(C_DOUBLE) :: bml_trace_C
+    end function bml_trace_C
+
+    function bml_traceMult_C(a, b) bind(C, name="bml_traceMult")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      real(C_DOUBLE) :: bml_traceMult_C
+    end function bml_traceMult_C
+
+    function bml_transpose_new_C(a) bind(C, name="bml_transpose_new")
+      import :: C_PTR
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR) :: bml_transpose_new_C
+    end function bml_transpose_new_C
+
+    subroutine bml_write_bml_matrix_C(a, filename) &
+         & bind(C, name="bml_write_bml_matrix")
+      import :: C_PTR, C_CHAR
+      type(C_PTR), value, intent(in) :: a
+      character(C_CHAR), intent(in) :: filename(*)
+    end subroutine bml_write_bml_matrix_C
+
+    function bml_zero_matrix_C(matrix_type, matrix_precision, n, m, &
+         & distrib_mode) bind(C, name="bml_zero_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: n
+      integer(C_INT), value, intent(in) :: m
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_zero_matrix_C
+    end function bml_zero_matrix_C
+
+    function bml_block_matrix_C(matrix_type, matrix_precision, nb, mb, bsizes, &
+         & distrib_mode) bind(C, name="bml_block_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: nb
+      integer(C_INT), value, intent(in) :: mb
+      integer(C_INT), intent(in), dimension(*) :: bsizes
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_block_matrix_C
+    end function bml_block_matrix_C
+
+    function bml_noinit_matrix_C(matrix_type, matrix_precision, n, m, &
+         & distrib_mode) bind(C, name="bml_noinit_matrix")
+      import :: C_INT, C_PTR
+      integer(C_INT), value, intent(in) :: matrix_type
+      integer(C_INT), value, intent(in) :: matrix_precision
+      integer(C_INT), value, intent(in) :: n
+      integer(C_INT), value, intent(in) :: m
+      integer(C_INT), value, intent(in) :: distrib_mode
+      type(C_PTR) :: bml_noinit_matrix_C
+    end function bml_noinit_matrix_C
 
   end interface
 

--- a/src/Fortran-interface/bml_elemental_m.F90
+++ b/src/Fortran-interface/bml_elemental_m.F90
@@ -7,10 +7,10 @@ module bml_elemental_m
   private
 
   interface bml_get
-     module procedure bml_get_single_real
-     module procedure bml_get_double_real
-     module procedure bml_get_single_complex
-     module procedure bml_get_double_complex
+    module procedure bml_get_single_real
+    module procedure bml_get_double_real
+    module procedure bml_get_single_complex
+    module procedure bml_get_double_complex
   end interface bml_get
 
   public :: bml_get

--- a/src/Fortran-interface/bml_export_m.F90
+++ b/src/Fortran-interface/bml_export_m.F90
@@ -9,10 +9,10 @@ module bml_export_m
   private
 
   interface bml_export_to_dense
-     module procedure bml_export_to_dense_single
-     module procedure bml_export_to_dense_double
-     module procedure bml_export_to_dense_single_complex
-     module procedure bml_export_to_dense_double_complex
+    module procedure bml_export_to_dense_single
+    module procedure bml_export_to_dense_double
+    module procedure bml_export_to_dense_single_complex
+    module procedure bml_export_to_dense_double_complex
   end interface bml_export_to_dense
 
   public :: bml_export_to_dense

--- a/src/Fortran-interface/bml_getters_m.F90
+++ b/src/Fortran-interface/bml_getters_m.F90
@@ -7,17 +7,17 @@ module bml_getters_m
   private
 
   interface bml_get_row
-     module procedure bml_get_row_single_real
-     module procedure bml_get_row_double_real
-     module procedure bml_get_row_single_complex
-     module procedure bml_get_row_double_complex
+    module procedure bml_get_row_single_real
+    module procedure bml_get_row_double_real
+    module procedure bml_get_row_single_complex
+    module procedure bml_get_row_double_complex
   end interface bml_get_row
 
   interface bml_get_diagonal
-     module procedure bml_get_diagonal_single_real
-     module procedure bml_get_diagonal_double_real
-     module procedure bml_get_diagonal_single_complex
-     module procedure bml_get_diagonal_double_complex
+    module procedure bml_get_diagonal_single_real
+    module procedure bml_get_diagonal_double_real
+    module procedure bml_get_diagonal_single_complex
+    module procedure bml_get_diagonal_double_complex
   end interface bml_get_diagonal
 
   public :: bml_get_row, bml_get_diagonal

--- a/src/Fortran-interface/bml_import_m.F90
+++ b/src/Fortran-interface/bml_import_m.F90
@@ -9,10 +9,10 @@ module bml_import_m
   private
 
   interface bml_import_from_dense
-     module procedure bml_import_from_dense_single
-     module procedure bml_import_from_dense_double
-     module procedure bml_import_from_dense_single_complex
-     module procedure bml_import_from_dense_double_complex
+    module procedure bml_import_from_dense_single
+    module procedure bml_import_from_dense_double
+    module procedure bml_import_from_dense_single_complex
+    module procedure bml_import_from_dense_double_complex
   end interface bml_import_from_dense
 
   public :: bml_import_from_dense
@@ -43,30 +43,30 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     if (present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
 
     n_ = size(a_dense, 1, C_INT)
 
     if (matrix_type /= BML_MATRIX_DENSE) then
-       if (.not. present(m)) then
-          write(*, *) "missing parameter m; number of non-zeros per row"
-          error stop
-       end if
+      if (.not. present(m)) then
+        write(*, *) "missing parameter m; number of non-zeros per row"
+        error stop
+      end if
     end if
 
     if (present(m)) then
-       m_ = m
+      m_ = m
     else
-       m_ = n_
+      m_ = n_
     end if
 
     call bml_deallocate(a)
@@ -103,30 +103,30 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     if (present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
 
     n_ = size(a_dense, 1, C_INT)
 
     if (matrix_type /= BML_MATRIX_DENSE) then
-       if (.not. present(m)) then
-          write(*, *) "missing parameter m; number of non-zeros per row"
-          error stop
-       end if
+      if (.not. present(m)) then
+        write(*, *) "missing parameter m; number of non-zeros per row"
+        error stop
+      end if
     end if
 
     if (present(m)) then
-       m_ = m
+      m_ = m
     else
-       m_ = n_
+      m_ = n_
     end if
 
     call bml_deallocate(a)
@@ -163,30 +163,30 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     if (present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
 
     n_ = size(a_dense, 1, C_INT)
 
     if (matrix_type /= BML_MATRIX_DENSE) then
-       if (.not. present(m)) then
-          write(*, *) "missing parameter m; number of non-zeros per row"
-          error stop
-       end if
+      if (.not. present(m)) then
+        write(*, *) "missing parameter m; number of non-zeros per row"
+        error stop
+      end if
     end if
 
     if (present(m)) then
-       m_ = m
+      m_ = m
     else
-       m_ = n_
+      m_ = n_
     end if
 
     call bml_deallocate(a)
@@ -223,30 +223,30 @@ contains
     character(len=20) :: distrib_mode_
 
     if (present(distrib_mode)) then
-       distrib_mode_ = distrib_mode
+      distrib_mode_ = distrib_mode
     else
-       distrib_mode_ = bml_dmode_sequential
+      distrib_mode_ = bml_dmode_sequential
     endif
 
     if (present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
 
     n_ = size(a_dense, 1, C_INT)
 
     if (matrix_type /= BML_MATRIX_DENSE) then
-       if (.not. present(m)) then
-          write(*, *) "missing parameter m; number of non-zeros per row"
-          error stop
-       end if
+      if (.not. present(m)) then
+        write(*, *) "missing parameter m; number of non-zeros per row"
+        error stop
+      end if
     end if
 
     if (present(m)) then
-       m_ = m
+      m_ = m
     else
-       m_ = n_
+      m_ = n_
     end if
 
     call bml_deallocate(a)

--- a/src/Fortran-interface/bml_init_m.F90
+++ b/src/Fortran-interface/bml_init_m.F90
@@ -21,9 +21,9 @@ contains
     integer :: arg_comm
 
     if(present(fcomm)) then
-       arg_comm = fcomm
+      arg_comm = fcomm
     else
-       arg_comm = 0
+      arg_comm = 0
     end if
     call bml_initF_C(arg_comm)
 

--- a/src/Fortran-interface/bml_interface_m.F90
+++ b/src/Fortran-interface/bml_interface_m.F90
@@ -101,14 +101,14 @@ contains
 
     select case (trim(type_string))
     case(BML_MATRIX_DENSE)
-       id = bml_matrix_type_dense_enum_id
+      id = bml_matrix_type_dense_enum_id
     case(BML_MATRIX_ELLPACK)
-       id = bml_matrix_type_ellpack_enum_id
+      id = bml_matrix_type_ellpack_enum_id
     case(BML_MATRIX_ELLBLOCK)
-       id = bml_matrix_type_ellblock_enum_id
+      id = bml_matrix_type_ellblock_enum_id
     case default
-       print *, "unknown matrix type"//trim(type_string)
-       error stop
+      print *, "unknown matrix type"//trim(type_string)
+      error stop
     end select
 
   end function get_matrix_id
@@ -122,27 +122,27 @@ contains
     select case (trim(element_type))
 
     case (BML_ELEMENT_REAL)
-       select case (element_kind)
-       case (C_FLOAT)
-          id = bml_matrix_precision_single_real_enum_id
-       case (C_DOUBLE)
-          id = bml_matrix_precision_double_real_enum_id
-       case default
-          print "(A,1X,I0)", "Unknown element kind:", element_kind
-       end select
+      select case (element_kind)
+      case (C_FLOAT)
+        id = bml_matrix_precision_single_real_enum_id
+      case (C_DOUBLE)
+        id = bml_matrix_precision_double_real_enum_id
+      case default
+        print "(A,1X,I0)", "Unknown element kind:", element_kind
+      end select
 
     case (BML_ELEMENT_COMPLEX)
-       select case (element_kind)
-       case (C_FLOAT_COMPLEX)
-          id = bml_matrix_precision_single_complex_enum_id
-       case (C_DOUBLE_COMPLEX)
-          id = bml_matrix_precision_double_complex_enum_id
-       case default
-          print "(A,1X,I0)", "Unknown element kind:", element_kind
-       end select
+      select case (element_kind)
+      case (C_FLOAT_COMPLEX)
+        id = bml_matrix_precision_single_complex_enum_id
+      case (C_DOUBLE_COMPLEX)
+        id = bml_matrix_precision_double_complex_enum_id
+      case default
+        print "(A,1X,I0)", "Unknown element kind:", element_kind
+      end select
 
     case default
-       print "(A,1X,A)", "Unknown element type:", element_type
+      print "(A,1X,A)", "Unknown element type:", element_type
 
     end select
 
@@ -161,14 +161,14 @@ contains
 
     select case (trim(dmode_string))
     case(BML_DMODE_SEQUENTIAL)
-       id = bml_distribution_mode_sequential_enum_id
+      id = bml_distribution_mode_sequential_enum_id
     case(BML_DMODE_DISTRIBUTED)
-       id = bml_distribution_mode_distributed_enum_id
+      id = bml_distribution_mode_distributed_enum_id
     case(BML_DMODE_GRAPH_DISTRIBUTED)
-       id = bml_distribution_mode_graph_distributed_enum_id
+      id = bml_distribution_mode_graph_distributed_enum_id
     case default
-       print *, "unknown distribution mode"//trim(dmode_string)
-       error stop
+      print *, "unknown distribution mode"//trim(dmode_string)
+      error stop
     end select
 
   end function get_dmode_id

--- a/src/Fortran-interface/bml_introspection_m.F90
+++ b/src/Fortran-interface/bml_introspection_m.F90
@@ -88,13 +88,13 @@ contains
 
     select case(bml_get_type_num)
     case(0)
-       bml_get_type = "Unformatted"
+      bml_get_type = "Unformatted"
     case(1)
-       bml_get_type = "dense"
+      bml_get_type = "dense"
     case(2)
-       bml_get_type = "ellpack"
+      bml_get_type = "ellpack"
     case default
-       stop 'Unknown matrix type in bml_get_type'
+      stop 'Unknown matrix type in bml_get_type'
     end select
 
   end function bml_get_type
@@ -131,13 +131,13 @@ contains
 
     select case(bml_precision_id)
     case(0)
-       stop 'Type/precision elements not initialized'
+      stop 'Type/precision elements not initialized'
     case(1)
-       bml_get_element_precision = kind(1.0)
+      bml_get_element_precision = kind(1.0)
     case(2)
-       bml_get_element_precision = kind(1.0d0)
+      bml_get_element_precision = kind(1.0d0)
     case default
-       stop 'Unknown elements type/precision'
+      stop 'Unknown elements type/precision'
     end select
 
   end function bml_get_element_precision
@@ -157,17 +157,17 @@ contains
 
     select case(bml_precision_id)
     case(0)
-       stop 'Type/precision elements not initialized'
+      stop 'Type/precision elements not initialized'
     case(1)
-       bml_get_element_type = "real"
+      bml_get_element_type = "real"
     case(2)
-       bml_get_element_type = "real"
+      bml_get_element_type = "real"
     case(3)
-       bml_get_element_type = "complex"
+      bml_get_element_type = "complex"
     case(4)
-       bml_get_element_type = "complex"
+      bml_get_element_type = "complex"
     case default
-       stop 'Unknown elements type/precision'
+      stop 'Unknown elements type/precision'
     end select
 
   end function bml_get_element_type
@@ -186,13 +186,13 @@ contains
 
     select case(dmode)
     case(0)
-       bml_get_distribution_mode = "sequential"
+      bml_get_distribution_mode = "sequential"
     case(1)
-       bml_get_distribution_mode = "distributed"
+      bml_get_distribution_mode = "distributed"
     case(3)
-       bml_get_distribution_mode = "graph_distributed"
+      bml_get_distribution_mode = "graph_distributed"
     case default
-       stop 'Unknown distribution type in bml_get_distribution_mode'
+      stop 'Unknown distribution type in bml_get_distribution_mode'
     end select
 
   end function bml_get_distribution_mode

--- a/src/Fortran-interface/bml_multiply_m.F90
+++ b/src/Fortran-interface/bml_multiply_m.F90
@@ -40,19 +40,19 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(alpha)) then
-       alpha_ = alpha
+      alpha_ = alpha
     else
-       alpha_ = 1
+      alpha_ = 1
     end if
     if(present(beta)) then
-       beta_ = beta
+      beta_ = beta
     else
-       beta_ = 0
+      beta_ = 0
     end if
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
     call bml_multiply_c(a%ptr, b%ptr, c%ptr, alpha_, beta_, threshold_)
 
@@ -83,9 +83,9 @@ contains
     double precision, pointer :: a_trace_ptr(:)
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
 
     trace_ptr = bml_multiply_x2_c(a%ptr, b%ptr, threshold_)

--- a/src/Fortran-interface/bml_normalize_m.F90
+++ b/src/Fortran-interface/bml_normalize_m.F90
@@ -6,11 +6,11 @@ module bml_normalize_m
   private
 
   interface bml_normalize
-     module procedure bml_normalize
+    module procedure bml_normalize
   end interface bml_normalize
 
   interface bml_gershgorin
-     module procedure bml_gershgorin
+    module procedure bml_gershgorin
   end interface bml_gershgorin
 
   public :: bml_normalize

--- a/src/Fortran-interface/bml_scale_m.F90
+++ b/src/Fortran-interface/bml_scale_m.F90
@@ -9,14 +9,14 @@ module bml_scale_m
 
   !> Scale a matrix.
   interface bml_scale
-     module procedure scale_one_single_real
-     module procedure scale_one_double_real
-     module procedure scale_one_single_complex
-     module procedure scale_one_double_complex
-     module procedure scale_two_single_real
-     module procedure scale_two_double_real
-     module procedure scale_two_single_complex
-     module procedure scale_two_double_complex
+    module procedure scale_one_single_real
+    module procedure scale_one_double_real
+    module procedure scale_one_single_complex
+    module procedure scale_one_double_complex
+    module procedure scale_two_single_real
+    module procedure scale_two_double_real
+    module procedure scale_two_single_complex
+    module procedure scale_two_double_complex
   end interface bml_scale
 
   public :: bml_scale

--- a/src/Fortran-interface/bml_setters_m.F90
+++ b/src/Fortran-interface/bml_setters_m.F90
@@ -16,37 +16,37 @@ module bml_setters_m
   !! no elements are replaced.
   !! The dense version remains the same as set_element.
   interface bml_set_element_new
-     module procedure bml_set_element_new_single_real
-     module procedure bml_set_element_new_double_real
-     module procedure bml_set_element_new_single_complex
-     module procedure bml_set_element_new_double_complex
+    module procedure bml_set_element_new_single_real
+    module procedure bml_set_element_new_double_real
+    module procedure bml_set_element_new_single_complex
+    module procedure bml_set_element_new_double_complex
   end interface bml_set_element_new
 
   !> Routine to set elements.
   !!
   interface bml_set_element
-     module procedure bml_set_element_single_real
-     module procedure bml_set_element_double_real
-     module procedure bml_set_element_single_complex
-     module procedure bml_set_element_double_complex
+    module procedure bml_set_element_single_real
+    module procedure bml_set_element_double_real
+    module procedure bml_set_element_single_complex
+    module procedure bml_set_element_double_complex
   end interface bml_set_element
 
   !> Routine to set rows.
   !!
   interface bml_set_row
-     module procedure bml_set_row_single_real
-     module procedure bml_set_row_double_real
-     module procedure bml_set_row_single_complex
-     module procedure bml_set_row_double_complex
+    module procedure bml_set_row_single_real
+    module procedure bml_set_row_double_real
+    module procedure bml_set_row_single_complex
+    module procedure bml_set_row_double_complex
   end interface bml_set_row
 
   !> Routine to set diagonal.
   !!
   interface bml_set_diagonal
-     module procedure bml_set_diagonal_single_real
-     module procedure bml_set_diagonal_double_real
-     module procedure bml_set_diagonal_single_complex
-     module procedure bml_set_diagonal_double_complex
+    module procedure bml_set_diagonal_single_real
+    module procedure bml_set_diagonal_double_real
+    module procedure bml_set_diagonal_single_complex
+    module procedure bml_set_diagonal_double_complex
   end interface bml_set_diagonal
 
   public :: bml_set_row
@@ -158,9 +158,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_row_C(a%ptr, i-1, c_loc(row), threshold_)
@@ -177,9 +177,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_row_C(a%ptr, i-1, c_loc(row), threshold_)
@@ -196,9 +196,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_row_C(a%ptr, i-1, c_loc(row), threshold_)
@@ -215,9 +215,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_row_C(a%ptr, i-1, c_loc(row), threshold_)
@@ -234,9 +234,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_diagonal_C(a%ptr, c_loc(diagonal), threshold_)
@@ -252,9 +252,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_diagonal_C(a%ptr, c_loc(diagonal), threshold_)
@@ -270,9 +270,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_diagonal_C(a%ptr,c_loc(diagonal), threshold_)
@@ -288,9 +288,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if(present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0d0
+      threshold_ = 0d0
     end if
 
     call bml_set_diagonal_C(a%ptr,c_loc(diagonal), threshold_)

--- a/src/Fortran-interface/bml_submatrix_m.F90
+++ b/src/Fortran-interface/bml_submatrix_m.F90
@@ -41,19 +41,19 @@ contains
     integer(C_INT) :: cflag
 
     if (double_jump_flag .eqv. .true.) then
-       cflag = 1
+      cflag = 1
     else
-       cflag = 0;
+      cflag = 0;
     endif
 
     if (present(a)) then
-       call bml_matrix2submatrix_index_C(a%ptr, b%ptr, &
-            c_loc(nodelist), nsize, c_loc(core_halo_index), &
-            c_loc(vsize), cflag)
+      call bml_matrix2submatrix_index_C(a%ptr, b%ptr, &
+           c_loc(nodelist), nsize, c_loc(core_halo_index), &
+           c_loc(vsize), cflag)
     else
-       call bml_matrix2submatrix_index_graph_C(b%ptr, &
-            c_loc(nodelist), nsize, c_loc(core_halo_index), &
-            c_loc(vsize), cflag)
+      call bml_matrix2submatrix_index_graph_C(b%ptr, &
+           c_loc(nodelist), nsize, c_loc(core_halo_index), &
+           c_loc(vsize), cflag)
     endif
 
   end subroutine bml_matrix2submatrix_index
@@ -98,9 +98,9 @@ contains
     real(C_DOUBLE) :: threshold_
 
     if (present(threshold)) then
-       threshold_ = threshold
+      threshold_ = threshold
     else
-       threshold_ = 0
+      threshold_ = 0
     end if
 
     call bml_submatrix2matrix_C(a%ptr, b%ptr, c_loc(core_halo_index), lsize, &

--- a/src/Fortran-interface/bml_types_m.F90
+++ b/src/Fortran-interface/bml_types_m.F90
@@ -23,22 +23,22 @@ module bml_types_m
 
   !> The bml vector type.
   type :: bml_vector_t
-     !> The C pointer to the vector.
-     type(C_PTR) :: ptr = C_NULL_PTR
-     !contains
-     !   procedure :: bml_vector_t_assign
-     !   generic :: assignment(=) => bml_vector_t_assign
-     !   final :: destruct_bml_vector_t
+    !> The C pointer to the vector.
+    type(C_PTR) :: ptr = C_NULL_PTR
+    !contains
+    !   procedure :: bml_vector_t_assign
+    !   generic :: assignment(=) => bml_vector_t_assign
+    !   final :: destruct_bml_vector_t
   end type bml_vector_t
 
   !> The bml matrix type.
   type :: bml_matrix_t
-     !> The C pointer to the matrix.
-     type(C_PTR) :: ptr = C_NULL_PTR
-     !contains
-     !   procedure :: bml_matrix_t_assign
-     !   generic :: assignment(=) => bml_matrix_t_assign
-     !   final :: destruct_bml_matrix_t
+    !> The C pointer to the matrix.
+    type(C_PTR) :: ptr = C_NULL_PTR
+    !contains
+    !   procedure :: bml_matrix_t_assign
+    !   generic :: assignment(=) => bml_matrix_t_assign
+    !   final :: destruct_bml_matrix_t
   end type bml_matrix_t
 
   !> The bml-dense matrix type identifier.
@@ -77,7 +77,7 @@ contains
     type(bml_matrix_t), intent(inout) :: a
 
     if (c_associated(a%ptr)) then
-       call bml_deallocate_C(a%ptr)
+      call bml_deallocate_C(a%ptr)
     end if
     a%ptr = C_NULL_PTR
 

--- a/src/Fortran-interface/bml_utilities_m.F90
+++ b/src/Fortran-interface/bml_utilities_m.F90
@@ -13,11 +13,11 @@ module bml_utilities_m
   private
 
   interface bml_print_vector
-     module procedure bml_print_bml_vector
+    module procedure bml_print_bml_vector
   end interface bml_print_vector
 
   interface bml_print_matrix
-     module procedure bml_print_bml_matrix
+    module procedure bml_print_bml_matrix
   end interface bml_print_matrix
 
   public :: bml_print_vector

--- a/src/Fortran-interface/bml_utilities_typed_m.F90
+++ b/src/Fortran-interface/bml_utilities_typed_m.F90
@@ -10,7 +10,7 @@ module bml_utilities_MATRIX_TYPE_m
 
   !> Print a dense matrix.
   interface bml_print_matrix
-     module procedure bml_print_dense_matrix_MATRIX_TYPE
+    module procedure bml_print_dense_matrix_MATRIX_TYPE
   end interface bml_print_matrix
 
   public :: bml_print_matrix

--- a/tests/Fortran-tests/add_matrix.F90
+++ b/tests/Fortran-tests/add_matrix.F90
@@ -8,8 +8,8 @@ module add_matrix_m
   private
 
   type, public, extends(test_t) :: add_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type add_matrix_t
 
 contains
@@ -66,25 +66,25 @@ contains
     call bml_print_matrix("C", c_dense, 1, n, 1, n)
     call bml_print_matrix("D", d_dense, 1, n, 1, n)
     do i = 1, n
-       do j = 1, n
-          expected = alpha * a_dense(i, j) + beta * c_dense(i, j)
-          rel_diff = abs((expected - b_dense(i, j)) / expected)
-          if(rel_diff > rel_tol) then
-             print *, "rel. diff = ", rel_diff
-             call bml_error(__FILE__, __LINE__, "add() matrices are not identical")
-          end if
+      do j = 1, n
+        expected = alpha * a_dense(i, j) + beta * c_dense(i, j)
+        rel_diff = abs((expected - b_dense(i, j)) / expected)
+        if(rel_diff > rel_tol) then
+          print *, "rel. diff = ", rel_diff
+          call bml_error(__FILE__, __LINE__, "add() matrices are not identical")
+        end if
 
-          if(i == j) then
-             expected = a_dense(i, j) + alpha
-          else
-             expected = a_dense(i, j)
-          end if
-          rel_diff = abs((expected - d_dense(i, j)) / expected)
-          if(rel_diff > rel_tol) then
-             print *, "rel. diff = ", rel_diff
-             call bml_error(__FILE__, __LINE__, "add_identity() matrices are not identical")
-          end if
-       end do
+        if(i == j) then
+          expected = a_dense(i, j) + alpha
+        else
+          expected = a_dense(i, j)
+        end if
+        rel_diff = abs((expected - d_dense(i, j)) / expected)
+        if(rel_diff > rel_tol) then
+          print *, "rel. diff = ", rel_diff
+          call bml_error(__FILE__, __LINE__, "add_identity() matrices are not identical")
+        end if
+      end do
     end do
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/allocate_matrix.F90
+++ b/tests/Fortran-tests/allocate_matrix.F90
@@ -8,8 +8,8 @@ module allocate_matrix_m
   private
 
   type, public, extends(test_t) :: allocate_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type allocate_matrix_t
 
 contains
@@ -33,18 +33,18 @@ contains
          & a)
     call bml_export_to_dense(a, a_dense)
     if(lbound(a_dense, 1) /= 1 .or. lbound(a_dense, 2) /= 1) then
-       print *, "incorrect lbound"
-       print *, "lbound(a_dense, 1) = ", lbound(a_dense, 1)
-       print *, "lbound(a_dense, 2) = ", lbound(a_dense, 2)
-       test_result = .false.
-       return
+      print *, "incorrect lbound"
+      print *, "lbound(a_dense, 1) = ", lbound(a_dense, 1)
+      print *, "lbound(a_dense, 2) = ", lbound(a_dense, 2)
+      test_result = .false.
+      return
     end if
     if(ubound(a_dense, 1) /= n .or. ubound(a_dense, 2) /= n) then
-       print *, "incorrect ubound"
-       print *, "ubound(a_dense, 1) = ", ubound(a_dense, 1)
-       print *, "ubound(a_dense, 2) = ", ubound(a_dense, 2)
-       test_result = .false.
-       return
+      print *, "incorrect ubound"
+      print *, "ubound(a_dense, 1) = ", ubound(a_dense, 1)
+      print *, "ubound(a_dense, 2) = ", ubound(a_dense, 2)
+      test_result = .false.
+      return
     end if
     call bml_print_matrix("A", a_dense, 1, n, 1, n)
     deallocate(a_dense)
@@ -55,21 +55,21 @@ contains
     call bml_print_matrix("A", a_dense, lbound(a_dense, 1), ubound(a_dense, 1), &
          lbound(a_dense, 2), ubound(a_dense, 2))
     do i = 1, n
-       do j = 1, n
-          if(i == j) then
-             if(abs(a_dense(i, j)-1) > 1e-12) then
-                print *, "Incorrect value on diagonal", a_dense(i, j)
-                test_result = .false.
-                return
-             end if
-          else
-             if(abs(a_dense(i, j)) > 1e-12) then
-                print *, "Incorrect value off diagonal", a_dense(i, j)
-                test_result = .false.
-                return
-             end if
+      do j = 1, n
+        if(i == j) then
+          if(abs(a_dense(i, j)-1) > 1e-12) then
+            print *, "Incorrect value on diagonal", a_dense(i, j)
+            test_result = .false.
+            return
           end if
-       end do
+        else
+          if(abs(a_dense(i, j)) > 1e-12) then
+            print *, "Incorrect value off diagonal", a_dense(i, j)
+            test_result = .false.
+            return
+          end if
+        end if
+      end do
     end do
     print *, "Identity matrix test passed"
 

--- a/tests/Fortran-tests/bandwidth.F90
+++ b/tests/Fortran-tests/bandwidth.F90
@@ -8,8 +8,8 @@ module bandwidth_m
   private
 
   type, public, extends(test_t) :: bandwidth_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type bandwidth_t
 
 contains
@@ -31,29 +31,29 @@ contains
 
     a_dense = 0
     do i = 1, n
-       do j = i, min(i + 4, n)
-          a_dense(i, j) = 1
-       end do
+      do j = i, min(i + 4, n)
+        a_dense(i, j) = 1
+      end do
     end do
     call bml_print_matrix("A", a_dense, 1, n, 1, n)
     call bml_import_from_dense(matrix_type, a_dense, a, 0d0, n)
     call bml_print_matrix("A", a, 1, n, 1, n)
 
     do i = 1, n
-       bandwidth = bml_get_row_bandwidth(a, i)
-       if(bandwidth /= min(i + 4, n) - i + 1) then
-          print *, "row ", i, " incorrect bandwidth, ", bandwidth, &
-               ", expected ", min(i + 4, n) - i + 1
-          test_result = .false.
-       else
-          print *, "row ", i, " correct bandwidth, ", bandwidth
-       end if
+      bandwidth = bml_get_row_bandwidth(a, i)
+      if(bandwidth /= min(i + 4, n) - i + 1) then
+        print *, "row ", i, " incorrect bandwidth, ", bandwidth, &
+             ", expected ", min(i + 4, n) - i + 1
+        test_result = .false.
+      else
+        print *, "row ", i, " correct bandwidth, ", bandwidth
+      end if
     end do
     bandwidth = bml_get_bandwidth(a)
     print *, "matrix banddwidth = ", bandwidth
     if(bandwidth /= 5) then
-       print *, "total bandwidth incorrect"
-       test_result = .false.
+      print *, "total bandwidth incorrect"
+      test_result = .false.
     end if
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/convert_matrix.F90
+++ b/tests/Fortran-tests/convert_matrix.F90
@@ -8,8 +8,8 @@ module convert_matrix_m
   private
 
   type, public, extends(test_t) :: convert_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type convert_matrix_t
 
 contains
@@ -38,20 +38,20 @@ contains
     call random_number(a_random)
     allocate(a_dense(n, n))
     do i = 1, n
-       do j = 1, n
-          a_dense(i, j) = a_random(i, j)
-       end do
+      do j = 1, n
+        a_dense(i, j) = a_random(i, j)
+      end do
     end do
     call bml_import_from_dense(matrix_type, a_dense, a, 0.0d0, m)
     call bml_export_to_dense(a, b_dense)
     call bml_print_matrix("A", a_dense, 1, n, 1, n)
     call bml_print_matrix("B", b_dense, 1, n, 1, n)
     if (maxval(abs(a_dense - b_dense)) > 1e-12) then
-       print *, "Matrix element mismatch"
-       test_result = .false.
+      print *, "Matrix element mismatch"
+      test_result = .false.
     end if
     if(test_result) then
-       print *, "Test passed"
+      print *, "Test passed"
     end if
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/copy_matrix.F90
+++ b/tests/Fortran-tests/copy_matrix.F90
@@ -8,8 +8,8 @@ module copy_matrix_m
   private
 
   type, public, extends(test_t) :: copy_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type copy_matrix_t
 
 contains
@@ -43,10 +43,10 @@ contains
     call bml_print_matrix("C", c_dense, 1, n, 1, n)
     if(maxval(abs(a_dense - b_dense)) > 1e-12 .or. &
          maxval(abs(a_dense - c_dense)) > 1e-12) then
-       test_result = .false.
-       print *, "matrices are not identical"
+      test_result = .false.
+      print *, "matrices are not identical"
     else
-       test_result = .true.
+      test_result = .true.
     end if
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/diagonalize_matrix.F90
+++ b/tests/Fortran-tests/diagonalize_matrix.F90
@@ -8,8 +8,8 @@ module diagonalize_matrix_m
   private
 
   type, public, extends(test_t) :: diagonalize_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type diagonalize_matrix_t
 
 contains

--- a/tests/Fortran-tests/get_bandwidth.F90
+++ b/tests/Fortran-tests/get_bandwidth.F90
@@ -8,8 +8,8 @@ module get_bandwidth_m
   private
 
   type, public, extends(test_t) :: get_bandwidth_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type get_bandwidth_t
 
 contains
@@ -32,13 +32,13 @@ contains
     test_result = .true.
 
     do i = 1, n
-       if(bml_get_row_bandwidth(a, i) /= 1) then
-          print *, "Wrong bandwidth on row ", i
-          print *, "Should be 1, but is ", bml_get_row_bandwidth(a, i)
-          call bml_print_matrix("A", a, 1, n, 1, n)
-          test_result = .false.
-          return
-       end if
+      if(bml_get_row_bandwidth(a, i) /= 1) then
+        print *, "Wrong bandwidth on row ", i
+        print *, "Should be 1, but is ", bml_get_row_bandwidth(a, i)
+        call bml_print_matrix("A", a, 1, n, 1, n)
+        test_result = .false.
+        return
+      end if
     end do
     print *, "Test passed"
 

--- a/tests/Fortran-tests/get_matrix.F90
+++ b/tests/Fortran-tests/get_matrix.F90
@@ -8,8 +8,8 @@ module get_matrix_m
   private
 
   type, public, extends(test_t) :: get_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type get_matrix_t
 
 contains
@@ -37,16 +37,16 @@ contains
     call bml_export_to_dense(a, a_dense)
     call bml_print_matrix("A", a_dense, 1, n, 1, n)
     do i = 1, n
-       do j = 1, n
-          call bml_get(a_ij, a, i, j)
-          if(abs(a_ij-a_dense(i, j)) > 1e-12) then
-             test_result = .false.
-             print *, "matrix element mismatch"
-             print *, "got ", a_ij
-             print *, "expected ", a_dense(i, j)
-             return
-          end if
-       end do
+      do j = 1, n
+        call bml_get(a_ij, a, i, j)
+        if(abs(a_ij-a_dense(i, j)) > 1e-12) then
+          test_result = .false.
+          print *, "matrix element mismatch"
+          print *, "got ", a_ij
+          print *, "expected ", a_dense(i, j)
+          return
+        end if
+      end do
     end do
     call bml_deallocate(a)
 

--- a/tests/Fortran-tests/inverse_matrix.F90
+++ b/tests/Fortran-tests/inverse_matrix.F90
@@ -8,8 +8,8 @@ module inverse_matrix_m
   private
 
   type, public, extends(test_t) :: inverse_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type inverse_matrix_t
 
 contains

--- a/tests/Fortran-tests/io_matrix.F90
+++ b/tests/Fortran-tests/io_matrix.F90
@@ -8,8 +8,8 @@ module io_matrix_m
   private
 
   type, public, extends(test_t) :: io_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type io_matrix_t
 
 contains
@@ -44,10 +44,10 @@ contains
     call bml_print_matrix("A", a_dense, 1, n, 1, n)
     call bml_print_matrix("B", b_dense, 1, n, 1, n)
     if(maxval(abs(a_dense - b_dense)) > 1e-12) then
-       test_result = .false.
-       print *, "matrices are not identical"
+      test_result = .false.
+      print *, "matrices are not identical"
     else
-       test_result = .true.
+      test_result = .true.
     end if
 
   end function test_function

--- a/tests/Fortran-tests/multiply_matrix.F90
+++ b/tests/Fortran-tests/multiply_matrix.F90
@@ -8,8 +8,8 @@ module multiply_matrix_m
   private
 
   type, public, extends(test_t) :: multiply_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type multiply_matrix_t
 
 contains
@@ -81,9 +81,9 @@ contains
     allocate(e_dense(n, n))
     e_dense = alpha * matmul(a_dense, b_dense) + beta * c_dense
     if(maxval(abs(e_dense - d_dense)) > abs_tol) then
-       test_result = .false.
-       print *, "incorrect matrix product"
-       print *, "max abs diff = ", maxval(abs(e_dense - d_dense))
+      test_result = .false.
+      print *, "incorrect matrix product"
+      print *, "max abs diff = ", maxval(abs(e_dense - d_dense))
     endif
 
     call bml_export_to_dense(f, f_dense)
@@ -91,9 +91,9 @@ contains
     call bml_print_matrix("F", f_dense, 1, n, 1, n)
     call bml_print_matrix("G", g_dense, 1, n, 1, n)
     if(maxval(abs(f_dense - g_dense)) > abs_tol) then
-       test_result = .false.
-       print *, "incorrect matrix product"
-       print *, "max abs diff = ", maxval(abs(f_dense - g_dense))
+      test_result = .false.
+      print *, "incorrect matrix product"
+      print *, "max abs diff = ", maxval(abs(f_dense - g_dense))
     endif
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/normalize_matrix.F90
+++ b/tests/Fortran-tests/normalize_matrix.F90
@@ -8,8 +8,8 @@ module normalize_matrix_m
   private
 
   type, public, extends(test_t) :: normalize_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type normalize_matrix_t
 
 contains
@@ -71,23 +71,23 @@ contains
          lbound(b_dense, 2), ubound(b_dense, 2))
 
     if ((abs(a_gbnd(1) - scale_factor) > rel_tol) .or. (a_gbnd(2) > rel_tol)) then
-       print *, "Incorrect maxeval or maxminusmin"
-       test_result = .false.
+      print *, "Incorrect maxeval or maxminusmin"
+      test_result = .false.
     end if
 
     if ((abs(b_gbnd(1) - scale_factor*scale_factor) > rel_tol) .or. &
          (abs(b_gbnd(2) - (scale_factor*scale_factor - scale_factor)) > rel_tol)) then
-       print *, "Incorrect maxeval or maxminusmin"
-       test_result = .false.
+      print *, "Incorrect maxeval or maxminusmin"
+      test_result = .false.
     end if
 
     if (abs(b_dense(1,1)) > rel_tol) then
-       print *, "Incorrect maxeval or maxminusmin, failed normalize"
-       test_result = .false.
+      print *, "Incorrect maxeval or maxminusmin, failed normalize"
+      test_result = .false.
     end if
 
     if(test_result) then
-       print *, "Test passed"
+      print *, "Test passed"
     end if
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/scale_matrix.F90
+++ b/tests/Fortran-tests/scale_matrix.F90
@@ -8,8 +8,8 @@ module scale_matrix_m
   private
 
   type, public, extends(test_t) :: scale_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type scale_matrix_t
 
 contains
@@ -45,14 +45,14 @@ contains
     call bml_export_to_dense(c, c_dense)
 
     if(maxval(abs(alpha * a_dense - c_dense)) > abs_tol) then
-       test_result = .false.
-       call bml_print_matrix("A", alpha * a_dense, 1, n, 1, n)
-       call bml_print_matrix("C", c_dense, 1, n, 1, n)
-       print *, "maxval abs difference = ", maxval(abs(alpha * a_dense - c_dense))
-       print *, "abs_tol = ", abs_tol
-       print *, "matrix element mismatch"
+      test_result = .false.
+      call bml_print_matrix("A", alpha * a_dense, 1, n, 1, n)
+      call bml_print_matrix("C", c_dense, 1, n, 1, n)
+      print *, "maxval abs difference = ", maxval(abs(alpha * a_dense - c_dense))
+      print *, "abs_tol = ", abs_tol
+      print *, "matrix element mismatch"
     else
-       test_result = .true.
+      test_result = .true.
     endif
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/test_driver.F90
+++ b/tests/Fortran-tests/test_driver.F90
@@ -13,8 +13,8 @@ program test
 
   write(*, "(A)") "Testing "//MATRIX_TYPE//":"//MATRIX_PRECISION
   if(.not. tester%test_function(MATRIX_TYPE, REAL_NAME, REAL_KIND, N, M)) then
-     write(*, "(A)") "Test failed"
-     error stop
+    write(*, "(A)") "Test failed"
+    error stop
   end if
 
 end program test

--- a/tests/Fortran-tests/test_m.F90
+++ b/tests/Fortran-tests/test_m.F90
@@ -6,18 +6,18 @@ module test_m
   implicit none
 
   type, abstract :: test_t
-   contains
-     procedure(test_function_interface), nopass, deferred :: test_function
+  contains
+    procedure(test_function_interface), nopass, deferred :: test_function
   end type test_t
 
   abstract interface
-     function test_function_interface(matrix_type, element_type, &
-          & element_precision, n, m) result(test_result)
-       character(len=*), intent(in) :: matrix_type, element_type
-       integer, intent(in) :: element_precision
-       integer, intent(in) :: n, m
-       logical :: test_result
-     end function test_function_interface
+    function test_function_interface(matrix_type, element_type, &
+         & element_precision, n, m) result(test_result)
+      character(len=*), intent(in) :: matrix_type, element_type
+      integer, intent(in) :: element_precision
+      integer, intent(in) :: n, m
+      logical :: test_result
+    end function test_function_interface
   end interface
 
 end module test_m

--- a/tests/Fortran-tests/threshold_matrix.F90
+++ b/tests/Fortran-tests/threshold_matrix.F90
@@ -8,8 +8,8 @@ module threshold_matrix_m
   private
 
   type, public, extends(test_t) :: threshold_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type threshold_matrix_t
 
 contains
@@ -35,14 +35,14 @@ contains
 
     test_result = .true.
     do i = 1, n
-       do j = 1, n
-          if(abs(a_dense(i, j)) > 0.0 .and. abs(a_dense(i, j)) < 0.5) then
-             test_result = .false.
-             call bml_print_matrix("A", a_dense, 1, n, 1, n)
-             print *, "matrix not thresholded"
-             return
-          end if
-       end do
+      do j = 1, n
+        if(abs(a_dense(i, j)) > 0.0 .and. abs(a_dense(i, j)) < 0.5) then
+          test_result = .false.
+          call bml_print_matrix("A", a_dense, 1, n, 1, n)
+          print *, "matrix not thresholded"
+          return
+        end if
+      end do
     end do
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/trace_matrix.F90
+++ b/tests/Fortran-tests/trace_matrix.F90
@@ -8,8 +8,8 @@ module trace_matrix_m
   private
 
   type, public, extends(test_t) :: trace_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type trace_matrix_t
 
 contains
@@ -44,14 +44,14 @@ contains
     tr_reference = 0
     call bml_export_to_dense(a, a_dense)
     do i = 1, n
-       tr_reference = tr_reference+a_dense(i, i)
+      tr_reference = tr_reference+a_dense(i, i)
     end do
 
     if(abs((tr_a - tr_reference)/tr_reference) > rel_tol) then
-       test_result = .false.
-       print *, "trace incorrect"
+      test_result = .false.
+      print *, "trace incorrect"
     else
-       test_result = .true.
+      test_result = .true.
     end if
 
     call bml_deallocate(a)

--- a/tests/Fortran-tests/transpose_matrix.F90
+++ b/tests/Fortran-tests/transpose_matrix.F90
@@ -8,8 +8,8 @@ module transpose_matrix_m
   private
 
   type, public, extends(test_t) :: transpose_matrix_t
-   contains
-     procedure, nopass :: test_function
+  contains
+    procedure, nopass :: test_function
   end type transpose_matrix_t
 
 contains
@@ -38,10 +38,10 @@ contains
     call bml_export_to_dense(b, b_dense)
 
     if(maxval(abs(a_dense-transpose(b_dense))) > 1e-12) then
-       test_result = .false.
-       print *, "matrices are not transposes"
+      test_result = .false.
+      print *, "matrices are not transposes"
     else
-       test_result = .true.
+      test_result = .true.
     end if
 
     call bml_deallocate(a)


### PR DESCRIPTION
This change adds the necessary settings for the `indent.sh` script and
all of the whitespace changes in the Fortran files.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/305)
<!-- Reviewable:end -->
