### PR TITLE
Distributed2d diagonalization and norm functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,11 @@ if (MAGMA_FOUND)
   endif()
 endif()
 
+set(BML_SCALAPACK FALSE CACHE BOOL "Whether to use ScaLAPACK library")
+if(BML_SCALAPACK)
+  add_definitions(-DBML_USE_SCALAPACK)
+endif()
+
 set(BML_INTERNAL_BLAS FALSE
   CACHE BOOL "Use internal BLAS functions")
 
@@ -501,6 +506,20 @@ if(LAPACK_FOUND)
     -DC_ZLACPY=${C_ZLACPY})
 
   list(APPEND LINK_LIBRARIES ${LAPACK_LIBRARIES})
+endif()
+
+if(BML_SCALAPACK)
+  bml_check_C_Fortran_function_exists(pssyevd PSSYEVD REQUIRED)
+  bml_check_C_Fortran_function_exists(pdsyevd PDSYEVD REQUIRED)
+  bml_check_C_Fortran_function_exists(pcheevd PCHEEVD REQUIRED)
+  bml_check_C_Fortran_function_exists(pzheevd PZHEEVD REQUIRED)
+  bml_check_C_Fortran_function_exists(numroc NUMROC REQUIRED)
+  add_definitions(
+    -DPSSYEVD=${PSSYEVD}
+    -DPDSYEVD=${PDSYEVD}
+    -DPCHEEVD=${PCHEEVD}
+    -DPZHEEVD=${PZHEEVD}
+    -DNUMROC=${NUMROC})
 endif()
 
 # Check whether the compiler supports complex types. The Nvidia

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,7 @@ EOF
     echo "BML_MAGMA              Build with MAGMA            (default is ${BML_MAGMA})"
     echo "BML_CUSOLVER           Build with cuSOLVER         (default is ${BML_CUSOLVER})"
     echo "BML_XSMM               Build with XSMM             (default is ${BML_XSMM})"
+    echo "BML_SCALAPACK          Build with SCALAPACK        (default is ${BML_SCALAPACK})"
     echo "BML_ELLBLOCK_MEMPOOL   Use ellblock memory pool    (default is ${BML_ELLBLOCK_MEMPOOL}"
     echo "CUDA_TOOLKIT_ROOT_DIR  Path to CUDA dir            (default is ${CUDA_TOOLKIT_ROOT_DIR})"
     echo "INTEL_OPT              {yes, no}                   (default is ${INTEL_OPT})"
