### PR TITLE
Refactor valgrind command line arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,9 @@ set(BML_TESTING FALSE
   CACHE BOOL "Whether to build the test suite.")
 set(BML_VALGRIND FALSE
   CACHE BOOL "Whether to test for memory leaks with valgrind")
+set(VALGRIND_COMMON_ARGS --fullpath-after="src/"  --error-exitcode=1
+  --leak-check=full --show-leak-kinds=all --read-var-info=yes
+  --track-origins=yes)
 
 if(BML_TESTING)
   message(STATUS "Setting up test suite")

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -46,6 +46,8 @@ void TYPED_FUNC(
     double ONE = 1.0;
     double ZERO = 0.0;
 
+    void *trace = NULL;
+
     if (A == NULL || B == NULL)
     {
         LOG_ERROR("Either matrix A or B are NULL\n");
@@ -53,7 +55,7 @@ void TYPED_FUNC(
 
     if (A == B && alpha == ONE && beta == ZERO)
     {
-        TYPED_FUNC(bml_multiply_x2_ellpack) (A, C, threshold);
+        trace = TYPED_FUNC(bml_multiply_x2_ellpack) (A, C, threshold);
     }
     else
     {
@@ -64,7 +66,7 @@ void TYPED_FUNC(
 
         if (A != NULL && A == B)
         {
-            TYPED_FUNC(bml_multiply_x2_ellpack) (A, A2, threshold);
+            trace = TYPED_FUNC(bml_multiply_x2_ellpack) (A, A2, threshold);
         }
         else
         {
@@ -82,6 +84,7 @@ void TYPED_FUNC(
 
         bml_deallocate_ellpack(A2);
     }
+    bml_free_memory(trace);
 }
 
 /** Matrix multiply.

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -101,8 +101,7 @@ function(test_formats ${formats})
       add_test(C-${N}-${T}-${P} bml-test -n ${N} -t ${T} -p ${P})
       #endif()
       if(NOT BML_MPI AND NOT BML_OPENMP AND VALGRIND)
-        add_test(C-${N}-${T}-${P}-valgrind ${VALGRIND} --error-exitcode=1
-          --leak-check=full --show-leak-kinds=all --read-var-info=yes --track-origins=yes
+        add_test(C-${N}-${T}-${P}-valgrind ${VALGRIND} ${VALGRIND_COMMON_ARGS}
           ${CMAKE_CURRENT_BINARY_DIR}/bml-test -n ${N} -t ${T} -p ${P})
       endif()
     endforeach()

--- a/tests/Fortran-tests/CMakeLists.txt
+++ b/tests/Fortran-tests/CMakeLists.txt
@@ -139,8 +139,7 @@ function(test_formats ${formats})
       set(testname ${language}-${N}-${T}-${P})
       add_test(${testname} ${CMAKE_CURRENT_BINARY_DIR}/bml-testf -n ${N} -t ${T} -p ${P})
       if(NOT BML_MPI AND NOT BML_OPENMP AND VALGRIND)
-        add_test(${testname}-valgrind ${VALGRIND} --error-exitcode=1
-          --leak-check=full --show-leak-kinds=all --read-var-info=yes --track-origins=yes
+        add_test(${testname}-valgrind ${VALGRIND} ${VALGRIND_COMMON_ARGS}
           ${CMAKE_CURRENT_BINARY_DIR}/bml-testf -n ${N} -t ${T} -p ${P})
         # [nicolasbock] Ignore errors in valgrind tests for now.
         # Please revert this change once all memory issues have been


### PR DESCRIPTION
To ease readability, refactor `valgrind` command line arguments into
the main `CMakeLists.txt` file.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/343)
<!-- Reviewable:end -->
