### PR TITLE
Add clarification to container job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   containers:
-    name: Update container images
+    name: Update container images (only approve if change involves the Dockerfile and if the change is trusted)
     runs-on: ubuntu-latest
     environment: CI
     steps:


### PR DESCRIPTION
The `container` job runs in a trusted environment since it needs to
access the DockerHub secrets so it can push the built image. This has
potential security implication.

Please only approve the `container` job if the PR is

- From a trusted party
- Involves a change in `Dockerfile`
- Does not print or make available in any way the environment secrets

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/433)
<!-- Reviewable:end -->