@@ -115,6 +116,7 @@ set_defaults() {
     : ${BML_MAGMA:=no}
     : ${BML_CUSOLVER:=no}
     : ${BML_XSMM:=no}
+    : ${BML_SCALAPACK:=no}
     : ${BML_ELLBLOCK_MEMPOOL:=no}
     : ${CUDA_TOOLKIT_ROOT_DIR:=}
     : ${INTEL_OPT:=no}
@@ -196,6 +198,7 @@ configure() {
         -DBML_MAGMA="${BML_MAGMA}" \
         -DBML_CUSOLVER="${BML_CUSOLVER}" \
         -DBML_XSMM="${BML_XSMM}" \
+        -DBML_SCALAPACK="${BML_SCALAPACK}" \
         -DBML_ELLBLOCK_MEMPOOL="${BML_ELLBLOCK_MEMPOOL}" \
         -DCUDA_TOOLKIT_ROOT_DIR="${CUDA_TOOLKIT_ROOT_DIR}" \
         -DINTEL_OPT="${INTEL_OPT:=no}" \

--- a/src/C-interface/bml_diagonalize.c
+++ b/src/C-interface/bml_diagonalize.c
@@ -7,6 +7,9 @@
 #include "ellpack/bml_diagonalize_ellpack.h"
 #include "ellblock/bml_diagonalize_ellblock.h"
 #include "csr/bml_diagonalize_csr.h"
+#ifdef DO_MPI
+#include "distributed2d/bml_diagonalize_distributed2d.h"
+#endif
 
 void
 bml_diagonalize(
@@ -31,6 +34,11 @@ bml_diagonalize(
         case csr:
             bml_diagonalize_csr(A, eigenvalues, eigenvectors);
             break;
+#ifdef DO_MPI
+        case distributed2d:
+            bml_diagonalize_distributed2d(A, eigenvalues, eigenvectors);
+            break;
+#endif
         default:
             LOG_ERROR("unknown matrix type\n");
             break;

--- a/src/C-interface/bml_introspection.c
+++ b/src/C-interface/bml_introspection.c
@@ -64,6 +64,11 @@ bml_get_precision(
         case csr:
             return bml_get_precision_csr(A);
             break;
+#ifdef DO_MPI
+        case distributed2d:
+            bml_get_precision(bml_get_local_matrix(A));
+            break;
+#endif
         default:
             LOG_ERROR("unknown precision");
             break;
@@ -329,6 +334,22 @@ bml_get_local_matrix(
 #endif
         default:
             LOG_ERROR("unknown matrix type in bml_get_local_matrix\n");
+            break;
+    }
+    return NULL;
+}
+
+void *
+bml_get_data_ptr(
+    bml_matrix_t * A)
+{
+    switch (bml_get_type(A))
+    {
+        case dense:
+            return bml_get_data_ptr_dense(A);
+            break;
+        default:
+            LOG_ERROR("unknown matrix type in bml_get_data_ptr\n");
             break;
     }
     return NULL;

--- a/src/C-interface/bml_introspection.h
+++ b/src/C-interface/bml_introspection.h
@@ -36,4 +36,7 @@ bml_distribution_mode_t bml_get_distribution_mode(
 
 bml_matrix_t *bml_get_local_matrix(
     bml_matrix_t * A);
+
+void *bml_get_data_ptr(
+    bml_matrix_t * A);
 #endif

--- a/src/C-interface/bml_norm.c
+++ b/src/C-interface/bml_norm.c
@@ -6,6 +6,9 @@
 #include "ellsort/bml_norm_ellsort.h"
 #include "ellblock/bml_norm_ellblock.h"
 #include "csr/bml_norm_csr.h"
+#ifdef DO_MPI
+#include "distributed2d/bml_norm_distributed2d.h"
+#endif
 
 #include <stdlib.h>
 
@@ -191,6 +194,11 @@ bml_fnorm(
         case csr:
             return bml_fnorm_csr(A);
             break;
+#ifdef DO_MPI
+        case distributed2d:
+            bml_fnorm_distributed2d(A);
+            break;
+#endif
         default:
             LOG_ERROR("unknown matrix type\n");
             break;

--- a/src/C-interface/bml_setters.c
+++ b/src/C-interface/bml_setters.c
@@ -6,6 +6,9 @@
 #include "ellsort/bml_setters_ellsort.h"
 #include "ellblock/bml_setters_ellblock.h"
 #include "csr/bml_setters_csr.h"
+#ifdef DO_MPI
+#include "distributed2d/bml_setters_distributed2d.h"
+#endif
 
 void
 bml_set_element_new(
@@ -121,6 +124,11 @@ bml_set_diagonal(
         case csr:
             bml_set_diagonal_csr(A, diagonal, threshold);
             break;
+#ifdef DO_MPI
+        case distributed2d:
+            bml_set_diagonal_distributed2d(A, diagonal, threshold);
+            break;
+#endif
         default:
             LOG_ERROR("unknown matrix type in bml_set_diagonal\n");
             break;

--- a/src/C-interface/dense/bml_introspection_dense.c
+++ b/src/C-interface/dense/bml_introspection_dense.c
@@ -187,3 +187,10 @@ bml_get_sparsity_dense(
     }
     return -1;
 }
+
+void *
+bml_get_data_ptr_dense(
+    bml_matrix_dense_t * A)
+{
+    return A->matrix;
+}

--- a/src/C-interface/dense/bml_introspection_dense.h
+++ b/src/C-interface/dense/bml_introspection_dense.h
@@ -71,4 +71,6 @@ double bml_get_sparsity_dense_double_complex(
     bml_matrix_dense_t * A,
     double threshold);
 
+void *bml_get_data_ptr_dense(
+    bml_matrix_dense_t * A);
 #endif

--- a/src/C-interface/distributed2d/CMakeLists.txt
+++ b/src/C-interface/distributed2d/CMakeLists.txt
@@ -4,10 +4,13 @@ set(HEADERS-DISTRIBUTED
   bml_import_distributed2d.h
   bml_convert_distributed2d.h
   bml_copy_distributed2d.h
+  bml_diagonalize_distributed2d.h
   bml_scale_distributed2d.h
   bml_add_distributed2d.h
   bml_introspection_distributed2d.h
   bml_multiply_distributed2d.h
+  bml_norm_distributed2d.h
+  bml_setters_distributed2d.h
   bml_transpose_distributed2d.h
   bml_trace_distributed2d.h )
 
@@ -17,11 +20,14 @@ set(SOURCES-DISTRIBUTED
   bml_import_distributed2d.c
   bml_convert_distributed2d.c
   bml_copy_distributed2d.c
+  bml_diagonalize_distributed2d.c
   bml_scale_distributed2d.c
   bml_add_distributed2d.c
   bml_introspection_distributed2d.c
   bml_import_distributed2d.c
   bml_multiply_distributed2d.c
+  bml_norm_distributed2d.c
+  bml_setters_distributed2d.c
   bml_transpose_distributed2d.c
   bml_trace_distributed2d.c )
 
@@ -39,6 +45,7 @@ set(SOURCES-DISTRIBUTED-TYPED
   bml_export_distributed2d_typed.c
   bml_import_distributed2d_typed.c
   bml_multiply_distributed2d_typed.c
+  bml_diagonalize_distributed2d_typed.c
   )
 
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)

--- a/src/C-interface/distributed2d/bml_allocate_distributed2d.c
+++ b/src/C-interface/distributed2d/bml_allocate_distributed2d.c
@@ -125,6 +125,7 @@ bml_zero_matrix_distributed2d(
         bml_allocate_memory(sizeof(bml_matrix_distributed2d_t));
     bml_setup_distributed2d(N, A);
     A->M = M;
+    A->matrix_precision = matrix_precision;
     int m = M / bml_sqrtint(A->ntasks);
     A->matrix =
         bml_zero_matrix(matrix_type, matrix_precision, A->n, m, sequential);
@@ -190,6 +191,7 @@ bml_identity_matrix_distributed2d(
         bml_allocate_memory(sizeof(bml_matrix_distributed2d_t));
     bml_setup_distributed2d(N, A);
     A->M = M;
+    A->matrix_precision = matrix_precision;
     int m = M / bml_sqrtint(A->ntasks);
     A->matrix = (A->myprow == A->mypcol) ?
         bml_identity_matrix(matrix_type, matrix_precision, A->n, m,

--- a/src/C-interface/distributed2d/bml_diagonalize_distributed2d.c
+++ b/src/C-interface/distributed2d/bml_diagonalize_distributed2d.c
@@ -1,0 +1,42 @@
+#include "../bml_logger.h"
+#include "../bml_types.h"
+#include "../bml_utilities.h"
+#include "../dense/bml_types_dense.h"
+#include "bml_diagonalize_distributed2d.h"
+#include "bml_types_distributed2d.h"
+
+#include <string.h>
+
+/** \page diagonalize
+ *
+ */
+
+void
+bml_diagonalize_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_t * eigenvectors)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_diagonalize_distributed2d_single_real(A, eigenvalues,
+                                                      eigenvectors);
+            break;
+        case double_real:
+            bml_diagonalize_distributed2d_double_real(A, eigenvalues,
+                                                      eigenvectors);
+            break;
+        case single_complex:
+            bml_diagonalize_distributed2d_single_complex(A, eigenvalues,
+                                                         eigenvectors);
+            break;
+        case double_complex:
+            bml_diagonalize_distributed2d_double_complex(A, eigenvalues,
+                                                         eigenvectors);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/distributed2d/bml_diagonalize_distributed2d.h
+++ b/src/C-interface/distributed2d/bml_diagonalize_distributed2d.h
@@ -1,0 +1,31 @@
+#ifndef __BML_DIAGONALIZE_DISTRIBUTED2D_H
+#define __BML_DIAGONALIZE_DISTRIBUTED2D_H
+
+#include "bml_types_distributed2d.h"
+
+void bml_diagonalize_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_t * eigenvectors);
+
+void bml_diagonalize_distributed2d_single_real(
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_distributed2d_t * eigenvectors);
+
+void bml_diagonalize_distributed2d_double_real(
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_distributed2d_t * eigenvectors);
+
+void bml_diagonalize_distributed2d_single_complex(
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_distributed2d_t * eigenvectors);
+
+void bml_diagonalize_distributed2d_double_complex(
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_distributed2d_t * eigenvectors);
+
+#endif

--- a/src/C-interface/distributed2d/bml_diagonalize_distributed2d_typed.c
+++ b/src/C-interface/distributed2d/bml_diagonalize_distributed2d_typed.c
@@ -1,0 +1,268 @@
+#include "bml_allocate_distributed2d.h"
+#include "bml_introspection_distributed2d.h"
+#include "../bml_introspection.h"
+#include "../bml_allocate.h"
+#include "../bml_convert.h"
+#include "bml_copy_distributed2d.h"
+#include "bml_diagonalize_distributed2d.h"
+#include "../bml_diagonalize.h"
+#include "../bml_logger.h"
+#include "bml_types_distributed2d.h"
+#include "../bml_types.h"
+#include "../bml_utilities.h"
+#include "../dense/bml_allocate_dense.h"
+#include "../dense/bml_diagonalize_dense.h"
+#include "../dense/bml_types_dense.h"
+#include "../../macros.h"
+#include "../../typed.h"
+
+#include <mpi.h>
+
+#include <complex.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef BML_USE_SCALAPACK
+// since scalapack does not provide an include file, we add prototypes here
+int Csys2blacs_handle(
+    MPI_Comm);
+void Cblacs_gridinfo(
+    int,
+    int *,
+    int *,
+    int *,
+    int *);
+void Cblacs_gridinit(
+    int *,
+    char[],
+    int,
+    int);
+int NUMROC(
+    int *,
+    int *,
+    int *,
+    int *,
+    int *);
+
+#if defined(SINGLE_REAL)
+void PSSYEVD(
+    const char *const,
+    const char *const,
+    int *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    REAL_T *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    int *);
+#define SYEVD PSSYEVD
+#elif defined(DOUBLE_REAL)
+void PDSYEVD(
+    const char *const,
+    const char *const,
+    int *,
+    double *,
+    int *,
+    int *,
+    int *,
+    double *,
+    double *,
+    int *,
+    int *,
+    int *,
+    double *,
+    int *,
+    int *,
+    int *,
+    int *);
+#define SYEVD PDSYEVD
+#elif defined(SINGLE_COMPLEX)
+void PCHEEVD(
+    const char *const,
+    const char *const,
+    int *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    float *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    REAL_T *,
+    int *,
+    float *,
+    int *,
+    int *,
+    int *,
+    int *);
+#define SYEVD PCHEEVD
+#elif defined(DOUBLE_COMPLEX)
+void PZHEEVD(
+    const char *const,
+    const char *const,
+    int *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    double *,
+    REAL_T *,
+    int *,
+    int *,
+    int *,
+    REAL_T *,
+    int *,
+    double *,
+    int *,
+    int *,
+    int *,
+    int *);
+#define SYEVD PZHEEVD
+#endif
+#endif // BML_USE_SCALAPACK
+
+/** Diagonalize matrix.
+ *
+ *  \ingroup diag_group
+ *
+ *  \param A The matrix A
+ *  \param eigenvalues Eigenvalues of A
+ *  \param eigenvectors Eigenvectors of A
+ */
+void TYPED_FUNC(
+    bml_diagonalize_distributed2d) (
+    bml_matrix_distributed2d_t * A,
+    void *eigenvalues,
+    bml_matrix_distributed2d_t * eigenvectors)
+{
+#ifdef BML_USE_SCALAPACK
+    char order = 'C';
+    int np_rows = A->nprows;
+    int np_cols = A->npcols;
+    int my_prow = A->myprow;
+    int my_pcol = A->mypcol;
+    int my_blacs_ctxt = Csys2blacs_handle(A->comm);
+    Cblacs_gridinit(&my_blacs_ctxt, &order, np_rows, np_cols);
+    Cblacs_gridinfo(my_blacs_ctxt, &np_rows, &np_cols, &my_prow, &my_pcol);
+
+    int m = A->N;
+    int mb = A->N / np_rows;
+
+    int desc[9];
+    desc[0] = 1;
+    desc[1] = my_blacs_ctxt;
+    desc[2] = A->N;
+    desc[3] = A->N;
+    desc[4] = mb;
+    desc[5] = mb;
+    desc[6] = 0;
+    desc[7] = 0;
+    desc[8] = A->N / np_rows;
+
+    bml_matrix_t *Alocal = A->matrix;
+
+    bml_matrix_t *zmat = NULL;
+    bml_matrix_t *amat = NULL;
+    if (bml_get_type(Alocal) == dense)
+    {
+        amat = Alocal;
+        zmat = eigenvectors->matrix;
+    }
+    else
+    {
+        LOG_INFO("WARNING: convert local matrices to dense...\n");
+        // convert local matrix to dense
+        amat = bml_convert(Alocal, dense, A->matrix_precision,
+                           -1, sequential);
+        zmat = bml_convert(eigenvectors->matrix, dense, A->matrix_precision,
+                           -1, sequential);
+    }
+
+    REAL_T *pzmat = bml_get_data_ptr(zmat);
+    assert(pzmat != NULL);
+    MPI_Barrier(MPI_COMM_WORLD);
+    // copy matrix into tmp array since scalapack will destroy its content
+    REAL_T *atmp = bml_allocate_memory(m * m * sizeof(REAL_T));
+    memcpy(atmp, bml_get_data_ptr(amat), m * m * sizeof(REAL_T));
+
+    int ione = 1;
+#if defined(SINGLE_REAL) || defined(DOUBLE_REAL)
+    int lwork = MAX(1 + 6 * m + 2 * mb * mb,
+                    3 * m + MAX(mb * (mb + 1), 3 * mb)) + 2 * m;
+#else
+    int izero = 0;
+    int np0 = NUMROC(&m, &mb, &izero, &izero, &np_rows);
+    int lwork = m + (2 * np0 + mb) * mb;
+#endif
+    REAL_T *work = bml_allocate_memory(lwork * sizeof(REAL_T));
+#if defined(SINGLE_REAL) || defined(SINGLE_COMPLEX)
+    float *ev = eigenvalues;
+#endif
+#if defined(DOUBLE_REAL) || defined(DOUBLE_COMPLEX)
+    double *ev = eigenvalues;
+#endif
+
+#if defined(SINGLE_COMPLEX) || defined(DOUBLE_COMPLEX)
+    int np = NUMROC(&m, &mb, &my_prow, &ione, &np_rows);
+    int nq = NUMROC(&m, &mb, &my_pcol, &ione, &np_cols);
+    int lrwork = 1 + 9 * m + 3 * np * nq;
+#endif
+
+#if defined(SINGLE_COMPLEX)
+    float *rwork = bml_allocate_memory(lrwork * sizeof(float));
+#endif
+#if defined(DOUBLE_COMPLEX)
+    double *rwork = bml_allocate_memory(lrwork * sizeof(double));
+#endif
+
+    int liwork = 7 * m + 8 * np_cols + 2;
+    int *iwork = bml_allocate_memory(liwork * sizeof(int));
+    // Solve matrix eigenvalue problem problem
+    char jobz = 'V';
+    char uplo = 'U';
+    int info;
+    SYEVD(&jobz, &uplo, &m, atmp, &ione, &ione, desc, ev,
+          pzmat, &ione, &ione, desc, work, &lwork,
+#if defined(SINGLE_COMPLEX) || defined(DOUBLE_COMPLEX)
+          rwork, &lrwork,
+#endif
+          iwork, &liwork, &info);
+
+    if (info > 0)
+        LOG_ERROR("Eigenvalue %d did not converge\n", info);
+
+    // clean up
+    bml_free_memory(work);
+    bml_free_memory(atmp);
+    bml_free_memory(iwork);
+#if defined(SINGLE_COMPLEX) || defined(DOUBLE_COMPLEX)
+    bml_free_memory(rwork);
+#endif
+
+    if (bml_get_type(Alocal) != dense)
+    {
+        bml_deallocate(&(eigenvectors->matrix));
+        eigenvectors->matrix =
+            bml_convert(zmat, bml_get_type(Alocal), A->matrix_precision,
+                        A->M / A->npcols, sequential);
+        bml_deallocate(&amat);
+        bml_deallocate(&zmat);
+    }
+#else
+    LOG_ERROR
+        ("Build with ScaLAPACK required for distributed2d diagonalization\n");
+#endif
+    return;
+}

--- a/src/C-interface/distributed2d/bml_norm_distributed2d.c
+++ b/src/C-interface/distributed2d/bml_norm_distributed2d.c
@@ -1,0 +1,123 @@
+#include "../bml_logger.h"
+#include "../bml_types.h"
+#include "../bml_norm.h"
+#include "../bml_parallel.h"
+#include "bml_norm_distributed2d.h"
+#include "bml_types_distributed2d.h"
+
+#include <math.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Calculate the sum of squares of the elements in matrix A.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix
+ *  \return Sum of squares of all elements in A
+ */
+double
+bml_sum_squares_distributed2d(
+    bml_matrix_distributed2d_t * A)
+{
+    double norm = bml_sum_squares(A->matrix);
+
+    bml_sumRealReduce(&norm);
+
+    return norm;
+}
+
+/** Calculate the sum of elements in
+ * \alpha A(i,j) * B(i,j).
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \param alpha Multiplier for matrix A
+ *  \param threshold Threshold
+ *  \return The sum of squares of all elements of \alpha A(i,j) * B(i,j)
+ */
+double
+bml_sum_AB_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    bml_matrix_distributed2d_t * B,
+    double alpha,
+    double threshold)
+{
+    double norm = bml_sum_AB(A->matrix, B->matrix, alpha, threshold);
+
+    bml_sumRealReduce(&norm);
+
+    return norm;
+}
+
+/** Calculate the sum of squares of elements in
+ * \alpha A + \beta B.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \param alpha Multiplier for matrix A
+ *  \param beta Multiplier for matrix B
+ *  \param threshold Threshold
+ *  \return The sum of squares of all elements of \alpha A + \beta B
+ */
+double
+bml_sum_squares2_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    bml_matrix_distributed2d_t * B,
+    double alpha,
+    double beta,
+    double threshold)
+{
+    double norm =
+        bml_sum_squares2(A->matrix, B->matrix, alpha, beta, threshold);
+    norm = norm * norm;
+
+    bml_sumRealReduce(&norm);
+
+    return sqrt(norm);
+}
+
+/** Calculate the Fobenius norm of matrix A.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix
+ *  \return Frobenius norm of A
+ */
+double
+bml_fnorm_distributed2d(
+    bml_matrix_distributed2d_t * A)
+{
+    double norm = bml_fnorm(A->matrix);
+
+    bml_sumRealReduce(&norm);
+
+    return norm;
+}
+
+/** Calculate the Fobenius norm of the difference between 2 matrices.
+ *
+ *  \ingroup norm_group
+ *
+ *  \param A The matrix A
+ *  \param B The matrix B
+ *  \return Frobenius norm of A-B
+ */
+double
+bml_fnorm2_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    bml_matrix_distributed2d_t * B)
+{
+    double norm = bml_fnorm2(A->matrix, B->matrix);
+    norm = norm * norm;
+
+    bml_sumRealReduce(&norm);
+
+    return sqrt(norm);
+}

--- a/src/C-interface/distributed2d/bml_norm_distributed2d.h
+++ b/src/C-interface/distributed2d/bml_norm_distributed2d.h
@@ -1,0 +1,33 @@
+#ifndef __BML_NORM_DISTRIBUTED2D_H
+#define __BML_NORM_DISTRIBUTED2D_H
+
+#include "bml_types_distributed2d.h"
+
+double bml_sum_squares_distributed2d(
+    bml_matrix_distributed2d_t * A);
+
+double bml_sum_squares_submatrix_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    int core_size);
+
+double bml_sum_AB_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    bml_matrix_distributed2d_t * B,
+    double alpha,
+    double threshold);
+
+double bml_sum_squares2_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    bml_matrix_distributed2d_t * B,
+    double alpha,
+    double beta,
+    double threshold);
+
+double bml_fnorm_distributed2d(
+    bml_matrix_distributed2d_t * A);
+
+double bml_fnorm2_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    bml_matrix_distributed2d_t * B);
+
+#endif

--- a/src/C-interface/distributed2d/bml_setters_distributed2d.c
+++ b/src/C-interface/distributed2d/bml_setters_distributed2d.c
@@ -1,0 +1,20 @@
+#include "../bml_introspection.h"
+#include "../bml_logger.h"
+#include "../bml_setters.h"
+#include "bml_setters_distributed2d.h"
+#include "bml_types_distributed2d.h"
+
+/** Setters for diagonal.
+ *
+ * \param A The matrix.
+ * \param diag The diagonal (a vector with all diagonal elements).
+ */
+void
+bml_set_diagonal_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    void *diagonal,
+    double threshold)
+{
+    if (A->myprow == A->mypcol)
+        bml_set_diagonal(A->matrix, diagonal, threshold);
+}

