### PR TITLE
Solved a bug in bml_export_to_dense when using magma

### DIFF
--- a/src/C-interface/dense/bml_export_dense_typed.c
+++ b/src/C-interface/dense/bml_export_dense_typed.c
@@ -47,6 +47,7 @@ void *TYPED_FUNC(
             MAGMA(getmatrix) (A->N, A->N,
                               A->matrix, A->ld,
                               (MAGMA_T *) A_dense, A->N, A->queue);
+            MAGMABLAS(transpose_inplace) (A->N, A->matrix, A->ld, A->queue);
 #else
             REAL_T *B_ptr = (REAL_T *) A->matrix;
             for (int i = 0; i < A->N; i++)


### PR DESCRIPTION
When bml_expoert_to_dense was invoked and bml was compiled with magma, the original bml matrix 
was modified (transposed). We are adding another "back" transpose to go back to the original matrix. Another solution would be to allocate an auxiliary matrix and let the original unchanged, but this implies the use of extra memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/309)
<!-- Reviewable:end -->
