### PR TITLE
Remove special CI environment for docker

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -12,7 +12,6 @@ jobs:
   containers:
     name: Update container images
     runs-on: ubuntu-latest
-    environment: CI
     steps:
       - name: Check out sources
         uses: actions/checkout@v2


### PR DESCRIPTION
This is not necessary anymore.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>