### PR TITLE
Switch back to using the `master` CI image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,13 @@ jobs:
   containers:
     name: Update container images (only approve if change involves the Dockerfile and if the change is trusted)
     runs-on: ubuntu-latest
+    # GitHub restricts access to environment secrets from forks for
+    # security reasons and building of the CI image will fail from a
+    # fork.
+    if: ${{ github.event.pull_request.head.repo.full_name == 'lanl/bml' }}
     environment: CI
     steps:
+      - run: echo ${{ github.event.pull_request.head.repo.full_name }}
       - name: Check out sources
         uses: actions/checkout@v2
       - name: Docker meta
@@ -64,7 +69,7 @@ jobs:
         uses: actions/checkout@v1
       - run: bundle install
       - run: bundle exec danger || true
-      - run: BML_OPENMP=no VERBOSE_MAKEFILE=yes EMACS=emacs26 ./build.sh check_indent
+      - run: BML_OPENMP=no VERBOSE_MAKEFILE=yes EMACS=emacs27 ./build.sh check_indent
 
   docs:
     name: Build docs
@@ -83,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     container:
-      image: nicolasbock/bml:pr-454
+      image: nicolasbock/bml:master
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This is a follow-on of lanl/bml#454.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lanl/bml/456)
<!-- Reviewable:end -->
