### PR TITLE
Update CI image to Bionic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,14 +85,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     container:
-      image: nicolasbock/bml:master
+      image: nicolasbock/bml:pr-454
     strategy:
       matrix:
         include:
-          - {CC: gcc-4.7, CXX: g++-4.7, FC: gfortran-4.7, BUILD_SHARED_LIBS: yes, BML_OPENMP: no,  BML_INTERNAL_BLAS: no}
-          - {CC: gcc-4.7, CXX: g++-4.7, FC: gfortran-4.7, BUILD_SHARED_LIBS: yes, BML_OPENMP: no,  BML_INTERNAL_BLAS: yes}
-          - {CC: gcc-4.7, CXX: g++-4.7, FC: gfortran-4.7, BUILD_SHARED_LIBS: yes, BML_OPENMP: yes, BML_INTERNAL_BLAS: no}
-          - {CC: gcc-4.7, CXX: g++-4.7, FC: gfortran-4.7, BUILD_SHARED_LIBS: yes, BML_OPENMP: yes, BML_INTERNAL_BLAS: yes}
+          - {CC: gcc-4.8, CXX: g++-4.8, FC: gfortran-4.8, BUILD_SHARED_LIBS: yes, BML_OPENMP: no,  BML_INTERNAL_BLAS: no}
+          - {CC: gcc-4.8, CXX: g++-4.8, FC: gfortran-4.8, BUILD_SHARED_LIBS: yes, BML_OPENMP: no,  BML_INTERNAL_BLAS: yes}
+          - {CC: gcc-4.8, CXX: g++-4.8, FC: gfortran-4.8, BUILD_SHARED_LIBS: yes, BML_OPENMP: yes, BML_INTERNAL_BLAS: no}
+          - {CC: gcc-4.8, CXX: g++-4.8, FC: gfortran-4.8, BUILD_SHARED_LIBS: yes, BML_OPENMP: yes, BML_INTERNAL_BLAS: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R C-.*-single_real",          BML_VALGRIND: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R C-.*-double_real",          BML_VALGRIND: yes}
           - {CC: gcc-9,   CXX: g++-9,   FC: gfortran-9,   BUILD_SHARED_LIBS: no,  BML_OPENMP: no,  BML_INTERNAL_BLAS: no, TESTING_EXTRA_ARGS: "-R C-.*-single_complex",       BML_VALGRIND: yes}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,26 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 RUN apt-get update
 RUN apt-get install --assume-yes --no-install-recommends \
-        apt-transport-https \
-        ca-certificates \
-        wget
+    apt-transport-https \
+    ca-certificates \
+    gnupg \
+    wget
 
-COPY ci-images/build/clang.list /etc/apt/sources.list.d
+COPY clang.list /etc/apt/sources.list.d
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 
-COPY ci-images/build/cmake.list /etc/apt/sources.list.d
+COPY cmake.list /etc/apt/sources.list.d
 RUN apt-key adv --keyserver keyserver.ubuntu.com \
-        --recv-keys DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4
+    --recv-keys DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4
 
-COPY ci-images/build/toolchain.list /etc/apt/sources.list.d
+COPY toolchain.list /etc/apt/sources.list.d
 RUN apt-key adv --keyserver keyserver.ubuntu.com \
-        --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+    --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
 
-COPY ci-images/lint/emacs.list /etc/apt/sources.list.d
+COPY emacs.list /etc/apt/sources.list.d
 RUN apt-key adv --keyserver keyserver.ubuntu.com \
-        --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
+    --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
 
 RUN apt-get update
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
@@ -27,22 +28,23 @@ RUN apt-get install --assume-yes tzdata
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure --frontend noninteractive tzdata
 
 RUN apt-get install --assume-yes --no-install-recommends \
-        apt-utils \
-        bundler \
-        emacs26 \
-        build-essential \
-        cmake cmake-data \
-        clang-9 llvm-9-dev libomp-9-dev \
-        gcc-4.7 g++-4.7 gfortran-4.7 \
-        gcc-9 g++-9 gfortran-9 \
-        git-core \
-        indent \
-        openssh-client \
-        libblas-dev liblapack-dev \
-        mpich libmpich-dev \
-        python python-pip python-wheel \
-        texlive \
-        valgrind \
-        vim
+    apt-utils \
+    bundler \
+    emacs27 \
+    build-essential \
+    cmake cmake-data \
+    clang-9 llvm-9-dev libomp-9-dev \
+    gcc-4.8 g++-4.8 gfortran-4.8 \
+    gcc-9 g++-9 gfortran-9 \
+    gcc-10 g++-10 gfortran-10 \
+    git-core \
+    indent \
+    openssh-client \
+    libblas-dev liblapack-dev \
+    mpich libmpich-dev \
+    python python-pip python-wheel \
+    texlive \
+    valgrind \
+    vim
 
 WORkDIR /root

--- a/clang.list
+++ b/clang.list
@@ -1,0 +1,9 @@
+# i386 not available
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
+# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
+# 11
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main
+# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main
+# 12
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main
+# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main

--- a/cmake.list
+++ b/cmake.list
@@ -1,0 +1,2 @@
+deb http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main 
+# deb-src http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main 

--- a/emacs.list
+++ b/emacs.list
@@ -1,0 +1,2 @@
+deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main

--- a/refresh-ci-images.sh
+++ b/refresh-ci-images.sh
@@ -2,13 +2,11 @@
 
 set -x -e
 
-: ${IMAGE_TAG:=bml-ci}
-: ${IMAGE_VERSION:=2}
+: ${IMAGE_TAG:=bml}
+: ${IMAGE_VERSION:=test}
 : ${PUSH_IMAGE:=no}
 
-for workflow in build lint docs; do
-  docker build --tag nicolasbock/${IMAGE_TAG}-${workflow}:${IMAGE_VERSION} ci-images/${workflow}
-  if [[ ${PUSH_IMAGE} = yes ]]; then
-    docker push nicolasbock/${IMAGE_TAG}-${workflow}:${IMAGE_VERSION}
-  fi
-done
+docker build --pull --tag nicolasbock/${IMAGE_TAG}:${IMAGE_VERSION} .
+if [[ ${PUSH_IMAGE} = yes ]]; then
+  docker push nicolasbock/${IMAGE_TAG}:${IMAGE_VERSION}
+fi

--- a/toolchain.list
+++ b/toolchain.list
@@ -1,0 +1,2 @@
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main 
+# deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main 


### PR DESCRIPTION
* Xenial is going out of regular maintenance mid-year 2021 [1]
* Xenial is EOL for LLVM since March 28 2021 [2]
* Xenial does not support >gcc-9 [3].

This change updates the CI image to using Bionic.

[1] https://ubuntu.com/about/release-cycle
[2] https://apt.llvm.org/
[3] https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test?field.series_filter=xenial

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/454)
<!-- Reviewable:end -->
