### PR TITLE
Modifications to enable build with ANL JLSE intel/2019 + mkl/2020.04.30.001 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,14 +50,14 @@ set(GNU_Fortran_FLAGS_RELEASE -O3 -g -ffree-line-length-none)
 set(GNU_Fortran_FLAGS_RELWITHDEBINFO -O3 -g -ffree-line-length-none -DNDEBUG)
 
 set(Intel_C_FLAGS_DEBUG -O0 -g -std=c99 -check=conversions,stack,uninit
-  -traceback -qopt-report=5)
-set(Intel_C_FLAGS_RELEASE -O2 -g -std=c99 -qopt-report=5 -DNDEBUG)
-set(Intel_C_FLAGS_RELWITHDEBINFO -O2 -g -std=c99 -qopt-report=5 -DNDEBUG)
+  -traceback -qopt-report=5 -DINTEL_SDK)
+set(Intel_C_FLAGS_RELEASE -O2 -g -std=c99 -qopt-report=5 -DNDEBUG -DINTEL_SDK)
+set(Intel_C_FLAGS_RELWITHDEBINFO -O2 -g -std=c99 -qopt-report=5 -DNDEBUG -DINTEL_SDK)
 set(Intel_Fortran_FLAGS_DEBUG -O0 -g -check all -assume realloc_lhs
-  -traceback -qopt-report=5)
-set(Intel_Fortran_FLAGS_RELEASE -O2 -g -assume realloc_lhs -qopt-report=5)
+  -traceback -qopt-report=5 -DINTEL_SDK)
+set(Intel_Fortran_FLAGS_RELEASE -O2 -g -assume realloc_lhs -qopt-report=5 -DINTEL_SDK)
 set(Intel_Fortran_FLAGS_RELWITHDEBINFO -O2 -g -assume realloc_lhs
-  -qopt-report=5 -DNDEBUG)
+  -qopt-report=5 -DNDEBUG -DINTEL_SDK)
 
 set(XL_C_FLAGS_DEBUG -O0 -g)
 set(XL_C_FLAGS_RELEASE -O3 -g -std=c99 -DNDEBUG)

--- a/src/Fortran-interface/bml_getters_m.F90
+++ b/src/Fortran-interface/bml_getters_m.F90
@@ -1,5 +1,6 @@
 module bml_getters_m
 
+  use bml_allocate_m
   use bml_c_interface_m
   use bml_types_m
 
@@ -41,7 +42,7 @@ contains
     ptr = bml_get_diagonal_C(a%ptr)
     call c_f_pointer(ptr, diagonal_ptr, [bml_get_N(a)])
     diagonal = diagonal_ptr
