### PR TITLE
Fix paths in tag update script

### DIFF
--- a/scripts/update_tags.sh
+++ b/scripts/update_tags.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-basedir=$(dirname $0)
+set -e -u -x
+
+basedir=$(readlink --canonicalize $(dirname $0)/..)
+pushd "${basedir}"
 readarray -t files < <(git ls-files '*.c' '*.h' '*.F90')
-pushd "${basedir}" || exit
 ctags "${files[@]}"
 etags "${files[@]}"
-popd || exit
+popd


### PR DESCRIPTION
Since the script was moved into the `scripts` directory, the `basedir`
needs to be updated to include files starting from the repository root
directory.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>