### PR TITLE
Do not restrict CI runs to `master` only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,8 +5,6 @@ on:
   release:
     type: [created]
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This change will enable CI testing on branches that do not correspond
to a PR. This might be helpful when developing a PR.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/451)
<!-- Reviewable:end -->
