### PR TITLE
Remove duplicate function

### DIFF
--- a/src/C-interface/bml_allocate.c
+++ b/src/C-interface/bml_allocate.c
@@ -135,7 +135,8 @@ bml_free_memory(
 }
 
 /** De-allocate a chunk of memory that was allocated inside a C
- * function.
+ * function. This is used by the Fortran bml_free_C interface. Note
+ * the "pointer to pointer" in the API.
  *
  * \ingroup allocate_group_C
  *
@@ -145,7 +146,7 @@ void
 bml_free_ptr(
     void **ptr)
 {
-    free(*ptr);
+    bml_free_memory(*ptr);
 }
 
 /** Deallocate a matrix.


### PR DESCRIPTION
The `bml_free_ptr()` function was only used in the Fortran interface
and did the same as the `bml_free_memory()` function. This change
removes the former.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/391)
<!-- Reviewable:end -->
