### PR TITLE
Fix race condition in call to MAGMA eigensolver

### DIFF
--- a/src/C-interface/dense/bml_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_multiply_dense_typed.c
@@ -59,6 +59,9 @@ void TYPED_FUNC(
     MAGMA_T alpha_ = MAGMACOMPLEX(MAKE) (alpha, 0.);
     MAGMA_T beta_ = MAGMACOMPLEX(MAKE) (beta, 0.);
 
+    magma_queue_sync(A->queue);
+    magma_queue_sync(B->queue);
+
     MAGMA(gemm) (MagmaNoTrans, MagmaNoTrans,
                  A->N, A->N, A->N, alpha_, B->matrix, B->ld,
                  A->matrix, A->ld, beta_, C->matrix, C->ld, C->queue);

--- a/src/C-interface/dense/bml_transpose_dense_typed.c
+++ b/src/C-interface/dense/bml_transpose_dense_typed.c
@@ -47,8 +47,10 @@ bml_matrix_dense_t *TYPED_FUNC(
     int myRank = bml_getMyRank();
 
 #ifdef BML_USE_MAGMA
+    magma_queue_sync(A->queue);
     MAGMABLAS(transpose) (A->N, A->N, A->matrix, A->ld,
-                          B->matrix, B->ld, A->queue);
+                          B->matrix, B->ld, B->queue);
+    magma_queue_sync(B->queue);
 #else
 #pragma omp parallel for                        \
   shared(N, A_matrix, B_matrix)                 \
@@ -79,6 +81,7 @@ void TYPED_FUNC(
     int N = A->N;
 
 #ifdef BML_USE_MAGMA
+    magma_queue_sync(A->queue);
     MAGMABLAS(transpose_inplace) (A->N, A->matrix, A->ld, A->queue);
 #else
     REAL_T *A_matrix = A->matrix;

--- a/tests/C-tests/diagonalize_matrix_typed.c
+++ b/tests/C-tests/diagonalize_matrix_typed.c
@@ -86,7 +86,7 @@ int TYPED_FUNC(
     printf("%s\n", "check eigenvectors norms");
     for (int i = 0; i < N; i++)
     {
-        REAL_T *val = bml_get_dense(aux2, i, i);
+        REAL_T *val = bml_get(aux2, i, i);
         if (fabsf(*val - 1.) > REL_TOL)
         {
             printf("i = %d, val = %e\n", i, *val);


### PR DESCRIPTION
Issue was not showing up for small problems,
but the diagonalize matrix test problem would fail for large
matrices of size >~ 1500.
Add calls to magma_queue_sync() in a few places to avoid race
conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/317)
<!-- Reviewable:end -->