--- a/src/C-interface/distributed2d/bml_setters_distributed2d.h
+++ b/src/C-interface/distributed2d/bml_setters_distributed2d.h
@@ -1,0 +1,13 @@
+/** \file */
+
+#ifndef __BML_SETTERS_DISTRIBUTED2D_H
+#define __BML_SETTERS_DISTRIBUTED2D_H
+
+#include "bml_types_distributed2d.h"
+
+void bml_set_diagonal_distributed2d(
+    bml_matrix_distributed2d_t * A,
+    void *diagonal,
+    double threshold);
+
+#endif

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -125,6 +125,7 @@ set(testlist-mpi
     allocate
     copy
     convert
+    diagonalize
     import_export
     scale
     mpi_sendrecv
@@ -181,10 +182,19 @@ foreach(N ${testlist})
 endforeach()
 
 if(BML_MPI)
-  foreach(N ${testlist-mpi})
-    set(formats dense ellpack ellsort ellblock csr)
-    test_formats_mpi(${formats})
-  endforeach()
+  if(BML_SCALAPACK)
+    foreach(N ${testlist-mpi})
+      set(formats dense ellpack ellsort ellblock csr)
+      test_formats_mpi(${formats})
+    endforeach()
+  else()
+    foreach(N ${testlist-mpi})
+      if(NOT ${N} MATCHES diagonalize)
+        set(formats dense ellpack ellsort ellblock csr)
+        test_formats_mpi(${formats})
+      endif()
+    endforeach()
+  endif()
 endif()
 
 add_executable(test-backtrace test_backtrace.c)


### PR DESCRIPTION
Diagonalization requires ScaLAPACK.
ScaLAPACK library should be specified using
export EXTRA_LINK_FLAGS=...
since cmake build has currently not capability to find it.