### PR TITLE
Update experimental CI images

### DIFF
--- a/Dockerfile-hirsute
+++ b/Dockerfile-hirsute
@@ -1,7 +1,7 @@
 FROM ubuntu:hirsute
 MAINTAINER nicolasbock@gmail.com
 
-COPY scripts/prepare-container-focal.sh /usr/sbin
-RUN /usr/sbin/prepare-container-focal.sh
+COPY scripts/prepare-container-hirsute.sh /usr/sbin
+RUN /usr/sbin/prepare-container-hirsute.sh
 
 WORkDIR /root

--- a/Dockerfile-impish
+++ b/Dockerfile-impish
@@ -1,7 +1,7 @@
 FROM ubuntu:impish
 MAINTAINER nicolasbock@gmail.com
 
-COPY scripts/prepare-container-focal.sh /usr/sbin
-RUN /usr/sbin/prepare-container-focal.sh
+COPY scripts/prepare-container-impish.sh /usr/sbin
+RUN /usr/sbin/prepare-container-impish.sh
 
 WORkDIR /root

--- a/scripts/prepare-container-hirsute.sh
+++ b/scripts/prepare-container-hirsute.sh
@@ -34,13 +34,6 @@ EOF
 ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
   --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
 
-cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/emacs.list
-deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu hirsute main
-# deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu hirsute main
-EOF
-${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
-  --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
-
 for i in $(seq 5); do
   ${SUDO} apt-get update && break
 done
@@ -55,7 +48,7 @@ ${SUDO} apt-get install --assume-yes --no-install-recommends \
   build-essential \
   bundler \
   cmake cmake-data \
-  emacs27 \
+  emacs \
   clang-9 llvm-9-dev libomp-9-dev \
   gcc-9 g++-9 gfortran-9 \
   gcc-10 g++-10 gfortran-10 \

--- a/scripts/prepare-container-impish.sh
+++ b/scripts/prepare-container-impish.sh
@@ -34,13 +34,6 @@ EOF
 ${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
   --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
 
-cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/emacs.list
-deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu impish main
-# deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu impish main
-EOF
-${SUDO} apt-key adv --keyserver keyserver.ubuntu.com \
-  --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
-
 for i in $(seq 5); do
   ${SUDO} apt-get update && break
 done
@@ -55,7 +48,7 @@ ${SUDO} apt-get install --assume-yes --no-install-recommends \
   build-essential \
   bundler \
   cmake cmake-data \
-  emacs27 \
+  emacs \
   clang-9 llvm-9-dev libomp-9-dev \
   gcc-9 g++-9 gfortran-9 \
   gcc-10 g++-10 gfortran-10 \


### PR DESCRIPTION
Both Hirsute and Impish ship with emacs-1:27.1 and we do not need to
use a separate PPA to install emacs27.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>