### PR TITLE
Use the latest CI image from `master`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
     name: Lint sources
     runs-on: ubuntu-latest
     container:
-      image: nicolasbock/bml-ci-lint:2
+      image: nicolasbock/bml:master
     steps:
       - uses: actions/checkout@v1
       - run: bundle install
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     container:
-      image: nicolasbock/bml-ci-docs:2
+      image: nicolasbock/bml:master
     steps:
       - uses: actions/checkout@v1
       - run: ./build.sh docs


### PR DESCRIPTION
This change uses the latest CI image (tagged `master`) for CI runs.
Updating the CI environment can be done now through a PR. Once the PR
is merged, the `master` image will be updated on `hub.docker.com` and
subsequent CI runs will use this new image.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/420)
<!-- Reviewable:end -->
