### PR TITLE
Fix memory leak

### DIFF
--- a/src/C-interface/ellsort/bml_multiply_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_multiply_ellsort_typed.c
@@ -46,6 +46,8 @@ void TYPED_FUNC(
     double ONE = 1.0;
     double ZERO = 0.0;
 
+    void *trace = NULL;
+
     if (A == NULL || B == NULL)
     {
         LOG_ERROR("Either matrix A or B are NULL\n");
@@ -53,7 +55,7 @@ void TYPED_FUNC(
 
     if (A == B && alpha == ONE && beta == ZERO)
     {
-        TYPED_FUNC(bml_multiply_x2_ellsort) (A, C, threshold);
+        trace = TYPED_FUNC(bml_multiply_x2_ellsort) (A, C, threshold);
     }
     else
     {
@@ -64,7 +66,7 @@ void TYPED_FUNC(
 
         if (A != NULL && A == B)
         {
-            TYPED_FUNC(bml_multiply_x2_ellsort) (A, A2, threshold);
+            trace = TYPED_FUNC(bml_multiply_x2_ellsort) (A, A2, threshold);
         }
         else
         {
@@ -82,6 +84,8 @@ void TYPED_FUNC(
 
         bml_deallocate_ellsort(A2);
     }
+
+    bml_free_memory(trace);
 }
 
 /** Matrix multiply.


### PR DESCRIPTION
We should investigate whether the call to `bml_multiply_x2_ellsort` is
necessary or could be written slightly differently so we don't have to
free the trace which is not used here.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/347)
<!-- Reviewable:end -->
