### PR TITLE
Add BML_MPI_NONDIST flag for the "allGatherVParallel" function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,12 @@ if(BML_COVERAGE)
   set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} --coverage)
 endif()
 
+set(BML_MPI_NONDIST FALSE CACHE BOOL "Compile with MPI NONDIST")
+if(BML_MPI_NONDIST)
+        message(STATUS "Will build with MPI NONDIST")
+        add_definitions(-DBML_MPI_NONDIST)
+endif()
+
 set(BML_MPI FALSE CACHE BOOL "Compile with MPI support")
 #if(BML_MPI)
   message(STATUS "Will build with MPI")

--- a/build.sh
+++ b/build.sh
@@ -48,6 +48,7 @@ EOF
     echo "FC                     Path to Fortran compiler    (default is ${FC})"
     echo "BML_OPENMP             {yes,no}                    (default is ${BML_OPENMP})"
     echo "BML_MPI                {yes,no}                    (default is ${BML_MPI})"
+    echo "BML_MPI_NONDIST        {yes,no}                    (default is ${BML_MPI_NONDIST})"
     echo "BML_MPIEXEC_EXECUTABLE Command to prepend MPI tests (default is ${BML_MPIEXEC_EXECUTABLE})"
     echo "BML_MPIEXEC_NUMPROCS_FLAG Flags to specify number of MPI tasks (default is ${BML_MPIEXEC_NUMPROCS_FLAG})"
     echo "BML_MPIEXEC_PREFLAGS  Extra flags for MPI tests    (default is ${BML_MPIEXEC_PREFLAGS})"
@@ -89,6 +90,7 @@ set_defaults() {
     : ${FC:=gfortran}
     : ${BML_OPENMP:=yes}
     : ${BML_MPI:=no}
+    : ${BML_MPI_NONDIST:=no}
     : ${BML_MPIEXEC_EXECUTABLE:=}
     : ${BML_MPIEXEC_NUMPROCS_FLAG:=}
     : ${BML_MPIEXEC_PREFLAGS:=}
@@ -174,6 +176,7 @@ configure() {
         -DLAPACK_LIBRARIES="${LAPACK_LIBRARIES}" \
         -DBML_OPENMP="${BML_OPENMP}" \
         -DBML_MPI="${BML_MPI}" \
+        -DBML_MPI_NONDIST="${BML_MPI_NONDIST}" \
         -DBML_MPIEXEC_EXECUTABLE="${BML_MPIEXEC_EXECUTABLE}" \
         -DBML_MPIEXEC_NUMPROCS_FLAG="${BML_MPIEXEC_NUMPROCS_FLAG}" \
         -DBML_MPIEXEC_PREFLAGS="${BML_MPIEXEC_PREFLAGS}" \

--- a/example_build.sh
+++ b/example_build.sh
@@ -12,12 +12,16 @@ export FC=${FC:=mpif90}
 export CXX=${CXX:=mpic++}
 export BLAS_VENDOR=${BLAS_VENDOR:=GNU}
 #export BML_MPI=${BML_MPI:=yes}
+export BML_MPI_NONDIST=${BML_MPI_NONDIST:=yes}
 export BML_OPENMP=${BML_OPENMP:=yes}
 export INSTALL_DIR=${INSTALL_DIR:="${MY_PATH}/install"}
 export BML_TESTING=${BML_TESTING:=yes}
 export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}
 export EXTRA_CFLAGS=${EXTRA_CFLAGS:=""}
 export EXTRA_LINK_FLAGS=${EXTRA_LINK_FLAGS:=""}
+export MAGMA_ROOT=${MAGMA_ROOT:="${HOME}/ecp/magma-2.5.2-lib"}
+#export MAGMA_ROOT=${MAGMA_ROOT:="${HOME}/ecp/magma-2.5.2"}
+export BML_MAGMA=${BML_MAGMA:=yes}
 
 ./build.sh configure
 

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -26,7 +26,7 @@ void TYPED_FUNC(
     bml_allGatherVParallel_dense) (
     bml_matrix_dense_t * A)
 {
-#ifdef DO_MPI
+#ifdef BML_MPI_NONDIST
     int myRank = bml_getMyRank();
 
     int N = A->N;

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -26,7 +26,7 @@ void TYPED_FUNC(
     bml_allGatherVParallel_dense) (
     bml_matrix_dense_t * A)
 {
-#ifdef BML_MPI_NONDIST
+#if defined(DO_MPI) && defined(BML_MPI_NONDIST) 
     int myRank = bml_getMyRank();
 
     int N = A->N;

--- a/src/C-interface/ellpack/bml_parallel_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_parallel_ellpack_typed.c
@@ -43,7 +43,7 @@ void TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#ifdef BML_MPI_NONDIST
+#if defined(DO_MPI) && defined(BML_MPI_NONDIST) 
 /*
     for (int i = 0; i < nRanks; i++)
     {

--- a/src/C-interface/ellpack/bml_parallel_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_parallel_ellpack_typed.c
@@ -43,7 +43,7 @@ void TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-//#ifdef DO_MPI
+#ifdef BML_MPI_NONDIST
 /*
     for (int i = 0; i < nRanks; i++)
     {
@@ -78,7 +78,7 @@ void TYPED_FUNC(
         A_nnz[3071], A_nnz[3072], A_nnz[6143]);
     }
 */
-//#endif
+#endif
 
 }
 

--- a/src/C-interface/ellsort/bml_parallel_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_parallel_ellsort_typed.c
@@ -43,7 +43,7 @@ void TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#ifdef BML_MPI_NONDIST
+#if defined(DO_MPI) && defined(BML_MPI_NONDIST) 
 /*
     for (int i = 0; i < nRanks; i++)
     {

--- a/src/C-interface/ellsort/bml_parallel_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_parallel_ellsort_typed.c
@@ -43,7 +43,7 @@ void TYPED_FUNC(
 
     REAL_T *A_value = (REAL_T *) A->value;
 
-#ifdef DO_MPI
+#ifdef BML_MPI_NONDIST
 /*
     for (int i = 0; i < nRanks; i++)
     {


### PR DESCRIPTION
Add BML_MPI_NONDIST flag for the "allGatherVParallel" function to collect data across MPI ranks for the non-distributed BML