### PR TITLE
Trigger qmd CI when updating `master`

### DIFF
--- a/.github/workflows/trigger-qmd.yaml
+++ b/.github/workflows/trigger-qmd.yaml
@@ -1,0 +1,22 @@
+---
+
+name: Trigger qmd-progress CI
+on:
+  push:
+    branches:
+      - master
+
+  workflow_dispatch:
+
+jobs:
+  trigger_qmd_CI:
+    name: Trigger qmd-progress CI
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'lanl/bml' }}
+    steps:
+      - run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token x${WORKFLOW_TOKEN}" \
+            -d '{"event_type":"bml_update"}' \
+            https://api.github.com/repos/lanl/qmd-progress/dispatches


### PR DESCRIPTION
We need to test the `qmd` library with the most recent `bml` library.
This change will trigger the CI workflow in the `qmd-progress`
repository when a pull request is merged into the `master` branch.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>