### PR TITLE
Added CSR type for Fortran interface

### DIFF
--- a/src/Fortran-interface/bml_interface_m.F90
+++ b/src/Fortran-interface/bml_interface_m.F90
@@ -40,6 +40,12 @@ module bml_interface_m
   !> The enum values of the C API. Keep this synchronized with the
   !! enum in bml_types.h.
   !!
+  !! Matrix type is ellblock.
+  integer, parameter :: bml_matrix_type_csr_enum_id = 5
+
+  !> The enum values of the C API. Keep this synchronized with the
+  !! enum in bml_types.h.
+  !!
   !! Matrix precision is unitialized.
   integer, parameter :: bml_matrix_precision_uninitialized_id = 0
 
@@ -114,6 +120,8 @@ contains
       id = bml_matrix_type_ellblock_enum_id
     case(BML_MATRIX_ELLSORT)
       id = bml_matrix_type_ellsort_enum_id
+    case(BML_MATRIX_CSR)
+      id = bml_matrix_type_csr_enum_id
     case default
       print *, "unknown matrix type"//trim(type_string)
       error stop

--- a/src/Fortran-interface/bml_types_m.F90
+++ b/src/Fortran-interface/bml_types_m.F90
@@ -9,6 +9,7 @@ module bml_types_m
   public :: bml_vector_t, bml_matrix_t
   public :: bml_deallocate
   public :: BML_MATRIX_DENSE, BML_MATRIX_ELLPACK, BML_MATRIX_ELLBLOCK, BML_MATRIX_ELLSORT
+  public :: BML_MATRIX_CSR
   public :: BML_ELEMENT_REAL, BML_ELEMENT_COMPLEX
   public :: BML_DMODE_SEQUENTIAL, BML_DMODE_DISTRIBUTED
   public :: BML_DMODE_GRAPH_DISTRIBUTED
@@ -50,8 +51,11 @@ module bml_types_m
   !> The bml-ellblock matrix type identifier.
   character(len=*), parameter :: BML_MATRIX_ELLBLOCK = "ellblock"
 
-  !> The bml-ellblock matrix type identifier.
+  !> The bml-ellsort matrix type identifier.
   character(len=*), parameter :: BML_MATRIX_ELLSORT = "ellsort"
+  
+  !> The bml-csr matrix type identifier.
+  character(len=*), parameter :: BML_MATRIX_CSR = "csr"
 
   !> The single precision identifier.
   character(len=*), parameter :: BML_ELEMENT_REAL = "real"

--- a/src/Fortran-interface/bml_types_m.F90
+++ b/src/Fortran-interface/bml_types_m.F90
@@ -53,7 +53,7 @@ module bml_types_m
 
   !> The bml-ellsort matrix type identifier.
   character(len=*), parameter :: BML_MATRIX_ELLSORT = "ellsort"
-  
+
   !> The bml-csr matrix type identifier.
   character(len=*), parameter :: BML_MATRIX_CSR = "csr"
 


### PR DESCRIPTION
Adding missing CSR type for Fortran interface

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/377)
<!-- Reviewable:end -->