-    deallocate(diagonal_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_diagonal_single_real
 
@@ -60,7 +61,7 @@ contains
     ptr = bml_get_diagonal_C(a%ptr)
     call c_f_pointer(ptr, diagonal_ptr, [bml_get_N(a)])
     diagonal = diagonal_ptr
-    deallocate(diagonal_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_diagonal_double_real
 
@@ -79,7 +80,7 @@ contains
     ptr = bml_get_diagonal_C(a%ptr)
     call c_f_pointer(ptr, diagonal_ptr, [bml_get_N(a)])
     diagonal = diagonal_ptr
-    deallocate(diagonal_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_diagonal_single_complex
 
@@ -98,7 +99,7 @@ contains
     ptr = bml_get_diagonal_C(a%ptr)
     call c_f_pointer(ptr, diagonal_ptr, [bml_get_N(a)])
     diagonal = diagonal_ptr
-    deallocate(diagonal_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_diagonal_double_complex
 
@@ -121,7 +122,7 @@ contains
     ptr = bml_get_row_C(a%ptr, i - 1)
     call c_f_pointer(ptr, row_ptr, [bml_get_N(a)])
     row = row_ptr
-    deallocate(row_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_row_single_real
 
@@ -142,7 +143,7 @@ contains
     ptr = bml_get_row_C(a%ptr, i - 1)
     call c_f_pointer(ptr, row_ptr, [bml_get_N(a)])
     row = row_ptr
-    deallocate(row_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_row_double_real
 
@@ -163,7 +164,7 @@ contains
     ptr = bml_get_row_C(a%ptr, i - 1)
     call c_f_pointer(ptr, row_ptr, [bml_get_N(a)])
     row = row_ptr
-    deallocate(row_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_row_single_complex
 
@@ -184,7 +185,7 @@ contains
     ptr = bml_get_row_C(a%ptr, i - 1)
     call c_f_pointer(ptr, row_ptr, [bml_get_N(a)])
     row = row_ptr
-    deallocate(row_ptr)
+    call bml_free(ptr)
 
   end subroutine bml_get_row_double_complex
 

--- a/tests/Fortran-tests/io_matrix_typed.F90
+++ b/tests/Fortran-tests/io_matrix_typed.F90
@@ -1,5 +1,9 @@
 module io_matrix_typed
 
+#ifdef INTEL_SDK
+  use ifport
+#endif
+
   use bml
   use prec
   use bml_utilities_m
@@ -19,11 +23,7 @@ contains
     logical :: test_result
     real(DUMMY_PREC) :: tol
     integer :: pid
-    character(23) :: tstamp_char
-    character(8)  :: date
-    character(10) :: time
-    character(5)  :: zone
-    integer,dimension(8) :: values
+    character(20) :: pid_char
     character(100) :: fname
 
 
@@ -33,9 +33,9 @@ contains
     DUMMY_KIND(DUMMY_PREC), allocatable :: a_dense(:, :)
     DUMMY_KIND(DUMMY_PREC), allocatable :: b_dense(:, :)
 
-    call date_and_time(date,time,zone,values)
-    write(tstamp_char,'(a,a,a)')date, time, zone
-    write(fname,*)"ftest_matrix",trim(adjustl(tstamp_char)),".mtx"
+    pid = getpid()
+    write(pid_char,*)pid
+    write(fname,*)"ftest_matrix",trim(adjustl(pid_char)),".mtx"
 
     allocate(a_dense(n,n))
     allocate(b_dense(n,n))

--- a/tests/Fortran-tests/io_matrix_typed.F90
+++ b/tests/Fortran-tests/io_matrix_typed.F90
@@ -19,7 +19,11 @@ contains
     logical :: test_result
     real(DUMMY_PREC) :: tol
     integer :: pid
-    character(20) :: pid_char
+    character(23) :: tstamp_char
+    character(8)  :: date
+    character(10) :: time
+    character(5)  :: zone
+    integer,dimension(8) :: values
     character(100) :: fname
 
 
@@ -29,9 +33,9 @@ contains
     DUMMY_KIND(DUMMY_PREC), allocatable :: a_dense(:, :)
     DUMMY_KIND(DUMMY_PREC), allocatable :: b_dense(:, :)
 
-    pid = getpid()
-    write(pid_char,*)pid
-    write(fname,*)"ftest_matrix",trim(adjustl(pid_char)),".mtx"
+    call date_and_time(date,time,zone,values)
+    write(tstamp_char,'(a,a,a)')date, time, zone
+    write(fname,*)"ftest_matrix",trim(adjustl(tstamp_char)),".mtx"
 
     allocate(a_dense(n,n))
     allocate(b_dense(n,n))


### PR DESCRIPTION
***Nick, Christian: Please check the first of these in particular to make sure it won't introduce a memory leak and recommend a different fix if this won't work. -- Mike

In src/Fortran-interface/bml_getters_m.F90:

Remove deallocate() lines from get_diagonal and get_row methods as Intel compiled code throws an error during tests indicating that diagonal_ptr cannot be deallocated.

In tests/Fortran-tests/io_matrix_typed.F90:

Changed the temporary file name to use date_and_time() time stamp instead of getpid() for portability. Intel getpid() requires including another module and throws an error during tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/387)
<!-- Reviewable:end -->
