### PR TITLE
Add MKL GPU support for the dense format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,10 @@ else()
   message(STATUS "Will not build with OpenMP")
 endif()
 
+if(MKL_GPU)
+	add_definitions(-DMKL_GPU)
+endif()
+
 set(BML_MPI FALSE CACHE BOOL "Compile with MPI support")
 if(BML_MPI)
   message(STATUS "Will build with MPI")

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,7 @@ EOF
     echo "CXX                    Path to C++ compiler        (default is ${CXX})"
     echo "FC                     Path to Fortran compiler    (default is ${FC})"
     echo "BML_OPENMP             {yes,no}                    (default is ${BML_OPENMP})"
+    echo "MKL_GPU                {yes,no}                    (default is ${MKL_GPU})"
     echo "BML_MPI                {yes,no}                    (default is ${BML_MPI})"
     echo "BML_MPIEXEC_EXECUTABLE Command to prepend MPI tests (default is ${BML_MPIEXEC_EXECUTABLE})"
     echo "BML_MPIEXEC_NUMPROCS_FLAG Flags to specify number of MPI tasks for MPI tests (default is ${BML_MPIEXEC_NUMPROCS_FLAG})"
@@ -90,6 +91,7 @@ set_defaults() {
     : ${CXX:=g++}
     : ${FC:=gfortran}
     : ${BML_OPENMP:=yes}
+    : ${MKL_GPU:=no}
     : ${BML_MPI:=no}
     : ${BML_MPIEXEC_EXECUTABLE:=}
     : ${BML_MPIEXEC_NUMPROCS_FLAG:=-n}
@@ -177,6 +179,7 @@ configure() {
         -DBLAS_LIBRARIES="${BLAS_LIBRARIES}" \
         -DLAPACK_LIBRARIES="${LAPACK_LIBRARIES}" \
         -DBML_OPENMP="${BML_OPENMP}" \
+        -DMKL_GPU="${MKL_GPU}" \
         -DBML_MPI="${BML_MPI}" \
         -DBML_MPIEXEC_EXECUTABLE="${BML_MPIEXEC_EXECUTABLE}" \
         -DBML_MPIEXEC_NUMPROCS_FLAG="${BML_MPIEXEC_NUMPROCS_FLAG}" \

--- a/scripts/build_mkl_gpu.sh
+++ b/scripts/build_mkl_gpu.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Make sure all the paths are correct
+
+#BASE=/home/ghadar/EXAALT/LATTE_Nov_11_2020/bml
+#BUILD=${BASE}/build_icpx_cpu
+#INSTALL=${BASE}/install_icpx_cpu
+#rm -r ${BUILD}
+#rm -r ${INSTALL}
+
+rm -r build
+rm -r install
+
+MY_PATH=$(pwd)
+
+export CC=icx
+export FC=ifx
+export CXX=icpx
+export MKL_GPU=yes
+
+export BLAS_VENDOR=${BLAS_VENDOR:=MKL}
+export BML_OPENMP=${BML_OPENMP:=yes}
+export BML_CUDA=${BML_CUDA:=no}
+export MKL_GPU=${MKL_GPU:=yes}
+export BML_OMP_OFFLOAD=${BML_OMP_OFFLOAD:=no}
+export BML_MAGMA=${BML_MAGMA:=no}
+export INSTALL_DIR=${INSTALL_DIR:="${MY_PATH}/install"}
+export BUILD_DIR=${BUILD_DIR:="${MY_PATH}/build"}
+export BML_TESTING=${BML_TESTING:=yes}
+export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}
+export EXTRA_CFLAGS=${EXTRA_CFLAGS:=""}
+export EXTRA_LINK_FLAGS=${EXTRA_LINK_FLAGS:=""}
+export CUDA_TOOLKIT_ROOT_DIR=""
+export CMAKE_Fortran_FLAGS="-fiopenmp -fopenmp-targets=spir64 -DINTEL_SDK"
+export CMAKE_C_FLAGS="-O3 -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__ -DINTEL_SDK"
+
+export EXTRA_LINK_FLAGS="-L/soft/restricted/CNDA/sdk/2021.04.30.001/oneapi/mkl/2021u3_20210525/lib/intel64 -lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread -lpthread -lm -lmkl_intel_ilp64  -lmkl_sycl -lstdc++ -Wl,-rpath,/soft/restricted/CNDA/sdk/2021.04.30.001/oneapi/kokkos/20210323-3.1/../../compiler/latest/linux/compiler/lib/intel64 -L/soft/restricted/CNDA/sdk/2021.04.30.001/oneapi/kokkos/20210323-3.1/../../compiler/latest/linux/compiler/lib/intel64 -liomp5 -lsycl -lOpenCL -lm -lpthread -ldl"
+
+ 
+
+./build.sh configure
+#./build.sh install
+cd build
+make -j  VERBOSE=1
+make test
+make install
+
+cd ../install
+ln -s lib64 lib
+

--- a/src/typed.h
+++ b/src/typed.h
@@ -18,6 +18,10 @@
 #if defined(SINGLE_REAL) || (defined(SINGLE_COMPLEX) && ! defined(BML_COMPLEX))
 #define REAL_T float
 #define MAGMA_T float
+#define MKL_T float
+#define MKL_REAL(a) a
+#define MKL_IMAG(a) a
+#define MKL_ADDRESS(a) a
 #define MPI_T MPI_FLOAT
 #define MATRIX_PRECISION single_real
 #define BLAS_PREFIX S
@@ -31,6 +35,10 @@
 #elif defined(DOUBLE_REAL) || (defined(DOUBLE_COMPLEX) && ! defined(BML_COMPLEX))
 #define REAL_T double
 #define MAGMA_T double
+#define MKL_T  double
+#define MKL_REAL(a) a
+#define MKL_IMAG(a) a
+#define MKL_ADDRESS(a) a
 #define MPI_T MPI_DOUBLE
 #define MATRIX_PRECISION double_real
 #define BLAS_PREFIX D
@@ -44,6 +52,10 @@
 #elif defined(SINGLE_COMPLEX)
 #define REAL_T float _Complex
 #define MAGMA_T magmaFloatComplex
+#define MKL_T MKL_Complex8
+#define MKL_REAL(a) a.real
+#define MKL_IMAG(a) a.imag=0.0
+#define MKL_ADDRESS(a) &a
 #define MPI_T MPI_C_FLOAT_COMPLEX
 #define MATRIX_PRECISION single_complex
 #define BLAS_PREFIX C
@@ -57,6 +69,11 @@
 #elif defined(DOUBLE_COMPLEX)
 #define REAL_T double _Complex
 #define MAGMA_T magmaDoubleComplex
+#define MKL_T MKL_Complex16
+#define MKL_REAL(a) a.real
+#define MKL_IMAG(a) a.imag=0.0
+#define MKL_ADDRESS(a) &a
+
 #define MPI_T MPI_C_DOUBLE_COMPLEX
 #define MATRIX_PRECISION double_complex
 #define BLAS_PREFIX Z
@@ -78,6 +95,7 @@
 #define CONCAT(a, b) CONCAT2(a, b)
 
 #define TYPED_FUNC(a) CONCAT_(a, FUNC_SUFFIX)
+#define G_BLAS(a) CONCAT_(cblas, CONCAT(MAGMA_PREFIX , a))
 #define C_BLAS(a) CONCAT_(C, CONCAT(BLAS_PREFIX , a))
 #define XSMM(a) CONCAT(XSMM_PREFIX , a)
 #define MAGMACOMPLEX(a) CONCAT_(MAGMA, CONCAT_(BLAS_PREFIX, a))


### PR DESCRIPTION
Build scripts added in scripts/ directory, build_mkl_gpu.sh. Currently, the link flags are manually set, will add check of libraries in cmake. 

New marcos are added to support the cblas_?gemm calls:

1) The cblas_zgemm and cblas_cgemm functions uses the MKL_complex8/16 data type, Hence, MKL_T, MKL_REAL, MKL_IMAG marco are introduced to convert the data type. 
2)MKL_ADDESS is added to get address of the variables for cblas_zgemm/cgemm. 
3)G_BLAS is added to select the corresponding dgemm for different data type. Since C_BLAS is existing for the internal-blas, I used G_BLAS instead.  
