### PR TITLE
Build and upload the tech preview CI images

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   containers:
-    name: Update container images
+    name: Update CI container images
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'lanl/bml' }}
     steps:
@@ -22,10 +22,41 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2.4.0
+      - name: Build and push default Docker image
+        uses: docker/build-push-action@v2
+        id: docker_build
         with:
+          context: .
+          file: Dockerfile
           push: true
           tags: nicolasbock/bml:latest
+      - name: Build and push experimental Focal Docker image
+        uses: docker/build-push-action@v2
+        id: docker_build_focal
+        with:
+          context: .
+          file: Dockerfile-focal
+          push: true
+          tags: nicolasbock/bml:focal
+      - name: Build and push experimental Hirsute Docker image
+        uses: docker/build-push-action@v2
+        id: docker_build_hirsute
+        with:
+          context: .
+          file: Dockerfile-hirsute
+          push: true
+          tags: nicolasbock/bml:hirsute
+      - name: Build and push experimental Impish Docker image
+        uses: docker/build-push-action@v2
+        id: docker_build_impish
+        with:
+          context: .
+          file: Dockerfile-impish
+          push: true
+          tags: nicolasbock/bml:impish
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: |
+          echo "Default image: ${{ steps.docker_build.outputs.digest }}"
+          echo "Focal image: ${{ steps.docker_build_focal.outputs.digest }}"
+          echo "Hirsute image: ${{ steps.docker_build_hirsute.outputs.digest }}"
+          echo "Impish image: ${{ steps.docker_build_impish.outputs.digest }}"


### PR DESCRIPTION
This change builds and uploads the experimental CI images to Docker
Hub.

They can be used by running:

     $ IMAGE=nicolasbock/bml:focal ./scripts/run-local-docker-container.sh

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>