### PR TITLE
Fix clang warnings about const

### DIFF
--- a/src/C-interface/ellpack/bml_submatrix_ellpack.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack.c
@@ -300,8 +300,8 @@ bml_group_matrix_ellpack(
 
 int
 sortById(
-    void *a,
-    void *b)
+    const void *a,
+    const void *b)
 {
     int aId = *((int *) a);
     int bId = *((int *) b);

--- a/tests/C-tests/multiply_banded_matrix_typed.c
+++ b/tests/C-tests/multiply_banded_matrix_typed.c
@@ -40,8 +40,8 @@ static int TYPED_FUNC(
     compare_matrix) (
     const int N,
     const bml_matrix_precision_t matrix_precision,
-    const REAL_T * A,
-    const REAL_T * B)
+    REAL_T * A,
+    REAL_T * B)
 {
     for (int i = 0; i < N * N; i++)
     {

--- a/tests/C-tests/multiply_matrix_typed.c
+++ b/tests/C-tests/multiply_matrix_typed.c
@@ -40,8 +40,8 @@ static int TYPED_FUNC(
     compare_matrix) (
     const int N,
     const bml_matrix_precision_t matrix_precision,
-    const REAL_T * A,
-    const REAL_T * B)
+    REAL_T * A,
+    REAL_T * B)
 {
     for (int i = 0; i < N * N; i++)
     {

--- a/tests/C-tests/multiply_matrix_x2_typed.c
+++ b/tests/C-tests/multiply_matrix_x2_typed.c
@@ -38,8 +38,8 @@ static int TYPED_FUNC(
     compare_matrix) (
     const int N,
     const bml_matrix_precision_t matrix_precision,
-    const REAL_T * A,
-    const REAL_T * B)
+    REAL_T * A,
+    REAL_T * B)
 {
     for (int i = 0; i < N * N; i++)
     {

--- a/tests/C-tests/test_bml_gemm_typed.c
+++ b/tests/C-tests/test_bml_gemm_typed.c
@@ -86,8 +86,8 @@ static int TYPED_FUNC(
     compare_matrix) (
     const int N,
     const bml_matrix_precision_t matrix_precision,
-    const REAL_T * A,
-    const REAL_T * B)
+    REAL_T * A,
+    REAL_T * B)
 {
     for (int i = 0; i < N * N; i++)
     {


### PR DESCRIPTION
Remove unnecessary 'const' qualifiers to fix clang warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/335)
<!-- Reviewable:end -->
