### PR TITLE
Fix copy and setters

### DIFF
--- a/src/C-interface/bml_copy.c
+++ b/src/C-interface/bml_copy.c
@@ -85,7 +85,7 @@ bml_copy(
     {
         LOG_ERROR("matrix size mismatch\n");
     }
-    if (bml_get_M(A) > bml_get_M(B))
+    if (bml_get_M(A) > bml_get_M(B) && bml_get_type(A) != csr)
     {
         LOG_ERROR("matrix parameter mismatch\n");
     }

--- a/src/C-interface/csr/bml_copy_csr_typed.c
+++ b/src/C-interface/csr/bml_copy_csr_typed.c
@@ -76,51 +76,6 @@ bml_matrix_csr_t *TYPED_FUNC(
     return B;
 }
 
-/** Copy an csr matrix - result is a new matrix.
- * Also allocates hash table and lvarsgid data
- *
- *  \ingroup copy_group
- *
- *  \param A The matrix to be copied
- *  \return A copy of matrix A.
- */
-/*
-bml_matrix_csr_t *TYPED_FUNC(
-    bml_copy_csr_new) (
-    const bml_matrix_csr_t * A)
-{
-    bml_matrix_csr_t *B =
-        TYPED_FUNC(bml_noinit_matrix_csr) (A->N_, A->NZMAX_,
-                                            A->TOTNNZ_, A->distribution_mode);
-
-    int N = A->N_;
-    csr_row_index_hash_t *table;
-
-    // copy lvarsgid_
-    memcpy(B->lvarsgid_, A->lvarsgid_, sizeof(int) * N);
-    // allocate hash table. Cannot copy table due to pointer incompatibilities
-    table = (csr_row_index_hash_t *)malloc(sizeof(csr_row_index_hash_t) * N);
-    for(int i=0; i<N; i++)
-    {
-      bml_csr_table_insert((A->lvarsgid_)[i]);
-    }
-    // allocate memory for pointers csr row data
-    B->data_ = (csr_sparse_row_t **)malloc(sizeof(csr_sparse_row_t *) * N);
-    // copy rows
-#pragma omp parallel for
-    for(int i=0; i<N; i++)
-    {
-       csr_sparse_row_t *new_row = TYPED_FUNC(copy_csr_new_row)((A->data_)[i]);
-       (B->data_)[i] = new_row;
-    }
-    // copy domain info
-    bml_copy_domain(A->domain, B->domain);
-    bml_copy_domain(A->domain2, B->domain2);
-
-    return B;
-}
-*/
-
 /** Copy a csr matrix row.
  *
  *  \ingroup copy_group
@@ -136,7 +91,10 @@ void TYPED_FUNC(
 {
     const int NNZ = arow->NNZ_;
     // Check size for data
-    assert(brow->alloc_size_ >= NNZ);
+    if (brow->alloc_size_ < NNZ)
+    {
+        LOG_ERROR("CSR row size mismatch\n");
+    }
 
     memcpy(brow->cols_, arow->cols_, NNZ * sizeof(int));
     memcpy(brow->vals_, arow->vals_, NNZ * sizeof(REAL_T));
@@ -194,41 +152,4 @@ void TYPED_FUNC(
     int *perm)
 {
     LOG_ERROR("bml_reorder_csr not implemented\n");
-/*
-    int N = A->N;
-    int M = A->M;
-
-    int *A_index = A->index;
-    int *A_nnz = A->nnz;
-    REAL_T *A_value = A->value;
-
-    bml_matrix_csr_t *B = bml_copy_new(A);
-    int *B_index = B->index;
-    int *B_nnz = B->nnz;
-    REAL_T *B_value = B->value;
-
-    // Reorder rows - need to copy
-#pragma omp parallel for
-    for (int i = 0; i < N; i++)
-    {
-        memcpy(&A_index[ROWMAJOR(perm[i], 0, N, M)],
-               &B_index[ROWMAJOR(i, 0, N, M)], M * sizeof(int));
-        memcpy(&A_value[ROWMAJOR(perm[i], 0, N, M)],
-               &B_value[ROWMAJOR(i, 0, N, M)], M * sizeof(REAL_T));
-        A_nnz[perm[i]] = B_nnz[i];
-    }
-
-    bml_deallocate_csr(B);
-
-    // Reorder elements in each row - just change index
-#pragma omp parallel for
-    for (int i = 0; i < N; i++)
-    {
-        for (int j = 0; j < A_nnz[i]; j++)
-        {
-            A_index[ROWMAJOR(i, j, N, M)] =
-                perm[A_index[ROWMAJOR(i, j, N, M)]];
-        }
-    }
-*/
 }

--- a/src/C-interface/csr/bml_setters_csr.h
+++ b/src/C-interface/csr/bml_setters_csr.h
@@ -69,26 +69,26 @@ void csr_set_row(
 void csr_set_row_single_real(
     csr_sparse_row_t * arow,
     const int count,
-    void *vals,
-    const double threshold);
+    const int *cols,
+    void *vals);
 
 void csr_set_row_double_real(
     csr_sparse_row_t * arow,
     const int count,
-    void *vals,
-    const double threshold);
+    const int *cols,
+    void *vals);
 
 void csr_set_row_single_complex(
     csr_sparse_row_t * arow,
     const int count,
-    void *vals,
-    const double threshold);
+    const int *cols,
+    void *vals);
 
 void csr_set_row_double_complex(
     csr_sparse_row_t * arow,
     const int count,
-    void *vals,
-    const double threshold);
+    const int *cols,
+    void *vals);
 
 void csr_set_sparse_row_single_real(
     csr_sparse_row_t * arow,


### PR DESCRIPTION
This PR:
1. Fixes an issue with bml_copy where we check for storage size using the initial column dimension. For CSR, this check is done internally, since individual rows need not have the same size.
2. Modifies bml_setters_csr to avoid allocating space for a dense row when setting sparse row entries from a dense array.