### PR TITLE
Remove job dependencies

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,7 +35,6 @@ jobs:
   docs:
     name: Build docs
     runs-on: ubuntu-18.04
-    needs: lint
     steps:
       - name: Check out sources
         uses: actions/checkout@v2
@@ -47,8 +46,8 @@ jobs:
   build:
     name: Build and test the library (${{ matrix.JOBNAME }})
     runs-on: ubuntu-18.04
-    needs: lint
     strategy:
+      fail-fast: false
       matrix:
         include:
           - JOBNAME: gcc-4.8 test 1


### PR DESCRIPTION
Remove job dependencies and fast fail so we get a more complete CI
picture in cases where jobs are failing. This should help in preparing
a fixed pull request.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>