### PR TITLE
Install ssl certificates

### DIFF
--- a/ci-images/build/Dockerfile
+++ b/ci-images/build/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DBA92F17B25AD78F9F2
 RUN apt-get update
 RUN apt-get install --assume-yes --no-install-recommends apt-utils
 RUN apt-get install --assume-yes --no-install-recommends build-essential
-RUN apt-get install --assume-yes --no-install-recommends git-core openssh-client
+RUN apt-get install --assume-yes --no-install-recommends git-core openssh-client ca-certificates
 RUN apt-get install --assume-yes --no-install-recommends cmake cmake-data libblas-dev liblapack-dev
 RUN apt-get install --assume-yes --no-install-recommends gcc-4.7 g++-4.7 gfortran-4.7
 RUN apt-get install --assume-yes --no-install-recommends gcc-9 g++-9 gfortran-9


### PR DESCRIPTION
While not needed for CI itself, it's necessary for running the
container yourself and be able to git clone from https.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/364)
<!-- Reviewable:end -->
