### PR TITLE
Only build container in main repository

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -15,6 +15,7 @@ jobs:
   containers:
     name: Update container images
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'lanl/bml' }}
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
If we do not restrict to the main repository, forked repositories will
try to run this workflow and fail because they are missing the
necessary credentials to push the image to Docker Hub.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>