### PR TITLE
Test workflow for OSX

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,3 +91,30 @@ jobs:
         env:
           TEST_SCRIPT: ${{ matrix.TEST_SCRIPT || env.TEST_SCRIPT }}
         run: ${TEST_SCRIPT} testing
+
+  build-osx:
+    name: Build and test the library (${{ matrix.JOBNAME }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - JOBNAME: gcc-5 test 1
+            TEST_SCRIPT: ./scripts/ci-gcc-5-test-1.sh
+          - JOBNAME: gcc-5 test 2
+            TEST_SCRIPT: ./scripts/ci-gcc-5-test-2.sh
+          - JOBNAME: gcc-5 test 3
+            TEST_SCRIPT: ./scripts/ci-gcc-5-test-3.sh
+          - JOBNAME: gcc-5 test 4
+            TEST_SCRIPT: ./scripts/ci-gcc-5-test-4.sh
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v2
+      - name: Prepare homebrew
+        run: |
+           ./scripts/prepare-homebrew.sh
+           echo "$(brew --prefix)/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
+      - name: Build and test library
+        env:
+          TEST_SCRIPT: ${{ matrix.TEST_SCRIPT || env.TEST_SCRIPT }}
+        run: ${TEST_SCRIPT} testing

--- a/scripts/ci-gcc-5-test-1.sh
+++ b/scripts/ci-gcc-5-test-1.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-5
+export CXX=g++-5
+export FC=gfortran-5
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=no
+export BML_INTERNAL_BLAS=no
+
+${basedir}/build.sh testing

--- a/scripts/ci-gcc-5-test-2.sh
+++ b/scripts/ci-gcc-5-test-2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-5
+export CXX=g++-5
+export FC=gfortran-5
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=no
+export BML_INTERNAL_BLAS=yes
+
+${basedir}/build.sh testing

--- a/scripts/ci-gcc-5-test-3.sh
+++ b/scripts/ci-gcc-5-test-3.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-5
+export CXX=g++-5
+export FC=gfortran-5
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=yes
+export BML_INTERNAL_BLAS=no
+
+${basedir}/build.sh testing

--- a/scripts/ci-gcc-5-test-4.sh
+++ b/scripts/ci-gcc-5-test-4.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+
+[[ -f ${basedir}/scripts/ci-defaults.sh ]] && . ${basedir}/scripts/ci-defaults.sh
+
+export CC=gcc-5
+export CXX=g++-5
+export FC=gfortran-5
+export BUILD_SHARED_LIBS=yes
+export BML_OPENMP=yes
+export BML_INTERNAL_BLAS=yes
+
+${basedir}/build.sh testing

--- a/scripts/prepare-homebrew.sh
+++ b/scripts/prepare-homebrew.sh
@@ -5,4 +5,5 @@ brew install \
   cmake \
   gcc@5 \
   gcc@11 \
+  ninja \
   openblas

--- a/scripts/prepare-homebrew.sh
+++ b/scripts/prepare-homebrew.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+brew install \
+  coreutils \
+  cmake \
+  gcc@5 \
+  gcc@11 \
+  openblas

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -37,7 +37,7 @@ bml_add_typed_library(bmltests double_real "${SOURCES_TYPED}")
 bml_add_typed_library(bmltests single_complex "${SOURCES_TYPED}")
 bml_add_typed_library(bmltests double_complex "${SOURCES_TYPED}")
 
-add_library(bmltests
+add_library(bmltests STATIC
   $<TARGET_OBJECTS:bmltests-single_real>
   $<TARGET_OBJECTS:bmltests-double_real>
   $<TARGET_OBJECTS:bmltests-single_complex>


### PR DESCRIPTION
Add a test workflow for OSX with GCC 5 / GFortran 5, currently failing.

- Link error can be fixed by declaring test library as `STATIC`, maybe better to add `target_link_libraries` with `bml` target (see #515)
- Segmentation fault when built with `BML_INTERNAL_BLAS=yes` (gcc-5 test 2 & gcc-5 test 4)
- Regular expression mismatch for `test-backstrace` (gcc-5 test 1 & gcc-5 test 3)

Opening this PR for further feedback, the `test-backtrace` regex can be fixed quite easily, not sure what is causing the segmentation fault, though.