### PR TITLE
Change the way MPI datatype is built for dense case

### DIFF
--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -64,11 +64,10 @@ void TYPED_FUNC(
     MPI_Datatype dtype[1];
     dtype[0] = MPI_T;
 
-    int blength[1];
-    blength[0] = A->N * A->N;
-    MPI_Aint displ[0];
+    int blength = A->N * A->N;
+    MPI_Aint displ[1];
     displ[0] = addr0 - baseaddr;
-    int mpiret = MPI_Type_create_struct(1, blength, displ, dtype, newtype);
+    int mpiret = MPI_Type_create_struct(1, &blength, displ, dtype, newtype);
     if (mpiret != MPI_SUCCESS)
         LOG_ERROR("MPI_Type_create_struct failed!");
     mpiret = MPI_Type_commit(newtype);

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -64,10 +64,11 @@ void TYPED_FUNC(
     MPI_Datatype dtype[1];
     dtype[0] = MPI_T;
 
-    int blength = A->N * A->N;
+    int blength[1];
+    blength[0] = A->N * A->N;
     MPI_Aint displ[0];
     displ[0] = addr0 - baseaddr;
-    int mpiret = MPI_Type_create_struct(1, &blength, displ, dtype, newtype);
+    int mpiret = MPI_Type_create_struct(1, blength, displ, dtype, newtype);
     if (mpiret != MPI_SUCCESS)
         LOG_ERROR("MPI_Type_create_struct failed!");
     mpiret = MPI_Type_commit(newtype);


### PR DESCRIPTION
I have to admit I don't fully understand why this change makes a difference, but it does on some platforms at least where the test suite fails without that fix.
Note that it is already done this way for other matrix formats. 