### PR TITLE
Fix issues with ScaLapack call

### DIFF
--- a/tests/C-tests/diagonalize_matrix_typed.c
+++ b/tests/C-tests/diagonalize_matrix_typed.c
@@ -60,7 +60,7 @@ int TYPED_FUNC(
     bml_add(A, A_t, 0.5, 0.5, 0.0);
 
     LOG_INFO("(A + A_t)/2 = \n");
-    bml_print_bml_matrix(A, 0, N, 0, N);
+    bml_print_bml_matrix(A, 0, max_row, 0, max_col);
 
     switch (matrix_precision)
     {
@@ -134,7 +134,7 @@ int TYPED_FUNC(
     if (bml_getMyRank() == 0)
     {
         LOG_INFO("%s\n", "eigenvalues");
-        for (int i = 0; i < N; i++)
+        for (int i = 0; i < max_row; i++)
             LOG_INFO("val = %e  i%e\n", REAL_PART(eigenvalues[i]),
                      IMAGINARY_PART(eigenvalues[i]));
     }

--- a/tests/C-tests/normalize_matrix_typed.c
+++ b/tests/C-tests/normalize_matrix_typed.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 
 #if defined(SINGLE_REAL) || defined(SINGLE_COMPLEX)
-#define REL_TOL 1e-6
+#define REL_TOL 2e-6
 #else
 #define REL_TOL 1e-12
 #endif
@@ -87,7 +87,7 @@ int TYPED_FUNC(
         || (A_gbnd[1] - A_gbnd[0]) > REL_TOL)
     {
         LOG_ERROR
-            ("A: incorrect mineval or maxeval or maxminusmin; mineval = %e maxeval = %e maxminusmin = %e\n",
+            ("A: incorrect maxeval or maxminusmin; mineval = %e maxeval = %e maxminusmin = %e\n",
              A_gbnd[0], A_gbnd[1], A_gbnd[1] - A_gbnd[0]);
         return -1;
     }
@@ -99,7 +99,7 @@ int TYPED_FUNC(
           REAL_PART(scale_factor * scale_factor - scale_factor))) > REL_TOL)
     {
         LOG_ERROR
-            ("B: incorrect mineval or maxeval or maxminusmin; mineval = %e maxeval = %e maxminusmin = %e\n",
+            ("B: incorrect maxeval or maxminusmin; mineval = %e maxeval = %e maxminusmin = %e\n",
              B_gbnd[0], B_gbnd[1], B_gbnd[1] - B_gbnd[0]);
         return -1;
     }


### PR DESCRIPTION
Size of work array had to be fixed. In addition, that size had to be increased
to work around possible bug in ScaLapack.
Failure was not seen for matrix size used in test suite, but only for larger
matrices.