### PR TITLE
Move CI test jobs into scripts

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -30,6 +30,7 @@ env:
   BUILD_SHARED_LIBS: no
   VERBOSE_MAKEFILE: yes
   CMAKE_BUILD_TYPE: Debug
+  TEST_SCRIPT: ./build.sh
 
 jobs:
   lint:
@@ -64,33 +65,13 @@ jobs:
       matrix:
         include:
           - JOBNAME: gcc-4.8 test 1
-            CC: gcc-4.8
-            CXX: g++-4.8
-            FC: gfortran-4.8
-            BUILD_SHARED_LIBS: yes
-            BML_OPENMP: no
-            BML_INTERNAL_BLAS: no
+            TEST_SCRIPT: ./scripts/ci-gcc-4.8-test-1.sh
           - JOBNAME: gcc-4.8 test 2
-            CC: gcc-4.8
-            CXX: g++-4.8
-            FC: gfortran-4.8
-            BUILD_SHARED_LIBS: yes
-            BML_OPENMP: no
-            BML_INTERNAL_BLAS: yes
+            TEST_SCRIPT: ./scripts/ci-gcc-4.8-test-2.sh
           - JOBNAME: gcc-4.8 test 3
-            CC: gcc-4.8
-            CXX: g++-4.8
-            FC: gfortran-4.8
-            BUILD_SHARED_LIBS: yes
-            BML_OPENMP: yes
-            BML_INTERNAL_BLAS: no
+            TEST_SCRIPT: ./scripts/ci-gcc-4.8-test-3.sh
           - JOBNAME: gcc-4.8 test 4
-            CC: gcc-4.8
-            CXX: g++-4.8
-            FC: gfortran-4.8
-            BUILD_SHARED_LIBS: yes
-            BML_OPENMP: yes
-            BML_INTERNAL_BLAS: yes
+            TEST_SCRIPT: ./scripts/ci-gcc-4.8-test-4.sh
           - JOBNAME: gcc-11 C single real
             CC: gcc-11
             CXX: g++-11
@@ -249,4 +230,5 @@ jobs:
           BML_VALGRIND: ${{ matrix.BML_VALGRIND || env.BML_VALGRIND }}
           EXTRA_LINK_FLAGS: ${{ matrix.EXTRA_LINK_FLAGS }}
           CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE || env.CMAKE_BUILD_TYPE }}
-        run: ./build.sh testing
+          TEST_SCRIPT: ${{ matrix.TEST_SCRIPT || env.TEST_SCRIPT }}
+        run: ${TEST_SCRIPT} testing

--- a/scripts/ci-defaults.sh
+++ b/scripts/ci-defaults.sh
@@ -1,0 +1,13 @@
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+export BML_INTERNAL_BLAS=no
+export BML_MPI=no
+export BML_MPIEXEC_NUMPROCS_FLAG=-n
+export BML_MPIEXEC_NUMPROCS=4
+export BML_OPENMP=no
+export BML_VALGRIND=no
+export BML_SCALAPACK=no
+export BUILD_SHARED_LIBS=no
+export VERBOSE_MAKEFILE=yes
+export CMAKE_BUILD_TYPE=Debug

--- a/scripts/ci-gcc-4.8-test-1.sh
+++ b/scripts/ci-gcc-4.8-test-1.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-4.8
+export CXX=g++-4.8
+export FC=gfortran-4.8
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=no
+export BML_INTERNAL_BLAS=no
+
+${basedir}/build.sh testing

--- a/scripts/ci-gcc-4.8-test-2.sh
+++ b/scripts/ci-gcc-4.8-test-2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-4.8
+export CXX=g++-4.8
+export FC=gfortran-4.8
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=no
+export BML_INTERNAL_BLAS=yes
+
+${basedir}/build.sh testing

--- a/scripts/ci-gcc-4.8-test-3.sh
+++ b/scripts/ci-gcc-4.8-test-3.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-4.8
+export CXX=g++-4.8
+export FC=gfortran-4.8
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=yes
+export BML_INTERNAL_BLAS=no
+
+${basedir}/build.sh testing

--- a/scripts/ci-gcc-4.8-test-4.sh
+++ b/scripts/ci-gcc-4.8-test-4.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-4.8
+export CXX=g++-4.8
+export FC=gfortran-4.8
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=yes
+export BML_INTERNAL_BLAS=yes
+
+${basedir}/build.sh testing


### PR DESCRIPTION
By moving the logic of the CI test jobs into separate scripts it will
become easier to locally test a particular job by simply running its
associated script.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>