### PR TITLE
Add functionality to send/recv matrices

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,7 +101,7 @@ jobs:
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R fortran-.*-double_real",    BML_VALGRIND: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R fortran-.*-single_complex", BML_VALGRIND: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R fortran-.*-double_complex", BML_VALGRIND: yes}
-          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_MPI: yes, BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R C-.*-single_real", BML_VALGRIND: yes}
+          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_MPI: yes, BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R MPI-C-.*-single_real", BML_VALGRIND: yes}
     steps:
       - name: Check out sources
         uses: actions/checkout@v2

--- a/src/C-interface/bml_parallel.c
+++ b/src/C-interface/bml_parallel.c
@@ -4,6 +4,8 @@
 #include "dense/bml_parallel_dense.h"
 #include "ellpack/bml_parallel_ellpack.h"
 #include "ellsort/bml_parallel_ellsort.h"
+#include "ellblock/bml_parallel_ellblock.h"
+#include "csr/bml_parallel_csr.h"
 #ifdef DO_MPI
 #include "distributed2d/bml_allocate_distributed2d.h"
 #endif
@@ -192,3 +194,94 @@ bml_allGatherVParallel(
             break;
     }
 }
+
+#ifdef DO_MPI
+void
+bml_mpi_send(
+    bml_matrix_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (bml_get_type(A))
+    {
+        case dense:
+            bml_mpi_send_dense(A, dst, comm);
+            break;
+        case ellpack:
+            bml_mpi_send_ellpack(A, dst, comm);
+            break;
+        case ellsort:
+            bml_mpi_send_ellsort(A, dst, comm);
+            break;
+        case ellblock:
+            bml_mpi_send_ellblock(A, dst, comm);
+            break;
+        case csr:
+            bml_mpi_send_csr(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown matrix type\n");
+            break;
+    }
+}
+
+void
+bml_mpi_recv(
+    bml_matrix_t * A,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (bml_get_type(A))
+    {
+        case dense:
+            bml_mpi_recv_dense(A, src, comm);
+            break;
+        case ellpack:
+            bml_mpi_recv_ellpack(A, src, comm);
+            break;
+        case ellsort:
+            bml_mpi_recv_ellsort(A, src, comm);
+            break;
+        default:
+            LOG_ERROR("unknown matrix type\n");
+            break;
+    }
+}
+
+bml_matrix_t *
+bml_mpi_recv_matrix(
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (matrix_type)
+    {
+        case dense:
+            return bml_mpi_recv_matrix_dense(matrix_precision, N, M, src,
+                                             comm);
+            break;
+        case ellpack:
+            return bml_mpi_recv_matrix_ellpack(matrix_precision, N, M, src,
+                                               comm);
+            break;
+        case ellsort:
+            return bml_mpi_recv_matrix_ellsort(matrix_precision, N, M, src,
+                                               comm);
+            break;
+        case ellblock:
+            return bml_mpi_recv_matrix_ellblock(matrix_precision, N, M, src,
+                                                comm);
+            break;
+        case csr:
+            return bml_mpi_recv_matrix_csr(matrix_precision, N, M, src, comm);
+            break;
+        default:
+            LOG_ERROR("unknown matrix type\n");
+            break;
+    }
+}
+
+#endif

--- a/src/C-interface/bml_parallel.h
+++ b/src/C-interface/bml_parallel.h
@@ -68,4 +68,22 @@ void bml_maxRealReduce(
 void bml_allGatherVParallel(
     bml_matrix_t * A);
 
+#ifdef DO_MPI
+void bml_mpi_send(
+    bml_matrix_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_recv(
+    bml_matrix_t * A,
+    const int dst,
+    MPI_Comm comm);
+bml_matrix_t *bml_mpi_recv_matrix(
+    bml_matrix_type_t matrix_type,
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+#endif
+
 #endif

--- a/src/C-interface/csr/CMakeLists.txt
+++ b/src/C-interface/csr/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HEADERS-CSR
   bml_export_csr.h
   bml_import_csr.h
   bml_introspection_csr.h
+  bml_parallel_csr.h
   bml_transpose_csr.h
   bml_threshold_csr.h
   bml_diagonalize_csr.h
@@ -35,6 +36,7 @@ set(SOURCES-CSR
   bml_export_csr.c
   bml_import_csr.c
   bml_introspection_csr.c
+  bml_parallel_csr.c
   bml_transpose_csr.c  
   bml_threshold_csr.c
   bml_diagonalize_csr.c
@@ -67,6 +69,7 @@ set(SOURCES-CSR-TYPED
   bml_export_csr_typed.c
   bml_import_csr_typed.c
   bml_introspection_csr_typed.c
+  bml_parallel_csr_typed.c
   bml_transpose_csr_typed.c  
   bml_threshold_csr_typed.c
   bml_diagonalize_csr_typed.c

--- a/src/C-interface/csr/bml_parallel_csr.c
+++ b/src/C-interface/csr/bml_parallel_csr.c
@@ -1,0 +1,91 @@
+#include "../bml_logger.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "bml_parallel_csr.h"
+#include "bml_types_csr.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef DO_MPI
+void
+bml_mpi_send_csr(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_send_csr_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_send_csr_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_send_csr_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_send_csr_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_recv_csr(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_recv_csr_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_recv_csr_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_recv_csr_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_recv_csr_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+bml_matrix_csr_t *
+bml_mpi_recv_matrix_csr(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_mpi_recv_matrix_csr_single_real(N, M, src, comm);
+            break;
+        case double_real:
+            return bml_mpi_recv_matrix_csr_double_real(N, M, src, comm);
+            break;
+        case single_complex:
+            return bml_mpi_recv_matrix_csr_single_complex(N, M, src, comm);
+            break;
+        case double_complex:
+            return bml_mpi_recv_matrix_csr_double_complex(N, M, src, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+#endif

--- a/src/C-interface/csr/bml_parallel_csr.h
+++ b/src/C-interface/csr/bml_parallel_csr.h
@@ -1,0 +1,80 @@
+#ifndef __BML_PARALLEL_CSR_H
+#define __BML_PARALLEL_CSR_H
+
+#include "bml_types_csr.h"
+
+#ifdef DO_MPI
+void bml_mpi_send_csr(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_send_csr_single_real(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_csr_double_real(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_csr_single_complex(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_csr_double_complex(
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_recv_csr(
+    bml_matrix_csr_t * A,
+    const int src,
+    MPI_Comm comm);
+
+void bml_mpi_recv_csr_single_real(
+    bml_matrix_csr_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_csr_double_real(
+    bml_matrix_csr_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_csr_single_complex(
+    bml_matrix_csr_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_csr_double_complex(
+    bml_matrix_csr_t * A,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_csr_t *bml_mpi_recv_matrix_csr(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_csr_t *bml_mpi_recv_matrix_csr_single_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_csr_t *bml_mpi_recv_matrix_csr_double_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_csr_t *bml_mpi_recv_matrix_csr_single_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_csr_t *bml_mpi_recv_matrix_csr_double_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+#endif
+
+#endif

--- a/src/C-interface/csr/bml_parallel_csr_typed.c
+++ b/src/C-interface/csr/bml_parallel_csr_typed.c
@@ -1,0 +1,142 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "../bml_allocate.h"
+#include "bml_parallel_csr.h"
+#include "bml_types_csr.h"
+#include "bml_allocate_csr.h"
+#include "../bml_logger.h"
+
+#include <complex.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef DO_MPI
+#include <mpi.h>
+#endif
+
+#ifdef DO_MPI
+void TYPED_FUNC(
+    bml_mpi_send_csr) (
+    bml_matrix_csr_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    int mpiret;
+
+    // send nnz
+    int *nnz = bml_allocate_memory(sizeof(int) * A->N_);
+    int totnnz = 0;
+    for (int i = 0; i < A->N_; i++)
+    {
+        nnz[i] = A->data_[i]->NNZ_;
+        totnnz += nnz[i];
+    }
+    mpiret = MPI_Send(nnz, A->N_, MPI_INT, dst, 111, comm);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Send failed for nnz");
+    bml_free_memory(nnz);
+
+    // send cols
+    int *cols = bml_allocate_memory(sizeof(int) * totnnz);
+    int *pcols = cols;
+    for (int i = 0; i < A->N_; i++)
+    {
+        csr_sparse_row_t *row = A->data_[i];
+        memcpy(pcols, row->cols_, row->NNZ_ * sizeof(int));
+        pcols += row->NNZ_;
+    }
+    mpiret = MPI_Send(cols, totnnz, MPI_INT, dst, 112, comm);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Send failed for cols");
+    bml_free_memory(cols);
+
+    // send matrix elements
+    LOG_DEBUG("Send values...\n");
+    REAL_T *values = bml_allocate_memory(sizeof(REAL_T) * totnnz);
+    REAL_T *pvalues = values;
+    for (int i = 0; i < A->N_; i++)
+    {
+        csr_sparse_row_t *row = A->data_[i];
+        memcpy(pvalues, row->vals_, row->NNZ_ * sizeof(REAL_T));
+        pvalues += row->NNZ_;
+    }
+    mpiret = MPI_Send(values, totnnz, MPI_T, dst, 113, comm);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Send failed for values");
+    bml_free_memory(values);
+
+    LOG_DEBUG("Done with Send...\n");
+}
+
+void TYPED_FUNC(
+    bml_mpi_recv_csr) (
+    bml_matrix_csr_t * A,
+    const int src,
+    MPI_Comm comm)
+{
+    MPI_Status status;
+    int mpiret;
+
+    // recv nnz
+    int *nnz = bml_allocate_memory(sizeof(int) * A->N_);
+    mpiret = MPI_Recv(nnz, A->N_, MPI_INT, src, 111, comm, &status);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Recv failed for nnz");
+    int totnnz = 0;
+    for (int i = 0; i < A->N_; i++)
+    {
+        A->data_[i]->NNZ_ = nnz[i];
+        totnnz += nnz[i];
+    }
+    bml_free_memory(nnz);
+
+    // recv columns indexes
+    int *cols = bml_allocate_memory(sizeof(int) * totnnz);
+    mpiret = MPI_Recv(cols, totnnz, MPI_INT, src, 112, comm, &status);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Recv failed for cols");
+    int *pcols = cols;
+    for (int i = 0; i < A->N_; i++)
+    {
+        csr_sparse_row_t *row = A->data_[i];
+        memcpy(row->cols_, pcols, row->NNZ_ * sizeof(int));
+        pcols += row->NNZ_;
+    }
+    bml_free_memory(cols);
+
+    // recv matrix elements
+    LOG_DEBUG("Recv values...\n");
+    REAL_T *values = bml_allocate_memory(sizeof(REAL_T) * totnnz);
+    mpiret = MPI_Recv(values, totnnz, MPI_T, src, 113, comm, &status);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Recv failed for values");
+    REAL_T *pvalues = values;
+    for (int i = 0; i < A->N_; i++)
+    {
+        csr_sparse_row_t *row = A->data_[i];
+        memcpy(row->vals_, pvalues, row->NNZ_ * sizeof(REAL_T));
+        pvalues += row->NNZ_;
+    }
+    bml_free_memory(values);
+
+    LOG_DEBUG("Done with Recv...\n");
+}
+
+/*
+ * Return BML matrix from data received from MPI task src
+ */
+bml_matrix_csr_t
+    * TYPED_FUNC(bml_mpi_recv_matrix_csr) (int N, int M,
+                                           const int src, MPI_Comm comm)
+{
+    bml_matrix_csr_t *A_bml =
+        TYPED_FUNC(bml_zero_matrix_csr) (N, M, sequential);
+
+    bml_mpi_recv_csr(A_bml, src, comm);
+
+    return A_bml;
+}
+
+#endif

--- a/src/C-interface/dense/bml_parallel_dense.c
+++ b/src/C-interface/dense/bml_parallel_dense.c
@@ -40,3 +40,112 @@ bml_allGatherVParallel_dense(
             break;
     }
 }
+
+#ifdef DO_MPI
+void
+bml_mpi_type_create_struct_dense(
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_type_create_struct_dense_single_real(A, newtype);
+            break;
+        case double_real:
+            bml_mpi_type_create_struct_dense_double_real(A, newtype);
+            break;
+        case single_complex:
+            bml_mpi_type_create_struct_dense_single_complex(A, newtype);
+            break;
+        case double_complex:
+            bml_mpi_type_create_struct_dense_double_complex(A, newtype);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_send_dense(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_send_dense_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_send_dense_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_send_dense_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_send_dense_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_recv_dense(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_recv_dense_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_recv_dense_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_recv_dense_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_recv_dense_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+bml_matrix_dense_t *
+bml_mpi_recv_matrix_dense(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_mpi_recv_matrix_dense_single_real(N, M, src, comm);
+            break;
+        case double_real:
+            return bml_mpi_recv_matrix_dense_double_real(N, M, src, comm);
+            break;
+        case single_complex:
+            return bml_mpi_recv_matrix_dense_single_complex(N, M, src, comm);
+            break;
+        case double_complex:
+            return bml_mpi_recv_matrix_dense_double_complex(N, M, src, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+#endif

--- a/src/C-interface/dense/bml_parallel_dense.h
+++ b/src/C-interface/dense/bml_parallel_dense.h
@@ -18,4 +18,95 @@ void bml_allGatherVParallel_dense_single_complex(
 void bml_allGatherVParallel_dense_double_complex(
     bml_matrix_dense_t * A);
 
+#ifdef DO_MPI
+void bml_mpi_type_create_struct_dense(
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype);
+
+void bml_mpi_type_create_struct_dense_single_real(
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_dense_double_real(
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_dense_single_complex(
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_dense_double_complex(
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype);
+
+void bml_mpi_send_dense(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_send_dense_single_real(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_dense_double_real(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_dense_single_complex(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_dense_double_complex(
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_recv_dense(
+    bml_matrix_dense_t * A,
+    const int src,
+    MPI_Comm comm);
+
+void bml_mpi_recv_dense_single_real(
+    bml_matrix_dense_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_dense_double_real(
+    bml_matrix_dense_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_dense_single_complex(
+    bml_matrix_dense_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_dense_double_complex(
+    bml_matrix_dense_t * A,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_dense_t *bml_mpi_recv_matrix_dense(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_dense_t *bml_mpi_recv_matrix_dense_single_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_dense_t *bml_mpi_recv_matrix_dense_double_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_dense_t *bml_mpi_recv_matrix_dense_single_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_dense_t *bml_mpi_recv_matrix_dense_double_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+#endif
+
 #endif

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -4,6 +4,8 @@
 #include "../bml_types.h"
 #include "bml_parallel_dense.h"
 #include "bml_types_dense.h"
+#include "bml_allocate_dense.h"
+#include "../bml_logger.h"
 
 #include <complex.h>
 #include <math.h>
@@ -38,3 +40,65 @@ void TYPED_FUNC(
                    A_domain->localDispl, REAL_MPI_TYPE, ccomm);
 #endif
 }
+
+#ifdef DO_MPI
+
+void TYPED_FUNC(
+    bml_mpi_type_create_struct_dense) (
+    bml_matrix_dense_t * A,
+    MPI_Datatype * newtype)
+{
+    MPI_Aint baseaddr;
+    MPI_Aint addr0, addr1, addr2;
+    MPI_Get_address(A, &baseaddr);
+    MPI_Get_address(A->matrix, &addr0);
+
+    MPI_Datatype dtype[1];
+    dtype[0] = MPI_T;
+
+    int blength[1];
+    blength[0] = A->N * A->N;
+
+    MPI_Aint displ[0];
+    displ[0] = addr0 - baseaddr;
+    int mpiret = MPI_Type_create_struct(1, blength, displ, dtype, newtype);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Type_create_struct failed!");
+    mpiret = MPI_Type_commit(newtype);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Type_commit failed!");
+}
+
+void TYPED_FUNC(
+    bml_mpi_send_dense) (
+    bml_matrix_dense_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    MPI_Send(A->matrix, A->N * A->N, MPI_T, dst, 222, comm);
+}
+
+void TYPED_FUNC(
+    bml_mpi_recv_dense) (
+    bml_matrix_dense_t * A,
+    const int src,
+    MPI_Comm comm)
+{
+    MPI_Status status;
+    MPI_Recv(A->matrix, A->N * A->N, MPI_T, src, 222, comm, &status);
+}
+
+bml_matrix_dense_t
+    * TYPED_FUNC(bml_mpi_recv_matrix_dense) (int N, int M,
+                                             const int src, MPI_Comm comm)
+{
+    bml_matrix_dimension_t matrix_dimension = { N, N, M };
+    bml_matrix_dense_t *A_bml =
+        TYPED_FUNC(bml_zero_matrix_dense) (matrix_dimension, sequential);
+
+    bml_mpi_recv_dense(A_bml, src, comm);
+
+    return A_bml;
+}
+
+#endif

--- a/src/C-interface/ellblock/CMakeLists.txt
+++ b/src/C-interface/ellblock/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HEADERS-ELLBLOCK
   bml_multiply_ellblock.h
   bml_normalize_ellblock.h
   bml_norm_ellblock.h
+  bml_parallel_ellblock.h
   bml_scale_ellblock.h
   bml_setters_ellblock.h
   bml_threshold_ellblock.h
@@ -34,6 +35,7 @@ set(SOURCES-ELLBLOCK
   bml_multiply_ellblock.c
   bml_normalize_ellblock.c
   bml_norm_ellblock.c
+  bml_parallel_ellblock.c
   bml_scale_ellblock.c
   bml_setters_ellblock.c
   bml_threshold_ellblock.c
@@ -66,6 +68,7 @@ set(SOURCES-ELLBLOCK-TYPED
   bml_multiply_ellblock_typed.c
   bml_normalize_ellblock_typed.c
   bml_norm_ellblock_typed.c
+  bml_parallel_ellblock_typed.c
   bml_scale_ellblock_typed.c
   bml_setters_ellblock_typed.c
   bml_threshold_ellblock_typed.c

--- a/src/C-interface/ellblock/bml_parallel_ellblock.c
+++ b/src/C-interface/ellblock/bml_parallel_ellblock.c
@@ -1,0 +1,93 @@
+#include "../bml_logger.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "bml_parallel_ellblock.h"
+#include "bml_types_ellblock.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef DO_MPI
+void
+bml_mpi_send_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_send_ellblock_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_send_ellblock_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_send_ellblock_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_send_ellblock_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_recv_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_recv_ellblock_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_recv_ellblock_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_recv_ellblock_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_recv_ellblock_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+bml_matrix_ellblock_t *
+bml_mpi_recv_matrix_ellblock(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_mpi_recv_matrix_ellblock_single_real(N, M, src, comm);
+            break;
+        case double_real:
+            return bml_mpi_recv_matrix_ellblock_double_real(N, M, src, comm);
+            break;
+        case single_complex:
+            return bml_mpi_recv_matrix_ellblock_single_complex(N, M, src,
+                                                               comm);
+            break;
+        case double_complex:
+            return bml_mpi_recv_matrix_ellblock_double_complex(N, M, src,
+                                                               comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+#endif

--- a/src/C-interface/ellblock/bml_parallel_ellblock.h
+++ b/src/C-interface/ellblock/bml_parallel_ellblock.h
@@ -1,0 +1,80 @@
+#ifndef __BML_PARALLEL_ELLBLOCK_H
+#define __BML_PARALLEL_ELLBLOCK_H
+
+#include "bml_types_ellblock.h"
+
+#ifdef DO_MPI
+void bml_mpi_send_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_send_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_recv_ellblock(
+    bml_matrix_ellblock_t * A,
+    const int src,
+    MPI_Comm comm);
+
+void bml_mpi_recv_ellblock_single_real(
+    bml_matrix_ellblock_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellblock_double_real(
+    bml_matrix_ellblock_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellblock_single_complex(
+    bml_matrix_ellblock_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellblock_double_complex(
+    bml_matrix_ellblock_t * A,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_ellblock_t *bml_mpi_recv_matrix_ellblock(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_ellblock_t *bml_mpi_recv_matrix_ellblock_single_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellblock_t *bml_mpi_recv_matrix_ellblock_double_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellblock_t *bml_mpi_recv_matrix_ellblock_single_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellblock_t *bml_mpi_recv_matrix_ellblock_double_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+#endif
+
+#endif

--- a/src/C-interface/ellblock/bml_parallel_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_parallel_ellblock_typed.c
@@ -1,0 +1,115 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "../bml_allocate.h"
+#include "bml_parallel_ellblock.h"
+#include "bml_types_ellblock.h"
+#include "bml_allocate_ellblock.h"
+#include "../bml_logger.h"
+
+#include <complex.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef DO_MPI
+#include <mpi.h>
+#endif
+
+#ifdef DO_MPI
+void TYPED_FUNC(
+    bml_mpi_send_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    // allocate buffers and send data
+    int *indexb = bml_allocate_memory(sizeof(int) * A->NB * A->MB);
+    memcpy(indexb, A->indexb, A->NB * A->MB * sizeof(int));
+    MPI_Send(indexb, A->NB * A->MB, MPI_INT, dst, 112, comm);
+
+    int *nnzb = bml_allocate_memory(sizeof(int) * A->NB);
+    memcpy(nnzb, A->nnzb, sizeof(int) * A->NB);
+    MPI_Send(nnzb, A->NB, MPI_INT, dst, 113, comm);
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    REAL_T *values = bml_allocate_memory(sizeof(REAL_T) * A->N * A->M);
+    REAL_T *pvalues = values;
+    for (int ib = 0; ib < A->NB; ib++)
+    {
+        for (int jp = 0; jp < A->nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+            int jb = A->indexb[ind];
+            int nelements = A->bsize[ib] * A->bsize[jb];
+            memcpy(pvalues, A_ptr_value[ind], nelements * sizeof(REAL_T));
+            pvalues += nelements;
+        }
+    }
+    MPI_Send(values, A->N * A->M, MPI_T, dst, 111, comm);
+
+    bml_free_memory(nnzb);
+    bml_free_memory(indexb);
+    bml_free_memory(values);
+}
+
+void TYPED_FUNC(
+    bml_mpi_recv_ellblock) (
+    bml_matrix_ellblock_t * A,
+    const int src,
+    MPI_Comm comm)
+{
+    MPI_Status status;
+
+    // allocate buffers and receive data
+    int *indexb = bml_allocate_memory(sizeof(int) * A->NB * A->MB);
+    MPI_Recv(indexb, A->NB * A->MB, MPI_INT, src, 112, comm, &status);
+
+    int *nnzb = bml_allocate_memory(sizeof(int) * A->NB);
+    MPI_Recv(nnzb, A->NB, MPI_INT, src, 113, comm, &status);
+
+    REAL_T *values = bml_allocate_memory(sizeof(REAL_T) * A->N * A->M);
+    MPI_Recv(values, A->N * A->M, MPI_T, src, 111, comm, &status);
+
+    // copy data into bml matrix
+    memcpy(A->nnzb, nnzb, sizeof(int) * A->NB);
+    memcpy(A->indexb, indexb, A->NB * A->MB * sizeof(int));
+
+    REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
+
+    REAL_T *pvalues = values;
+    for (int ib = 0; ib < A->NB; ib++)
+    {
+        for (int jp = 0; jp < A->nnzb[ib]; jp++)
+        {
+            int ind = ROWMAJOR(ib, jp, A->NB, A->MB);
+            int jb = A->indexb[ind];
+            int nelements = A->bsize[ib] * A->bsize[jb];
+            A_ptr_value[ind] =
+                TYPED_FUNC(bml_allocate_block_ellblock) (A, ib, nelements);
+            memcpy(A_ptr_value[ind], pvalues, nelements * sizeof(REAL_T));
+            pvalues += nelements;
+        }
+    }
+    bml_free_memory(nnzb);
+    bml_free_memory(indexb);
+    bml_free_memory(values);
+}
+
+/*
+ * Return BML matrix from data received from MPI task src
+ */
+bml_matrix_ellblock_t
+    * TYPED_FUNC(bml_mpi_recv_matrix_ellblock) (int N, int M,
+                                                const int src, MPI_Comm comm)
+{
+    bml_matrix_ellblock_t *A_bml =
+        TYPED_FUNC(bml_zero_matrix_ellblock) (N, M, sequential);
+
+    bml_mpi_recv_ellblock(A_bml, src, comm);
+
+    return A_bml;
+}
+
+#endif

--- a/src/C-interface/ellpack/bml_parallel_ellpack.c
+++ b/src/C-interface/ellpack/bml_parallel_ellpack.c
@@ -37,3 +37,114 @@ bml_allGatherVParallel_ellpack(
             break;
     }
 }
+
+#ifdef DO_MPI
+void
+bml_mpi_type_create_struct_ellpack(
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_type_create_struct_ellpack_single_real(A, newtype);
+            break;
+        case double_real:
+            bml_mpi_type_create_struct_ellpack_double_real(A, newtype);
+            break;
+        case single_complex:
+            bml_mpi_type_create_struct_ellpack_single_complex(A, newtype);
+            break;
+        case double_complex:
+            bml_mpi_type_create_struct_ellpack_double_complex(A, newtype);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_send_ellpack(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_send_ellpack_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_send_ellpack_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_send_ellpack_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_send_ellpack_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_recv_ellpack(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_recv_ellpack_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_recv_ellpack_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_recv_ellpack_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_recv_ellpack_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+bml_matrix_ellpack_t *
+bml_mpi_recv_matrix_ellpack(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_mpi_recv_matrix_ellpack_single_real(N, M, src, comm);
+            break;
+        case double_real:
+            return bml_mpi_recv_matrix_ellpack_double_real(N, M, src, comm);
+            break;
+        case single_complex:
+            return bml_mpi_recv_matrix_ellpack_single_complex(N, M, src,
+                                                              comm);
+            break;
+        case double_complex:
+            return bml_mpi_recv_matrix_ellpack_double_complex(N, M, src,
+                                                              comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+#endif

--- a/src/C-interface/ellpack/bml_parallel_ellpack.h
+++ b/src/C-interface/ellpack/bml_parallel_ellpack.h
@@ -18,4 +18,96 @@ void bml_allGatherVParallel_ellpack_single_complex(
 void bml_allGatherVParallel_ellpack_double_complex(
     bml_matrix_ellpack_t * A);
 
+#ifdef DO_MPI
+void bml_mpi_type_create_struct_ellpack(
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype);
+
+void bml_mpi_type_create_struct_ellpack_single_real(
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_ellpack_double_real(
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_ellpack_single_complex(
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_ellpack_double_complex(
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype);
+
+void bml_mpi_send_ellpack(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_send_ellpack_single_real(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellpack_double_real(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellpack_single_complex(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellpack_double_complex(
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_recv_ellpack(
+    bml_matrix_ellpack_t * A,
+    const int src,
+    MPI_Comm comm);
+
+void bml_mpi_recv_ellpack_single_real(
+    bml_matrix_ellpack_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellpack_double_real(
+    bml_matrix_ellpack_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellpack_single_complex(
+    bml_matrix_ellpack_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellpack_double_complex(
+    bml_matrix_ellpack_t * A,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_ellpack_t *bml_mpi_recv_matrix_ellpack(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_ellpack_t *bml_mpi_recv_matrix_ellpack_single_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellpack_t *bml_mpi_recv_matrix_ellpack_double_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellpack_t *bml_mpi_recv_matrix_ellpack_single_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellpack_t *bml_mpi_recv_matrix_ellpack_double_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+
+#endif
+
 #endif

--- a/src/C-interface/ellpack/bml_parallel_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_parallel_ellpack_typed.c
@@ -4,6 +4,8 @@
 #include "../bml_types.h"
 #include "bml_parallel_ellpack.h"
 #include "bml_types_ellpack.h"
+#include "bml_allocate_ellpack.h"
+#include "../bml_logger.h"
 
 #include <complex.h>
 #include <math.h>
@@ -79,3 +81,87 @@ void TYPED_FUNC(
 #endif
 
 }
+
+#ifdef DO_MPI
+
+void TYPED_FUNC(
+    bml_mpi_type_create_struct_ellpack) (
+    bml_matrix_ellpack_t * A,
+    MPI_Datatype * newtype)
+{
+    MPI_Aint baseaddr;
+    MPI_Aint addr0, addr1, addr2;
+    MPI_Get_address(A, &baseaddr);
+    MPI_Get_address(A->value, &addr0);
+    MPI_Get_address(A->index, &addr1);
+    MPI_Get_address(A->nnz, &addr2);
+
+    MPI_Datatype dtype[3];
+    dtype[0] = MPI_T;
+    dtype[1] = MPI_INT;
+    dtype[2] = MPI_INT;
+
+    int blength[3];
+    blength[0] = A->N * A->M;
+    blength[1] = A->N * A->M;
+    blength[2] = A->N;
+
+    MPI_Aint displ[3];
+    displ[0] = addr0 - baseaddr;
+    displ[1] = addr1 - baseaddr;
+    displ[2] = addr2 - baseaddr;
+    int mpiret = MPI_Type_create_struct(3, blength, displ, dtype, newtype);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Type_create_struct failed!");
+    mpiret = MPI_Type_commit(newtype);
+    if (mpiret != MPI_SUCCESS)
+        LOG_ERROR("MPI_Type_commit failed!");
+}
+
+void TYPED_FUNC(
+    bml_mpi_send_ellpack) (
+    bml_matrix_ellpack_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    // create MPI data type to avoid multiple messages
+    MPI_Datatype mpi_data_type;
+    bml_mpi_type_create_struct_ellpack(A, &mpi_data_type);
+
+    MPI_Send(A, 1, mpi_data_type, dst, 111, comm);
+
+    MPI_Type_free(&mpi_data_type);
+}
+
+void TYPED_FUNC(
+    bml_mpi_recv_ellpack) (
+    bml_matrix_ellpack_t * A,
+    const int src,
+    MPI_Comm comm)
+{
+    // create MPI data type to avoid multiple messages
+    MPI_Datatype mpi_data_type;
+    bml_mpi_type_create_struct_ellpack(A, &mpi_data_type);
+
+    MPI_Status status;
+    MPI_Recv(A, 1, mpi_data_type, src, 111, comm, &status);
+
+    MPI_Type_free(&mpi_data_type);
+}
+
+/*
+ * Return BML matrix from data received from MPI task src
+ */
+bml_matrix_ellpack_t
+    * TYPED_FUNC(bml_mpi_recv_matrix_ellpack) (int N, int M,
+                                               const int src, MPI_Comm comm)
+{
+    bml_matrix_ellpack_t *A_bml =
+        TYPED_FUNC(bml_zero_matrix_ellpack) (N, M, sequential);
+
+    bml_mpi_recv_ellpack(A_bml, src, comm);
+
+    return A_bml;
+}
+
+#endif

--- a/src/C-interface/ellsort/bml_parallel_ellsort.c
+++ b/src/C-interface/ellsort/bml_parallel_ellsort.c
@@ -37,3 +37,113 @@ bml_allGatherVParallel_ellsort(
             break;
     }
 }
+
+#ifdef DO_MPI
+void
+bml_mpi_type_create_struct_ellsort(
+    bml_matrix_ellsort_t * A,
+    MPI_Datatype * newtype)
+{
+
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_type_create_struct_ellsort_single_real(A, newtype);
+            break;
+        case double_real:
+            bml_mpi_type_create_struct_ellsort_double_real(A, newtype);
+            break;
+        case single_complex:
+            bml_mpi_type_create_struct_ellsort_single_complex(A, newtype);
+            break;
+        case double_complex:
+            bml_mpi_type_create_struct_ellsort_double_complex(A, newtype);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_send_ellsort(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_send_ellsort_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_send_ellsort_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_send_ellsort_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_send_ellsort_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+void
+bml_mpi_recv_ellsort(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_mpi_recv_ellsort_single_real(A, dst, comm);
+            break;
+        case double_real:
+            bml_mpi_recv_ellsort_double_real(A, dst, comm);
+            break;
+        case single_complex:
+            bml_mpi_recv_ellsort_single_complex(A, dst, comm);
+            break;
+        case double_complex:
+            bml_mpi_recv_ellsort_double_complex(A, dst, comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+
+bml_matrix_ellsort_t *
+bml_mpi_recv_matrix_ellsort(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return bml_mpi_recv_matrix_ellsort_single_real(N, M, src, comm);
+            break;
+        case double_real:
+            return bml_mpi_recv_matrix_ellsort_double_real(N, M, src, comm);
+            break;
+        case single_complex:
+            return bml_mpi_recv_matrix_ellsort_single_complex(N, M, src,
+                                                              comm);
+            break;
+        case double_complex:
+            return bml_mpi_recv_matrix_ellsort_double_complex(N, M, src,
+                                                              comm);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}
+#endif

--- a/src/C-interface/ellsort/bml_parallel_ellsort.h
+++ b/src/C-interface/ellsort/bml_parallel_ellsort.h
@@ -18,4 +18,95 @@ void bml_allGatherVParallel_ellsort_single_complex(
 void bml_allGatherVParallel_ellsort_double_complex(
     bml_matrix_ellsort_t * A);
 
+#ifdef DO_MPI
+void bml_mpi_type_create_struct_ellsort(
+    bml_matrix_ellsort_t * A,
+    MPI_Datatype * newtype);
+
+void bml_mpi_type_create_struct_ellsort_single_real(
+    bml_matrix_ellsort_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_ellsort_double_real(
+    bml_matrix_ellsort_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_ellsort_single_complex(
+    bml_matrix_ellsort_t * A,
+    MPI_Datatype * newtype);
+void bml_mpi_type_create_struct_ellsort_double_complex(
+    bml_matrix_ellsort_t * A,
+    MPI_Datatype * newtype);
+
+void bml_mpi_send_ellsort(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_send_ellsort_single_real(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellsort_double_real(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellsort_single_complex(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm);
+void bml_mpi_send_ellsort_double_complex(
+    bml_matrix_ellsort_t * A,
+    const int dst,
+    MPI_Comm comm);
+
+void bml_mpi_recv_ellsort(
+    bml_matrix_ellsort_t * A,
+    const int src,
+    MPI_Comm comm);
+
+void bml_mpi_recv_ellsort_single_real(
+    bml_matrix_ellsort_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellsort_double_real(
+    bml_matrix_ellsort_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellsort_single_complex(
+    bml_matrix_ellsort_t * A,
+    const int src,
+    MPI_Comm comm);
+void bml_mpi_recv_ellsort_double_complex(
+    bml_matrix_ellsort_t * A,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_ellsort_t *bml_mpi_recv_matrix_ellsort(
+    bml_matrix_precision_t matrix_precision,
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+
+bml_matrix_ellsort_t *bml_mpi_recv_matrix_ellsort_single_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellsort_t *bml_mpi_recv_matrix_ellsort_double_real(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellsort_t *bml_mpi_recv_matrix_ellsort_single_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+bml_matrix_ellsort_t *bml_mpi_recv_matrix_ellsort_double_complex(
+    int N,
+    int M,
+    const int src,
+    MPI_Comm comm);
+#endif
+
 #endif

--- a/src/typed.h
+++ b/src/typed.h
@@ -22,6 +22,7 @@
 #define MATRIX_PRECISION single_real
 #define BLAS_PREFIX S
 #define MAGMA_PREFIX s
+#define MPI_T MPI_FLOAT
 #define XSMM_PREFIX libxsmm_
 #define REAL_PART(x) (x)
 #define IMAGINARY_PART(x) (0.0)
@@ -35,6 +36,7 @@
 #define MATRIX_PRECISION double_real
 #define BLAS_PREFIX D
 #define MAGMA_PREFIX d
+#define MPI_T MPI_DOUBLE
 #define XSMM_PREFIX libxsmm_
 #define REAL_PART(x) (x)
 #define IMAGINARY_PART(x) (0.0)
@@ -48,6 +50,7 @@
 #define MATRIX_PRECISION single_complex
 #define BLAS_PREFIX C
 #define MAGMA_PREFIX c
+#define MPI_T MPI_C_FLOAT_COMPLEX
 #define XSMM_PREFIX
 #define REAL_PART(x) (crealf(x))
 #define IMAGINARY_PART(x) (cimagf(x))
@@ -61,6 +64,7 @@
 #define MATRIX_PRECISION double_complex
 #define BLAS_PREFIX Z
 #define MAGMA_PREFIX z
+#define MPI_T MPI_C_DOUBLE_COMPLEX
 #define XSMM_PREFIX
 #define REAL_PART(x) (creal(x))
 #define IMAGINARY_PART(x) (cimag(x))

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES_TYPED
   import_export_matrix_typed.c
   inverse_matrix_typed.c
   io_matrix_typed.c
+  mpi_sendrecv_typed.c
   multiply_banded_matrix_typed.c
   multiply_matrix_typed.c
   multiply_matrix_x2_typed.c
@@ -60,6 +61,7 @@ add_executable(bml-test
   import_export_matrix.c
   inverse_matrix.c
   io_matrix.c
+  mpi_sendrecv.c
   multiply_banded_matrix.c
   multiply_matrix.c
   multiply_matrix_x2.c
@@ -97,9 +99,6 @@ endif()
 function(test_formats ${formats})
   foreach(T ${formats} )
     foreach(P single_real double_real single_complex double_complex)
-      if(BML_MPI)
-        add_test(${N}-${T}-${P} mpirun -np 4 bml-test -n ${N} -t ${T} -p ${P})
-      endif()
       add_test(C-${N}-${T}-${P} bml-test -n ${N} -t ${T} -p ${P})
       if(NOT BML_MPI AND NOT BML_OPENMP AND VALGRIND AND BML_VALGRIND)
         add_test(C-${N}-${T}-${P}-valgrind ${VALGRIND} ${VALGRIND_COMMON_ARGS}
@@ -109,41 +108,49 @@ function(test_formats ${formats})
   endforeach()
 endfunction(test_formats)
 
-if(BML_MPI)
-  set(testlist
-      allocate)
-else()
-  set(testlist
-    add
-    adjacency
-    adjungate_triangle
+function(test_formats_mpi ${formats})
+  foreach(T ${formats} )
+    foreach(P single_real double_real single_complex double_complex)
+      add_test(MPI-${N}-${T}-${P} mpirun -np 4 bml-test -n ${N} -t ${T} -p ${P})
+    endforeach()
+  endforeach()
+endfunction(test_formats_mpi)
+
+
+set(testlist-mpi
     allocate
-    bml_gemm
-    convert
-    copy
-    diagonalize
-    get_element
-    get_set_diagonal
-    get_sparsity
-    import_export
-    inverse
-    io_matrix
-    multiply
-    multiply_banded
-    multiply_x2
-    norm
-    normalize
-    print
-    scale
-    set_element
-    set_row
-    submatrix
-    threshold
-    trace
-    trace_mult
-    transpose
-  )
-endif()
+    mpi_sendrecv)
+
+set(testlist
+  add
+  adjacency
+  adjungate_triangle
+  allocate
+  bml_gemm
+  convert
+  copy
+  diagonalize
+  get_element
+  get_set_diagonal
+  get_sparsity
+  import_export
+  inverse
+  io_matrix
+  multiply
+  multiply_banded
+  multiply_x2
+  norm
+  normalize
+  print
+  scale
+  set_element
+  set_row
+  submatrix
+  threshold
+  trace
+  trace_mult
+  transpose
+)
 
 foreach(N ${testlist})
   set(formats dense ellpack ellsort ellblock csr)
@@ -161,6 +168,12 @@ foreach(N ${testlist})
   test_formats(${formats})
 endforeach()
 
+if(BML_MPI)
+  foreach(N ${testlist-mpi})
+    set(formats dense ellpack ellsort ellblock csr)
+    test_formats_mpi(${formats})
+  endforeach()
+endif()
 
 add_executable(test-backtrace test_backtrace.c)
 target_link_libraries(test-backtrace bml ${LINK_LIBRARIES})

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -111,15 +111,15 @@ endfunction(test_formats)
 function(test_formats_mpi ${formats})
   foreach(T ${formats} )
     foreach(P single_real double_real single_complex double_complex)
-      add_test(MPI-${N}-${T}-${P} mpirun -np 4 bml-test -n ${N} -t ${T} -p ${P})
+      add_test(MPI-C-${N}-${T}-${P} mpirun -np 4 ./bml-test -n ${N} -t ${T} -p ${P})
     endforeach()
   endforeach()
 endfunction(test_formats_mpi)
 
-
 set(testlist-mpi
     allocate
-    mpi_sendrecv)
+    mpi_sendrecv
+)
 
 set(testlist
   add

--- a/tests/C-tests/bml_test.c
+++ b/tests/C-tests/bml_test.c
@@ -8,7 +8,11 @@
 
 #include "bml_test.h"
 
+#ifdef DO_MPI
+const int NUM_TESTS = 29;
+#else
 const int NUM_TESTS = 28;
+#endif
 
 typedef struct
 {
@@ -32,6 +36,9 @@ const char *test_name[] = {
     "get_sparsity",
     "inverse",
     "io_matrix",
+#ifdef DO_MPI
+    "mpi_sendrecv",
+#endif
     "multiply",
     "multiply_banded",
     "multiply_x2",
@@ -63,6 +70,9 @@ const char *test_description[] = {
     "Get the sparsity",
     "Matrix inverse",
     "Read and write an mtx matrix",
+#ifdef DO_MPI
+    "Send/Recv matrix with MPI",
+#endif
     "Multiply two bml matrices",
     "Multiply two banded bml matrices",
     "Multiply two identical matrices",
@@ -94,6 +104,9 @@ const test_function_t testers[] = {
     test_get_sparsity,
     test_inverse,
     test_io_matrix,
+#ifdef DO_MPI
+    test_mpi_sendrecv,
+#endif
     test_multiply,
     test_multiply_banded,
     test_multiply_x2,

--- a/tests/C-tests/bml_test.h
+++ b/tests/C-tests/bml_test.h
@@ -23,6 +23,7 @@ typedef int (
 #include "import_export_matrix.h"
 #include "inverse_matrix.h"
 #include "io_matrix.h"
+#include "mpi_sendrecv.h"
 #include "multiply_banded_matrix.h"
 #include "multiply_matrix.h"
 #include "multiply_matrix_x2.h"

--- a/tests/C-tests/mpi_sendrecv.c
+++ b/tests/C-tests/mpi_sendrecv.c
@@ -1,0 +1,40 @@
+#include "bml.h"
+#include "bml_test.h"
+
+#include <stdio.h>
+
+#ifdef DO_MPI
+
+int
+test_mpi_sendrecv(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return test_mpi_sendrecv_single_real(N, matrix_type,
+                                                 matrix_precision, M);
+            break;
+        case double_real:
+            return test_mpi_sendrecv_double_real(N, matrix_type,
+                                                 matrix_precision, M);
+            break;
+        case single_complex:
+            return test_mpi_sendrecv_single_complex(N, matrix_type,
+                                                    matrix_precision, M);
+            break;
+        case double_complex:
+            return test_mpi_sendrecv_double_complex(N, matrix_type,
+                                                    matrix_precision, M);
+            break;
+        default:
+            fprintf(stderr, "unknown matrix precision\n");
+            return -1;
+            break;
+    }
+}
+
+#endif

--- a/tests/C-tests/mpi_sendrecv.h
+++ b/tests/C-tests/mpi_sendrecv.h
@@ -1,0 +1,36 @@
+#ifndef __TEST_MPI_SENDRECV_H
+#define __TEST_MPI_SENDRECV_H
+
+#include <bml.h>
+
+int test_mpi_sendrecv(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_mpi_sendrecv_single_real(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_mpi_sendrecv_double_real(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_mpi_sendrecv_single_complex(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_mpi_sendrecv_double_complex(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+#endif

--- a/tests/C-tests/mpi_sendrecv_typed.c
+++ b/tests/C-tests/mpi_sendrecv_typed.c
@@ -1,0 +1,92 @@
+#include "bml.h"
+#include "../typed.h"
+#include "bml_parallel.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+
+#ifdef DO_MPI
+
+int TYPED_FUNC(
+    test_mpi_sendrecv) (
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M)
+{
+    bml_matrix_t *A =
+        bml_random_matrix(matrix_type, matrix_precision, N, M, sequential);
+    REAL_T *A_dense = bml_export_to_dense(A, dense_row_major);
+
+    int myrank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &myrank);
+    if (myrank % 2 == 1)
+    {
+        LOG_DEBUG("Send matrix\n");
+        bml_mpi_send(A, myrank - 1, MPI_COMM_WORLD);
+        MPI_Send(A_dense, N * M, MPI_T, myrank - 1, 4567, MPI_COMM_WORLD);
+    }
+    else if (myrank % 2 == 0)
+    {
+        LOG_DEBUG("Recv matrix\n");
+        // receive copy of A into B
+        bml_matrix_t *B =
+            bml_mpi_recv_matrix(matrix_type, matrix_precision, N, M,
+                                myrank + 1, MPI_COMM_WORLD);
+
+        MPI_Status status;
+        MPI_Recv(A_dense, N * M, MPI_T, myrank + 1, 4567, MPI_COMM_WORLD,
+                 &status);
+
+        LOG_DEBUG("Compare matrix\n");
+        // compare A and B
+        REAL_T *B_dense = bml_export_to_dense(B, dense_row_major);
+
+//        bml_print_dense_matrix(N, matrix_precision, dense_row_major, A_dense,
+//                               0, N, 0, N);
+//        bml_print_dense_matrix(N, matrix_precision, dense_row_major, B_dense,
+//                               0, N, 0, N);
+
+        for (int i = 0; i < N; i++)
+        {
+            for (int j = 0; j < N; j++)
+            {
+                if (i == j)
+                {
+                    if (ABS(A_dense[i * N + j] - B_dense[i * N + j]) > 1e-12)
+                    {
+                        LOG_ERROR
+                            ("incorrect value on diagonal; A[%d,%d] = %e B[%d,%d] = %e\n",
+                             i, i, A_dense[i * N + j], i, i,
+                             B_dense[i * N + j]);
+                        return -1;
+                    }
+                }
+                else
+                {
+                    if (ABS(A_dense[i * N + j] - B_dense[i * N + j]) > 1e-12)
+                    {
+                        LOG_ERROR
+                            ("incorrect value off-diagonal; A[%d,%d] = %e B[%d,%d] = %e\n",
+                             i, j, A_dense[i * N + j], i, i,
+                             B_dense[i * N + j]);
+                        return -1;
+                    }
+                }
+            }
+        }
+
+        LOG_INFO("send/recv test passed\n");
+        bml_free_memory(B_dense);
+        bml_deallocate(&B);
+    }
+
+    bml_clear(A);
+    bml_deallocate(&A);
+    bml_free_memory(A_dense);
+
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
MPI point-to-point send/recv for BML matrices
of all formats

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/438)
<!-- Reviewable:end -->
