### PR TITLE
Fix clang warnings

### DIFF
--- a/src/C-interface/bml_export.c
+++ b/src/C-interface/bml_export.c
@@ -32,7 +32,7 @@
  */
 void *
 bml_export_to_dense(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     bml_dense_order_t order)
 {
     switch (bml_get_type(A))

--- a/src/C-interface/bml_export.h
+++ b/src/C-interface/bml_export.h
@@ -6,7 +6,7 @@
 #include "bml_types.h"
 
 void *bml_export_to_dense(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/bml_introspection.c
+++ b/src/C-interface/bml_introspection.c
@@ -17,9 +17,9 @@
  */
 bml_matrix_type_t
 bml_get_type(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
-    bml_matrix_type_t *matrix_type = A;
+    const bml_matrix_type_t *matrix_type = A;
     if (A != NULL)
     {
         return *matrix_type;
@@ -38,7 +38,7 @@ bml_get_type(
  */
 bml_matrix_precision_t
 bml_get_precision(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -71,7 +71,7 @@ bml_get_precision(
  */
 int
 bml_get_N(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -104,7 +104,7 @@ bml_get_N(
  */
 int
 bml_get_M(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -132,7 +132,7 @@ bml_get_M(
 
 int
 bml_get_NB(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -166,7 +166,7 @@ bml_get_NB(
  */
 int
 bml_get_row_bandwidth(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     int i)
 {
     if (i < 0 || i >= bml_get_N(A))
@@ -198,7 +198,7 @@ bml_get_row_bandwidth(
  */
 int
 bml_get_bandwidth(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -225,7 +225,7 @@ bml_get_bandwidth(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode(
-    bml_matrix_t * A)
+    const bml_matrix_t * A)
 {
     switch (bml_get_type(A))
     {
@@ -253,7 +253,7 @@ bml_get_distribution_mode(
  */
 double
 bml_get_sparsity(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     double threshold)
 {
     switch (bml_get_type(A))

--- a/src/C-interface/bml_introspection.h
+++ b/src/C-interface/bml_introspection.h
@@ -6,32 +6,32 @@
 #include "bml_types.h"
 
 bml_matrix_type_t bml_get_type(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 bml_matrix_precision_t bml_get_precision(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 int bml_get_N(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 int bml_get_M(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 int bml_get_NB(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 int bml_get_row_bandwidth(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     int i);
 
 int bml_get_bandwidth(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 double bml_get_sparsity(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     double threshold);
 
 bml_distribution_mode_t bml_get_distribution_mode(
-    bml_matrix_t * A);
+    const bml_matrix_t * A);
 
 #endif

--- a/src/C-interface/bml_utilities.c
+++ b/src/C-interface/bml_utilities.c
@@ -20,7 +20,7 @@
  */
 void
 bml_print_bml_vector(
-    bml_vector_t * v,
+    const bml_vector_t * v,
     int i_l,
     int i_u)
 {
@@ -37,7 +37,7 @@ bml_print_bml_vector(
  */
 void
 bml_print_bml_matrix(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     int i_l,
     int i_u,
     int j_l,
@@ -53,38 +53,38 @@ bml_print_bml_matrix(
             {
                 case single_real:
                 {
-                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const float *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), single_real,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((float*)A_dense);
                     break;
                 }
                 case double_real:
                 {
-                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const double *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), double_real,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((double*)A_dense);
                     break;
                 }
                 case single_complex:
                 {
-                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const float *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), single_complex,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((float*)A_dense);
                     break;
                 }
                 case double_complex:
                 {
-                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const double *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), double_complex,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((double*)A_dense);
                     break;
                 }
                 default:
@@ -97,38 +97,38 @@ bml_print_bml_matrix(
             {
                 case single_real:
                 {
-                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const float *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), single_real,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((float*)A_dense);
                     break;
                 }
                 case double_real:
                 {
-                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const double *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), double_real,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((double*)A_dense);
                     break;
                 }
                 case single_complex:
                 {
-                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const float *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), single_complex,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((float*)A_dense);
                     break;
                 }
                 case double_complex:
                 {
-                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const double *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), double_complex,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((double*)A_dense);
                     break;
                 }
                 default:
@@ -141,40 +141,43 @@ bml_print_bml_matrix(
             {
                 case single_real:
                 {
-                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const float *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), single_real,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((float*)A_dense);
                     break;
                 }
                 case double_real:
                 {
-                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const double *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), double_real,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((double*)A_dense);
                     break;
                 }
                 case single_complex:
                 {
-                    float *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const float *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), single_complex,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((float*)A_dense);
                     break;
                 }
                 case double_complex:
                 {
-                    double *A_dense = bml_export_to_dense(A, dense_row_major);
+                    const double *A_dense = bml_export_to_dense(A, dense_row_major);
                     bml_print_dense_matrix(bml_get_N(A), double_complex,
                                            dense_row_major, A_dense, i_l, i_u,
                                            j_l, j_u);
-                    free(A_dense);
+                    free((double*)A_dense);
                     break;
                 }
+                default:
+                    LOG_ERROR("unknown precision\n");
+                    break;            
             }
             break;
         default:
@@ -199,7 +202,7 @@ bml_print_dense_matrix(
     int N,
     bml_matrix_precision_t matrix_precision,
     bml_dense_order_t order,
-    void *A,
+    const void *A,
     int i_l,
     int i_u,
     int j_l,
@@ -213,7 +216,7 @@ bml_print_dense_matrix(
     {
         case single_real:
         {
-            float *A_typed = A;
+            const float *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -244,7 +247,7 @@ bml_print_dense_matrix(
         }
         case double_real:
         {
-            double *A_typed = A;
+            const double *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -275,7 +278,7 @@ bml_print_dense_matrix(
         }
         case single_complex:
         {
-            float complex *A_typed = A;
+            const float complex *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -310,7 +313,7 @@ bml_print_dense_matrix(
         }
         case double_complex:
         {
-            double complex *A_typed = A;
+            const double complex *A_typed = A;
             switch (order)
             {
                 case dense_row_major:
@@ -361,7 +364,7 @@ void
 bml_print_dense_vector(
     int N,
     bml_matrix_precision_t matrix_precision,
-    void *v,
+    const void *v,
     int i_l,
     int i_u)
 {
@@ -369,7 +372,7 @@ bml_print_dense_vector(
     {
         case single_real:
         {
-            float *v_typed = v;
+            const float *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f", v_typed[i]);
@@ -379,7 +382,7 @@ bml_print_dense_vector(
         }
         case double_real:
         {
-            double *v_typed = v;
+            const double *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f", v_typed[i]);
@@ -389,7 +392,7 @@ bml_print_dense_vector(
         }
         case single_complex:
         {
-            float complex *v_typed = v;
+            const float complex *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f%+1.3fi", creal(v_typed[i]),
@@ -400,7 +403,7 @@ bml_print_dense_vector(
         }
         case double_complex:
         {
-            double complex *v_typed = v;
+            const double complex *v_typed = v;
             for (int i = i_l; i < i_u; i++)
             {
                 printf(" % 1.3f%+1.3fi", creal(v_typed[i]),

--- a/src/C-interface/bml_utilities.h
+++ b/src/C-interface/bml_utilities.h
@@ -9,7 +9,7 @@ void bml_print_dense_matrix(
     int N,
     bml_matrix_precision_t matrix_precision,
     bml_dense_order_t order,
-    void *A,
+    const void *A,
     int i_l,
     int i_u,
     int j_l,
@@ -18,17 +18,17 @@ void bml_print_dense_matrix(
 void bml_print_dense_vector(
     int N,
     bml_matrix_precision_t matrix_precision,
-    void *v,
+    const void *v,
     int i_l,
     int i_u);
 
 void bml_print_bml_vector(
-    bml_vector_t * v,
+    const bml_vector_t * v,
     int i_l,
     int i_u);
 
 void bml_print_bml_matrix(
-    bml_matrix_t * A,
+    const bml_matrix_t * A,
     int i_l,
     int i_u,
     int j_l,

--- a/src/C-interface/dense/bml_export_dense.c
+++ b/src/C-interface/dense/bml_export_dense.c
@@ -21,7 +21,7 @@
  */
 void *
 bml_export_to_dense_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/dense/bml_export_dense.h
+++ b/src/C-interface/dense/bml_export_dense.h
@@ -4,23 +4,23 @@
 #include "bml_types_dense.h"
 
 void *bml_export_to_dense_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_single_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_double_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_single_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_dense_double_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/dense/bml_export_dense_typed.c
+++ b/src/C-interface/dense/bml_export_dense_typed.c
@@ -24,7 +24,7 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_dense) (
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     bml_dense_order_t order)
 {
     REAL_T *A_dense = bml_allocate_memory(sizeof(REAL_T) * A->N * A->N);

--- a/src/C-interface/dense/bml_introspection_dense.c
+++ b/src/C-interface/dense/bml_introspection_dense.c
@@ -10,7 +10,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_dense(
-    bml_matrix_dense_t * A)
+    const bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -29,7 +29,7 @@ bml_get_precision_dense(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_dense(
-    bml_matrix_dense_t * A)
+    const bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -48,7 +48,7 @@ bml_get_distribution_mode_dense(
  */
 int
 bml_get_N_dense(
-    bml_matrix_dense_t * A)
+    const bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -67,7 +67,7 @@ bml_get_N_dense(
  */
 int
 bml_get_M_dense(
-    bml_matrix_dense_t * A)
+    const bml_matrix_dense_t * A)
 {
     if (A != NULL)
     {
@@ -87,7 +87,7 @@ bml_get_M_dense(
  */
 int
 bml_get_row_bandwidth_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i)
 {
     switch (bml_get_precision_dense(A))
@@ -121,7 +121,7 @@ bml_get_row_bandwidth_dense(
  */
 int
 bml_get_bandwidth_dense(
-    bml_matrix_dense_t * A)
+    const bml_matrix_dense_t * A)
 {
     switch (bml_get_precision_dense(A))
     {
@@ -161,7 +161,7 @@ bml_get_bandwidth_dense(
  */
 double
 bml_get_sparsity_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold)
 {
     switch (bml_get_precision_dense(A))

--- a/src/C-interface/dense/bml_introspection_dense.h
+++ b/src/C-interface/dense/bml_introspection_dense.h
@@ -4,71 +4,71 @@
 #include "bml_types_dense.h"
 
 bml_matrix_precision_t bml_get_precision_dense(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_N_dense(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_M_dense(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_row_bandwidth_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i);
 
 bml_distribution_mode_t bml_get_distribution_mode_dense(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_row_bandwidth_dense_single_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i);
 
 int bml_get_row_bandwidth_dense_double_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i);
 
 int bml_get_row_bandwidth_dense_single_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i);
 
 int bml_get_row_bandwidth_dense_double_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i);
 
 int bml_get_bandwidth_dense(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_single_real(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_double_real(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_single_complex(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 int bml_get_bandwidth_dense_double_complex(
-    bml_matrix_dense_t * A);
+    const bml_matrix_dense_t * A);
 
 // Get the sparsity of a bml matrix
 double bml_get_sparsity_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold);
 
 double bml_get_sparsity_dense_single_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold);
 
 double bml_get_sparsity_dense_double_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold);
 
 double bml_get_sparsity_dense_single_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold);
 
 double bml_get_sparsity_dense_double_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold);
 
 #endif

--- a/src/C-interface/dense/bml_introspection_dense_typed.c
+++ b/src/C-interface/dense/bml_introspection_dense_typed.c
@@ -17,7 +17,7 @@
  */
 int TYPED_FUNC(
     bml_get_row_bandwidth_dense) (
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i)
 {
     assert(A != NULL);
@@ -42,7 +42,7 @@ int TYPED_FUNC(
  */
 int TYPED_FUNC(
     bml_get_bandwidth_dense) (
-    bml_matrix_dense_t * A)
+    const bml_matrix_dense_t * A)
 {
     assert(A != NULL);
 
@@ -76,7 +76,7 @@ int TYPED_FUNC(
  */
 double TYPED_FUNC(
     bml_get_sparsity_dense) (
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     double threshold)
 {
 

--- a/src/C-interface/dense/bml_utilities_dense.c
+++ b/src/C-interface/dense/bml_utilities_dense.c
@@ -55,7 +55,7 @@ bml_write_bml_matrix_dense(
 
 void
 bml_print_bml_matrix_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,

--- a/src/C-interface/dense/bml_utilities_dense.h
+++ b/src/C-interface/dense/bml_utilities_dense.h
@@ -9,35 +9,35 @@
 #include <stdlib.h>
 
 void bml_print_bml_matrix_dense(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,
     int j_u);
 
 void bml_print_bml_matrix_dense_single_real(
-    bml_matrix_dense_t * A,
+    const  bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,
     int j_u);
 
 void bml_print_bml_matrix_dense_double_real(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,
     int j_u);
 
 void bml_print_bml_matrix_dense_single_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,
     int j_u);
 
 void bml_print_bml_matrix_dense_double_complex(
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,

--- a/src/C-interface/dense/bml_utilities_dense_typed.c
+++ b/src/C-interface/dense/bml_utilities_dense_typed.c
@@ -129,7 +129,7 @@ void TYPED_FUNC(
 
 void TYPED_FUNC(
     bml_print_bml_matrix_dense) (
-    bml_matrix_dense_t * A,
+    const bml_matrix_dense_t * A,
     int i_l,
     int i_u,
     int j_l,

--- a/src/C-interface/ellblock/bml_export_ellblock.c
+++ b/src/C-interface/ellblock/bml_export_ellblock.c
@@ -17,7 +17,7 @@
  */
 void *
 bml_export_to_dense_ellblock(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/ellblock/bml_export_ellblock.h
+++ b/src/C-interface/ellblock/bml_export_ellblock.h
@@ -4,23 +4,23 @@
 #include "bml_types_ellblock.h"
 
 void *bml_export_to_dense_ellblock(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_single_real(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_double_real(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_single_complex(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellblock_double_complex(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/ellblock/bml_export_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_export_ellblock_typed.c
@@ -27,7 +27,7 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_ellblock) (
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     bml_dense_order_t order)
 {
     assert(A->N > 0);

--- a/src/C-interface/ellblock/bml_import_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_import_ellblock_typed.c
@@ -84,7 +84,7 @@ bml_matrix_ellblock_t *TYPED_FUNC(
             }
             double norminf = TYPED_FUNC(bml_norm_inf)
                 (A_ij, A_bsize[ib], A_bsize[jb], A_bsize[jb]);
-            if (is_above_threshold(norminf, threshold))
+            if (is_norm_above_threshold(norminf, threshold))
             {
                 int ind = ROWMAJOR(ib, A_nnzb[ib], NB, MB);
                 A_bml->ptr_value[ind] = malloc(nelements * sizeof(REAL_T));

--- a/src/C-interface/ellblock/bml_introspection_ellblock.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_ellblock(
-    bml_matrix_ellblock_t * A)
+    const bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -37,7 +37,7 @@ bml_get_precision_ellblock(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_ellblock(
-    bml_matrix_ellblock_t * A)
+    const bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -56,7 +56,7 @@ bml_get_distribution_mode_ellblock(
  */
 int
 bml_get_N_ellblock(
-    bml_matrix_ellblock_t * A)
+    const bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -75,7 +75,7 @@ bml_get_N_ellblock(
  */
 int
 bml_get_M_ellblock(
-    bml_matrix_ellblock_t * A)
+    const bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -89,7 +89,7 @@ bml_get_M_ellblock(
 
 int
 bml_get_NB_ellblock(
-    bml_matrix_ellblock_t * A)
+    const bml_matrix_ellblock_t * A)
 {
     if (A != NULL)
     {
@@ -109,7 +109,7 @@ bml_get_NB_ellblock(
  */
 int
 bml_get_row_bandwidth_ellblock(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     int i)
 {
     //determine block index and index within block
@@ -136,7 +136,7 @@ bml_get_row_bandwidth_ellblock(
  */
 int
 bml_get_bandwidth_ellblock(
-    bml_matrix_ellblock_t * A)
+    const bml_matrix_ellblock_t * A)
 {
     int max_bandwidth = 0;
     int offset = 0;
@@ -164,7 +164,7 @@ bml_get_bandwidth_ellblock(
  */
 double
 bml_get_sparsity_ellblock(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold)
 {
     switch (bml_get_precision_ellblock(A))

--- a/src/C-interface/ellblock/bml_introspection_ellblock.h
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.h
@@ -4,46 +4,46 @@
 #include "bml_types_ellblock.h"
 
 bml_matrix_precision_t bml_get_precision_ellblock(
-    bml_matrix_ellblock_t * A);
+    const bml_matrix_ellblock_t * A);
 
 bml_distribution_mode_t bml_get_distribution_mode_ellblock(
-    bml_matrix_ellblock_t * A);
+    const bml_matrix_ellblock_t * A);
 
 int bml_get_N_ellblock(
-    bml_matrix_ellblock_t * A);
+    const bml_matrix_ellblock_t * A);
 
 int bml_get_M_ellblock(
-    bml_matrix_ellblock_t * A);
+    const bml_matrix_ellblock_t * A);
 
 int bml_get_NB_ellblock(
-    bml_matrix_ellblock_t * A);
+    const bml_matrix_ellblock_t * A);
 
 int bml_get_row_bandwidth_ellblock(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     int i);
 
 int bml_get_bandwidth_ellblock(
-    bml_matrix_ellblock_t * A);
+    const bml_matrix_ellblock_t * A);
 
     // Get the sparsity of a bml matrix
 double bml_get_sparsity_ellblock(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold);
 
 double bml_get_sparsity_ellblock_single_real(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold);
 
 double bml_get_sparsity_ellblock_double_real(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold);
 
 double bml_get_sparsity_ellblock_single_complex(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold);
 
 double bml_get_sparsity_ellblock_double_complex(
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold);
 
 #endif

--- a/src/C-interface/ellblock/bml_introspection_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock_typed.c
@@ -25,7 +25,7 @@
  */
 double TYPED_FUNC(
     bml_get_sparsity_ellblock) (
-    bml_matrix_ellblock_t * A,
+    const bml_matrix_ellblock_t * A,
     double threshold)
 {
     int nnzs = 0;

--- a/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
@@ -203,9 +203,9 @@ void *TYPED_FUNC(
             assert(ll < MB);
             int jp = jx[jb];
             REAL_T *xtmp = x_ptr[jp];
-            REAL_T normx = TYPED_FUNC(bml_norm_inf_fast)
+            double normx = TYPED_FUNC(bml_norm_inf_fast)
                 (xtmp, bsize[ib] * bsize[jp]);
-            if (jp == ib || is_above_threshold(normx, threshold))
+            if (jp == ib || is_norm_above_threshold(normx, threshold))
             {
                 if (jp == ib)
                 {
@@ -347,7 +347,7 @@ void TYPED_FUNC(
             double normx = TYPED_FUNC(bml_norm_inf)
                 (xtmp, bsize[ib], bsize[jp], bsize[jp]);
 
-            if (jp == ib || is_above_threshold(normx, threshold))
+            if (jp == ib || is_norm_above_threshold(normx, threshold))
             {
                 int nelements = bsize[ib] * bsize[jp];
                 int ind = ROWMAJOR(ib, ll, NB, C->MB);
@@ -467,7 +467,7 @@ void TYPED_FUNC(
             {
                 int jp = jx[jb];
                 REAL_T *xtmp = x_ptr[jp];
-                REAL_T normx = TYPED_FUNC(bml_norm_inf)
+                double normx = TYPED_FUNC(bml_norm_inf)
                     (xtmp, bsize[ib], bsize[jp], bsize[jp]);
                 // Diagonal elements are saved in first column
                 if (jp == ib)
@@ -477,7 +477,7 @@ void TYPED_FUNC(
                     C_indexb[ROWMAJOR(ib, ll, NB, MB)] = jp;
                     ll++;
                 }
-                else if (is_above_threshold(normx, adjust_threshold))
+                else if (is_norm_above_threshold(normx, adjust_threshold))
                 {
                     memcpy(C_ptr_value[ROWMAJOR(ib, ll, NB, MB)], xtmp,
                            bsize[ib] * bsize[ll] * sizeof(REAL_T));

--- a/src/C-interface/ellblock/bml_trace_ellblock.h
+++ b/src/C-interface/ellblock/bml_trace_ellblock.h
@@ -1,5 +1,5 @@
 #ifndef __BML_TRACE_ELLBLOCK_H
-#define __BML_TRACE_ELLNLOCK_H
+#define __BML_TRACE_ELLBLOCK_H
 
 #include "bml_types_ellblock.h"
 

--- a/src/C-interface/ellpack/bml_export_ellpack.c
+++ b/src/C-interface/ellpack/bml_export_ellpack.c
@@ -17,7 +17,7 @@
  */
 void *
 bml_export_to_dense_ellpack(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/ellpack/bml_export_ellpack.h
+++ b/src/C-interface/ellpack/bml_export_ellpack.h
@@ -4,23 +4,23 @@
 #include "bml_types_ellpack.h"
 
 void *bml_export_to_dense_ellpack(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_single_real(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_double_real(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_single_complex(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellpack_double_complex(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/ellpack/bml_export_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_export_ellpack_typed.c
@@ -25,7 +25,7 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_ellpack) (
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     bml_dense_order_t order)
 {
     int N = A->N;

--- a/src/C-interface/ellpack/bml_introspection_ellpack.c
+++ b/src/C-interface/ellpack/bml_introspection_ellpack.c
@@ -18,7 +18,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_ellpack(
-    bml_matrix_ellpack_t * A)
+    const bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -37,7 +37,7 @@ bml_get_precision_ellpack(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_ellpack(
-    bml_matrix_ellpack_t * A)
+    const bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -56,7 +56,7 @@ bml_get_distribution_mode_ellpack(
  */
 int
 bml_get_N_ellpack(
-    bml_matrix_ellpack_t * A)
+   const bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -75,7 +75,7 @@ bml_get_N_ellpack(
  */
 int
 bml_get_M_ellpack(
-    bml_matrix_ellpack_t * A)
+    const bml_matrix_ellpack_t * A)
 {
     if (A != NULL)
     {
@@ -95,7 +95,7 @@ bml_get_M_ellpack(
  */
 int
 bml_get_row_bandwidth_ellpack(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     int i)
 {
     return A->nnz[i];
@@ -108,7 +108,7 @@ bml_get_row_bandwidth_ellpack(
  */
 int
 bml_get_bandwidth_ellpack(
-    bml_matrix_ellpack_t * A)
+    const bml_matrix_ellpack_t * A)
 {
     int max_bandwidth = 0;
     for (int i = 0; i < A->N; i++)
@@ -134,7 +134,7 @@ bml_get_bandwidth_ellpack(
  */
 double
 bml_get_sparsity_ellpack(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold)
 {
     switch (bml_get_precision_ellpack(A))

--- a/src/C-interface/ellpack/bml_introspection_ellpack.h
+++ b/src/C-interface/ellpack/bml_introspection_ellpack.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellpack.h"
 
 bml_matrix_precision_t bml_get_precision_ellpack(
-    bml_matrix_ellpack_t * A);
+    const bml_matrix_ellpack_t * A);
 
 bml_distribution_mode_t bml_get_distribution_mode_ellpack(
-    bml_matrix_ellpack_t * A);
+    const bml_matrix_ellpack_t * A);
 
 int bml_get_N_ellpack(
-    bml_matrix_ellpack_t * A);
+    const bml_matrix_ellpack_t * A);
 
 int bml_get_M_ellpack(
-    bml_matrix_ellpack_t * A);
+    const bml_matrix_ellpack_t * A);
 
 int bml_get_row_bandwidth_ellpack(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     int i);
 
 int bml_get_bandwidth_ellpack(
-    bml_matrix_ellpack_t * A);
+    const bml_matrix_ellpack_t * A);
 
     // Get the sparsity of a bml matrix
 double bml_get_sparsity_ellpack(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold);
 
 double bml_get_sparsity_ellpack_single_real(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold);
 
 double bml_get_sparsity_ellpack_double_real(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold);
 
 double bml_get_sparsity_ellpack_single_complex(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold);
 
 double bml_get_sparsity_ellpack_double_complex(
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold);
 
 #endif

--- a/src/C-interface/ellpack/bml_introspection_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_introspection_ellpack_typed.c
@@ -24,7 +24,7 @@
  */
 double TYPED_FUNC(
     bml_get_sparsity_ellpack) (
-    bml_matrix_ellpack_t * A,
+    const bml_matrix_ellpack_t * A,
     double threshold)
 {
     int nnzs = 0;

--- a/src/C-interface/ellpack/bml_submatrix_ellpack.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack.c
@@ -300,8 +300,8 @@ bml_group_matrix_ellpack(
 
 int
 sortById(
-    void *a,
-    void *b)
+    const void *a,
+    const void *b)
 {
     int aId = *((int *) a);
     int bId = *((int *) b);

--- a/src/C-interface/ellsort/bml_export_ellsort.c
+++ b/src/C-interface/ellsort/bml_export_ellsort.c
@@ -17,7 +17,7 @@
  */
 void *
 bml_export_to_dense_ellsort(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order)
 {
     switch (A->matrix_precision)

--- a/src/C-interface/ellsort/bml_export_ellsort.h
+++ b/src/C-interface/ellsort/bml_export_ellsort.h
@@ -4,23 +4,23 @@
 #include "bml_types_ellsort.h"
 
 void *bml_export_to_dense_ellsort(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_single_real(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_double_real(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_single_complex(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order);
 
 void *bml_export_to_dense_ellsort_double_complex(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order);
 
 #endif

--- a/src/C-interface/ellsort/bml_export_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_export_ellsort_typed.c
@@ -25,7 +25,7 @@
  */
 void *TYPED_FUNC(
     bml_export_to_dense_ellsort) (
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     bml_dense_order_t order)
 {
     int N = A->N;

--- a/src/C-interface/ellsort/bml_introspection_ellsort.c
+++ b/src/C-interface/ellsort/bml_introspection_ellsort.c
@@ -17,7 +17,7 @@
  */
 bml_matrix_precision_t
 bml_get_precision_ellsort(
-    bml_matrix_ellsort_t * A)
+    const bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -36,7 +36,7 @@ bml_get_precision_ellsort(
  */
 bml_distribution_mode_t
 bml_get_distribution_mode_ellsort(
-    bml_matrix_ellsort_t * A)
+    const bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -55,7 +55,7 @@ bml_get_distribution_mode_ellsort(
  */
 int
 bml_get_N_ellsort(
-    bml_matrix_ellsort_t * A)
+    const bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -74,7 +74,7 @@ bml_get_N_ellsort(
  */
 int
 bml_get_M_ellsort(
-    bml_matrix_ellsort_t * A)
+    const bml_matrix_ellsort_t * A)
 {
     if (A != NULL)
     {
@@ -94,7 +94,7 @@ bml_get_M_ellsort(
  */
 int
 bml_get_row_bandwidth_ellsort(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     int i)
 {
     return A->nnz[i];
@@ -107,7 +107,7 @@ bml_get_row_bandwidth_ellsort(
  */
 int
 bml_get_bandwidth_ellsort(
-    bml_matrix_ellsort_t * A)
+    const bml_matrix_ellsort_t * A)
 {
     int max_bandwidth = 0;
     for (int i = 0; i < A->N; i++)
@@ -132,7 +132,7 @@ bml_get_bandwidth_ellsort(
  */
 double
 bml_get_sparsity_ellsort(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold)
 {
     double sparsity;

--- a/src/C-interface/ellsort/bml_introspection_ellsort.h
+++ b/src/C-interface/ellsort/bml_introspection_ellsort.h
@@ -4,43 +4,43 @@
 #include "bml_types_ellsort.h"
 
 bml_matrix_precision_t bml_get_precision_ellsort(
-    bml_matrix_ellsort_t * A);
+    const bml_matrix_ellsort_t * A);
 
 bml_distribution_mode_t bml_get_distribution_mode_ellsort(
-    bml_matrix_ellsort_t * A);
+    const bml_matrix_ellsort_t * A);
 
 int bml_get_N_ellsort(
-    bml_matrix_ellsort_t * A);
+    const bml_matrix_ellsort_t * A);
 
 int bml_get_M_ellsort(
-    bml_matrix_ellsort_t * A);
+    const bml_matrix_ellsort_t * A);
 
 int bml_get_row_bandwidth_ellsort(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     int i);
 
 int bml_get_bandwidth_ellsort(
-    bml_matrix_ellsort_t * A);
+    const bml_matrix_ellsort_t * A);
 
     // Get the sparsity of a bml matrix
 double bml_get_sparsity_ellsort(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold);
 
 double bml_get_sparsity_ellsort_single_real(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold);
 
 double bml_get_sparsity_ellsort_double_real(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold);
 
 double bml_get_sparsity_ellsort_single_complex(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold);
 
 double bml_get_sparsity_ellsort_double_complex(
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold);
 
 #endif

--- a/src/C-interface/ellsort/bml_introspection_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_introspection_ellsort_typed.c
@@ -24,7 +24,7 @@
  */
 double TYPED_FUNC(
     bml_get_sparsity_ellsort) (
-    bml_matrix_ellsort_t * A,
+    const bml_matrix_ellsort_t * A,
     double threshold)
 {
     int nnzs = 0;

--- a/src/typed.h
+++ b/src/typed.h
@@ -23,7 +23,7 @@
 #define MAGMA_PREFIX s
 #define XSMM_PREFIX libxsmm_
 #define REAL_PART(x) (x)
-#define IMAGINARY_PART(x) (0)
+#define IMAGINARY_PART(x) (0.)
 #define COMPLEX_CONJUGATE(x) (x)
 #define ABS(x) (fabsf(x))
 #define is_above_threshold(x, t) (fabsf(x) > (float) (t))
@@ -35,7 +35,7 @@
 #define MAGMA_PREFIX d
 #define XSMM_PREFIX libxsmm_
 #define REAL_PART(x) (x)
-#define IMAGINARY_PART(x) (0)
+#define IMAGINARY_PART(x) (0.)
 #define COMPLEX_CONJUGATE(x) (x)
 #define ABS(x) (fabs(x))
 #define is_above_threshold(x, t) (fabs(x) > (double) (t))
@@ -67,6 +67,7 @@
 #error Unknown precision type
 #endif
 
+#define is_norm_above_threshold(x, t) ((double) (x) > (double) (t))
 #define CONCAT2_(a, b) a ## _ ## b
 #define CONCAT_(a, b) CONCAT2_(a, b)
 

--- a/tests/C-tests/diagonalize_matrix_typed.c
+++ b/tests/C-tests/diagonalize_matrix_typed.c
@@ -73,7 +73,7 @@ int TYPED_FUNC(
 
     printf("%s\n", "eigenvalues");
     for (int i = 0; i < N; i++)
-        printf("val = %e\n", eigenvalues[i]);
+        printf("val = %e  i%e\n", REAL_PART(eigenvalues[i]), IMAGINARY_PART(eigenvalues[i]));
 
     aux = bml_transpose_new(eigenvectors);
     bml_multiply(aux, eigenvectors, aux2, 1.0, 0.0, 0.0);       // C^t*C
@@ -81,9 +81,9 @@ int TYPED_FUNC(
     for (int i = 0; i < N; i++)
     {
         REAL_T *val = bml_get(aux2, i, i);
-        if (fabsf(*val - 1.) > REL_TOL)
+        if (ABS((REAL_T)(*val - 1.)) > REL_TOL)
         {
-            printf("i = %d, val = %e\n", i, *val);
+            printf("i = %d, val = %e  i%e\n", i, REAL_PART(*val), IMAGINARY_PART(*val));
             LOG_ERROR
                 ("Error in matrix diagonalization; eigenvector not normalized\n");
         }

--- a/tests/C-tests/multiply_banded_matrix_typed.c
+++ b/tests/C-tests/multiply_banded_matrix_typed.c
@@ -45,7 +45,7 @@ static int TYPED_FUNC(
 {
     for (int i = 0; i < N * N; i++)
     {
-        if (fabs(A[i] - B[i]) > ABS_TOL)
+        if (ABS(A[i] - B[i]) > ABS_TOL)
         {
             bml_print_dense_matrix(N, matrix_precision, dense_row_major, A, 0,
                                    N, 0, N);


### PR DESCRIPTION
This PR attempts to fix various compile warnings when building with clang (on my mac). Most of these are "benign" and related to the use of const. However, a few were related to type/ format inconsistencies and typos that could lead to errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/331)
<!-- Reviewable:end -->
