### PR TITLE
Add testing of remaining float types to MPI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,7 +101,10 @@ jobs:
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R fortran-.*-double_real",    BML_VALGRIND: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R fortran-.*-single_complex", BML_VALGRIND: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R fortran-.*-double_complex", BML_VALGRIND: yes}
-          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, BML_MPI: yes, BML_MPIEXEC_NUMPROCS_FLAG: "-np", TESTING_EXTRA_ARGS: "-R MPI-C-.*-single_real", BML_VALGRIND: yes}
+          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, BML_MPI: yes, BML_MPIEXEC_NUMPROCS_FLAG: "-np", TESTING_EXTRA_ARGS: "-R MPI-C-.*-single_real", BML_VALGRIND: no}
+          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, BML_MPI: yes, BML_MPIEXEC_NUMPROCS_FLAG: "-np", TESTING_EXTRA_ARGS: "-R MPI-C-.*-double_real", BML_VALGRIND: no}
+          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, BML_MPI: yes, BML_MPIEXEC_NUMPROCS_FLAG: "-np", TESTING_EXTRA_ARGS: "-R MPI-C-.*-single_complex", BML_VALGRIND: no}
+          - {CC: mpicc,   CXX: mpic++,  FC: mpifort,      BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, BML_MPI: yes, BML_MPIEXEC_NUMPROCS_FLAG: "-np", TESTING_EXTRA_ARGS: "-R MPI-C-.*-double_complex", BML_VALGRIND: no}
     steps:
       - name: Check out sources
         uses: actions/checkout@v2


### PR DESCRIPTION
So far we are testing only the `single_real` float type for the MPI
tests. This change adds the other float types.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/452)
<!-- Reviewable:end -->
