### PR TITLE
Build CI environment in workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,7 @@ env:
   BML_MPI: no
   BML_INTERNAL_BLAS: no
   BML_VALGRIND: no
+  VERBOSE_MAKEFILE: yes
 
 jobs:
   containers:
@@ -61,34 +62,32 @@ jobs:
 
   lint:
     name: Lint sources
-    runs-on: ubuntu-latest
-    container:
-      image: nicolasbock/bml:master
+    runs-on: ubuntu-18.04
     steps:
       - name: Check out sources
         uses: actions/checkout@v1
+      - name: Prepare container
+        run: ./prepare-container.sh
       - run: bundle install
       - run: bundle exec danger || true
-      - run: BML_OPENMP=no VERBOSE_MAKEFILE=yes EMACS=emacs27 ./build.sh check_indent
+      - run: BML_OPENMP=no EMACS=emacs27 ./build.sh check_indent
 
   docs:
     name: Build docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: lint
-    container:
-      image: nicolasbock/bml:master
     steps:
       - name: Check out sources
         uses: actions/checkout@v2
+      - name: Prepare container
+        run: ./prepare-container.sh
       - name: Build docs
         run: ./build.sh docs
 
   build:
     name: Build and test the library
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: lint
-    container:
-      image: nicolasbock/bml:master
     strategy:
       matrix:
         include:
@@ -111,6 +110,8 @@ jobs:
     steps:
       - name: Check out sources
         uses: actions/checkout@v2
+      - name: Prepare container
+        run: ./prepare-container.sh
       - name: Build and test library
         env:
           CC: ${{ matrix.CC }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,6 @@
 FROM ubuntu:bionic
 
-RUN apt-get update
-RUN apt-get install --assume-yes --no-install-recommends \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget
-
-COPY clang.list /etc/apt/sources.list.d
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-
-COPY cmake.list /etc/apt/sources.list.d
-RUN apt-key adv --keyserver keyserver.ubuntu.com \
-    --recv-keys DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4
-
-COPY toolchain.list /etc/apt/sources.list.d
-RUN apt-key adv --keyserver keyserver.ubuntu.com \
-    --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
-
-COPY emacs.list /etc/apt/sources.list.d
-RUN apt-key adv --keyserver keyserver.ubuntu.com \
-    --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
-
-RUN apt-get update
-RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime
-RUN apt-get install --assume-yes tzdata
-RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure --frontend noninteractive tzdata
-
-RUN apt-get install --assume-yes --no-install-recommends \
-    apt-utils \
-    bundler \
-    emacs27 \
-    build-essential \
-    cmake cmake-data \
-    clang-9 llvm-9-dev libomp-9-dev \
-    gcc-4.8 g++-4.8 gfortran-4.8 \
-    gcc-9 g++-9 gfortran-9 \
-    gcc-10 g++-10 gfortran-10 \
-    git-core \
-    indent \
-    openssh-client \
-    libblas-dev liblapack-dev \
-    mpich libmpich-dev \
-    python python-pip python-wheel \
-    texlive \
-    valgrind \
-    vim
+COPY prepare-container.sh /usr/sbin
+RUN /usr/sbin/prepare-container.sh
 
 WORkDIR /root

--- a/clang.list
+++ b/clang.list
@@ -1,9 +1,0 @@
-# i386 not available
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
-# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
-# 11
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main
-# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main
-# 12
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main
-# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main

--- a/cmake.list
+++ b/cmake.list
@@ -1,2 +1,0 @@
-deb http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main 
-# deb-src http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main 

--- a/emacs.list
+++ b/emacs.list
@@ -1,2 +1,0 @@
-deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main
-# deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main

--- a/prepare-container.sh
+++ b/prepare-container.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e -u -x
+
+SUDO=$(which sudo || true)
+
+${SUDO} apt-get update
+${SUDO} apt-get install --assume-yes --no-install-recommends \
+  apt-transport-https \
+  ca-certificates \
+  gnupg \
+  wget
+
+cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/clang.list
+# i386 not available
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
+# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main
+# 11
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main
+# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main
+# 12
+deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main
+# deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main
+EOF
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | ${SUDO} apt-key add -
+
+cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/cmake.list
+deb http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main
+EOF
+${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
+  --recv-keys DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4
+
+cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/toolchain.list
+deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main
+EOF
+${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
+  --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+
+cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/emacs.list
+deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main
+# deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main
+EOF
+${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
+  --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
+
+${SUDO} apt-get update
+${SUDO} ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+${SUDO} apt-get install --assume-yes tzdata
+DEBIAN_FRONTEND=noninteractive ${SUDO} dpkg-reconfigure \
+  --frontend noninteractive tzdata
+
+${SUDO} apt-get install --assume-yes --no-install-recommends \
+  apt-utils \
+  bundler \
+  emacs27 \
+  build-essential \
+  cmake cmake-data \
+  clang-9 llvm-9-dev libomp-9-dev \
+  gcc-4.8 g++-4.8 gfortran-4.8 \
+  gcc-9 g++-9 gfortran-9 \
+  gcc-10 g++-10 gfortran-10 \
+  git-core \
+  indent \
+  openssh-client \
+  libblas-dev liblapack-dev \
+  mpich libmpich-dev \
+  python python-pip python-wheel \
+  texlive \
+  valgrind \
+  vim

--- a/toolchain.list
+++ b/toolchain.list
@@ -1,2 +1,0 @@
-deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main 
-# deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main 


### PR DESCRIPTION
This change removes the custom built container from the GitHub
workflows and instead configures the build environment during the CI
run itself. This has the advantage that we can modify the build
environment in a PR and use is for that same PP in CI.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>