### PR TITLE
Add Fortran related indentation settings

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,4 +3,8 @@
 
 ((c-mode
   ((c-basic-offset . 4)
-   (c-offsets-alist . ((arglist-intro . 4))))))
+   (c-offsets-alist . ((arglist-intro . 4)))))
+ (f90-mode
+  ((f90-if-indent . 2)
+   (f90-do-indent . 2)
+   (f90-type-indent . 2))))


### PR DESCRIPTION
This change adds more settings for the Emacs editor for Fortran
related indentation settings.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/306)
<!-- Reviewable:end -->
