### PR TITLE
Element-wise matrix multiplication and corresponding tests are added

### DIFF
--- a/src/C-interface/CMakeLists.txt
+++ b/src/C-interface/CMakeLists.txt
@@ -20,6 +20,7 @@ set(HEADERS-C
   bml_inverse.h
   bml_logger.h
   bml_multiply.h
+  bml_element_multiply.h
   bml_norm.h
   bml_normalize.h
   bml_parallel.h
@@ -56,6 +57,7 @@ set(SOURCES-C
   bml_inverse.c
   bml_logger.c
   bml_multiply.c
+  bml_element_multiply.c
   bml_norm.c
   bml_normalize.c
   bml_parallel.c

--- a/src/C-interface/bml.h
+++ b/src/C-interface/bml.h
@@ -207,6 +207,7 @@
 #include "bml_inverse.h"
 #include "bml_logger.h"
 #include "bml_multiply.h"
+#include "bml_element_multiply.h"
 #include "bml_normalize.h"
 #include "bml_norm.h"
 #include "bml_parallel.h"

--- a/src/C-interface/bml_element_multiply.c
+++ b/src/C-interface/bml_element_multiply.c
@@ -1,0 +1,50 @@
+#include "bml_element_multiply.h"
+#include "bml_introspection.h"
+#include "bml_logger.h"
+#include "dense/bml_element_multiply_dense.h"
+#include "ellpack/bml_element_multiply_ellpack.h"
+#include "ellsort/bml_element_multiply_ellsort.h"
+#include "csr/bml_element_multiply_csr.h"
+#ifdef DO_MPI
+#include "distributed2d/bml_multiply_distributed2d.h"
+#endif
+
+#include <stdlib.h>
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup multiply_group_C
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Threshold for multiplication
+ */
+void
+bml_element_multiply_AB(
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    bml_matrix_t * C,
+    double threshold)
+{
+    switch (bml_get_type(A))
+    {
+        case dense:
+            bml_element_multiply_AB_dense(A, B, C);
+            break;
+        case ellpack:
+            bml_element_multiply_AB_ellpack(A, B, C, threshold);
+            break;
+        case ellsort:
+            bml_element_multiply_AB_ellsort(A, B, C, threshold);
+            break;
+        case csr:
+            bml_element_multiply_AB_csr(A, B, C, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown matrix type\n");
+            break;
+    }
+}

--- a/src/C-interface/bml_element_multiply.h
+++ b/src/C-interface/bml_element_multiply.h
@@ -1,0 +1,15 @@
+/** \file */
+
+#ifndef __BML_ELEMNET_MULTIPLY_H
+#define __BML_ELEMNET_MULTIPLY_H
+
+#include "bml_types.h"
+
+// Element-wise Matrix multiply (Hadamard product)
+void bml_element_multiply_AB(
+    bml_matrix_t * A,
+    bml_matrix_t * B,
+    bml_matrix_t * C,
+    double threshold);
+
+#endif

--- a/src/C-interface/csr/CMakeLists.txt
+++ b/src/C-interface/csr/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HEADERS-CSR
   bml_add_csr.h
   bml_normalize_csr.h
   bml_multiply_csr.h
+  bml_element_multiply_csr.h
 )
 
 
@@ -46,6 +47,7 @@ set(SOURCES-CSR
   bml_add_csr.c
   bml_normalize_csr.c
   bml_multiply_csr.c  
+  bml_element_multiply_csr.c  
 )
 
 add_library(bml-csr OBJECT ${SOURCES-CSR})
@@ -80,6 +82,7 @@ set(SOURCES-CSR-TYPED
   bml_add_csr_typed.c
   bml_normalize_csr_typed.c
   bml_multiply_csr_typed.c
+  bml_element_multiply_csr_typed.c
   )
   
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)

--- a/src/C-interface/csr/bml_element_multiply_csr.c
+++ b/src/C-interface/csr/bml_element_multiply_csr.c
@@ -1,0 +1,49 @@
+#include "../bml_add.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_types.h"
+#include "bml_add_csr.h"
+#include "bml_element_multiply_csr.h"
+#include "bml_types_csr.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Used for sparse multiply
+ */
+void
+bml_element_multiply_AB_csr(
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_element_multiply_AB_csr_single_real(A, B, C, threshold);
+            break;
+        case double_real:
+            bml_element_multiply_AB_csr_double_real(A, B, C, threshold);
+            break;
+        case single_complex:
+            bml_element_multiply_AB_csr_single_complex(A, B, C, threshold);
+            break;
+        case double_complex:
+            bml_element_multiply_AB_csr_double_complex(A, B, C, threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/csr/bml_element_multiply_csr.h
+++ b/src/C-interface/csr/bml_element_multiply_csr.h
@@ -1,0 +1,36 @@
+#ifndef __BML_ELEMNET_MULTIPLY_CSR_H
+#define __BML_ELEMNET_MULTIPLY_CSR_H
+
+#include "bml_types_csr.h"
+
+void bml_element_multiply_AB_csr(
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_csr_single_real(
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_csr_double_real(
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_csr_single_complex(
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_csr_double_complex(
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold);
+
+#endif

--- a/src/C-interface/csr/bml_element_multiply_csr_typed.c
+++ b/src/C-interface/csr/bml_element_multiply_csr_typed.c
@@ -1,0 +1,119 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_add.h"
+#include "../bml_allocate.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "bml_add_csr.h"
+#include "bml_allocate_csr.h"
+#include "bml_element_multiply_csr.h"
+#include "bml_types_csr.h"
+#include "bml_setters_csr.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Used for sparse multiply
+ */
+void TYPED_FUNC(
+    bml_element_multiply_AB_csr) (
+    bml_matrix_csr_t * A,
+    bml_matrix_csr_t * B,
+    bml_matrix_csr_t * C,
+    double threshold)
+{
+    const int A_N = A->N_;
+    const int C_N = C->N_;
+
+#if !(defined(__IBMC__) || defined(__ibmxl__))
+    int ix[C_N], jx[C_N];
+    REAL_T x[C_N];
+
+    memset(ix, 0, C_N * sizeof(int));
+    memset(jx, 0, C_N * sizeof(int));
+    memset(x, 0.0, C_N * sizeof(REAL_T));
+#endif
+
+#if defined(__IBMC__) || defined(__ibmxl__)
+#pragma omp parallel for                       \
+    shared(A_N, C_N)
+#else
+#pragma omp parallel for                       \
+    firstprivate(ix, jx, x)
+#endif
+
+    for (int i = 0; i < A_N; i++)
+    {
+#if defined(__IBMC__) || defined(__ibmxl__)
+        int ix[C_N], jx[C_N];
+        REAL_T x[C_N];
+
+        memset(ix, 0, C_N * sizeof(int));
+#endif
+        int *acols = A->data_[i]->cols_;
+        REAL_T *avals = (REAL_T *) A->data_[i]->vals_;
+        const int annz = A->data_[i]->NNZ_;
+        int l = 0;
+        for (int pos = 0; pos < annz; pos++)
+        {
+            REAL_T a = avals[pos];
+            const int k = acols[pos];
+            if (ix[k] == 0)
+            {
+                x[k] = 0.0;
+                jx[l] = k;
+                ix[k] = i + 1;
+                l++;
+            }
+
+            const int bnnz = B->data_[i]->NNZ_;
+            REAL_T *bvals = (REAL_T *) B->data_[i]->vals_;
+            int *bcols = B->data_[i]->cols_;
+            for (int bpos = 0; bpos < bnnz; bpos++)
+            {
+                const int kb = bcols[bpos];
+                if (k == kb)
+                {
+                    x[k] += a * bvals[bpos];
+                }
+            }
+        }
+
+        // clear row
+        TYPED_FUNC(csr_clear_row) (C->data_[i]);
+        for (int j = 0; j < l; j++)
+        {
+            int jp = jx[j];
+            REAL_T xtmp = x[jp];
+            if (jp == i)
+            {
+                TYPED_FUNC(csr_set_row_element_new) (C->data_[i], jp, &xtmp);
+            }
+            else if (is_above_threshold(xtmp, threshold))
+            {
+                TYPED_FUNC(csr_set_row_element_new) (C->data_[i], jp, &xtmp);
+            }
+            // reset
+            ix[jp] = 0;
+            x[jp] = 0.0;
+        }
+    }
+}

--- a/src/C-interface/dense/CMakeLists.txt
+++ b/src/C-interface/dense/CMakeLists.txt
@@ -11,6 +11,7 @@ set(HEADERS-DENSE
   bml_introspection_dense.h
   bml_inverse_dense.h
   bml_multiply_dense.h
+  bml_element_multiply_dense.h
   bml_normalize_dense.h
   bml_norm_dense.h
   bml_parallel_dense.h
@@ -37,6 +38,7 @@ set(SOURCES-DENSE
   bml_introspection_dense.c
   bml_inverse_dense.c
   bml_multiply_dense.c
+  bml_element_multiply_dense.c
   bml_normalize_dense.c
   bml_norm_dense.c
   bml_parallel_dense.c
@@ -71,6 +73,7 @@ set(SOURCES-DENSE-TYPED
   bml_introspection_dense_typed.c
   bml_inverse_dense_typed.c
   bml_multiply_dense_typed.c
+  bml_element_multiply_dense_typed.c
   bml_normalize_dense_typed.c
   bml_norm_dense_typed.c
   bml_parallel_dense_typed.c

--- a/src/C-interface/dense/bml_element_multiply_dense.c
+++ b/src/C-interface/dense/bml_element_multiply_dense.c
@@ -1,0 +1,44 @@
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_types.h"
+#include "bml_element_multiply_dense.h"
+#include "bml_types_dense.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ */
+void
+bml_element_multiply_AB_dense(
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_element_multiply_AB_dense_single_real(A, B, C);
+            break;
+        case double_real:
+            bml_element_multiply_AB_dense_double_real(A, B, C);
+            break;
+        case single_complex:
+            bml_element_multiply_AB_dense_single_complex(A, B, C);
+            break;
+        case double_complex:
+            bml_element_multiply_AB_dense_double_complex(A, B, C);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/dense/bml_element_multiply_dense.h
+++ b/src/C-interface/dense/bml_element_multiply_dense.h
@@ -1,0 +1,32 @@
+#ifndef __BML_ELEMNET_MULTIPLY_DENSE_H
+#define __BML_ELEMNET_MULTIPLY_DENSE_H
+
+#include "bml_types_dense.h"
+
+// Element-wise Matrix multiply (Hadamard product)
+void bml_element_multiply_AB_dense(
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C);
+
+void bml_element_multiply_AB_dense_single_real(
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C);
+
+void bml_element_multiply_AB_dense_double_real(
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C);
+
+void bml_element_multiply_AB_dense_single_complex(
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C);
+
+void bml_element_multiply_AB_dense_double_complex(
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C);
+
+#endif

--- a/src/C-interface/dense/bml_element_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_element_multiply_dense_typed.c
@@ -1,0 +1,103 @@
+#ifdef BML_USE_MAGMA
+#include "magma_v2.h"
+#endif
+
+#include "../../internal-blas/bml_gemm.h"
+#include "../../typed.h"
+#include "../bml_allocate.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_parallel.h"
+#include "../bml_trace.h"
+#include "../bml_types.h"
+#include "bml_allocate_dense.h"
+#include "bml_element_multiply_dense.h"
+#include "bml_trace_dense.h"
+#include "bml_types_dense.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+#ifdef MKL_GPU
+#include "stdio.h"
+#include "mkl.h"
+#include "mkl_omp_offload.h"
+#endif
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup norm_group
+ *
+ * \param A The matrix A
+ * \param B The matrix B
+ * \param C Matrix C
+ */
+void TYPED_FUNC(
+    bml_element_multiply_AB_dense) (
+    bml_matrix_dense_t * A,
+    bml_matrix_dense_t * B,
+    bml_matrix_dense_t * C)
+{
+    int N = A->N;
+    double alpha = 1.0;
+
+    REAL_T sum = 0.0;
+#ifdef BML_USE_MAGMA            //do work on CPU for now...
+    MAGMA_T *A_matrix = bml_allocate_memory(sizeof(MAGMA_T) * A->N * A->N);
+    MAGMA(getmatrix) (A->N, A->N, A->matrix, A->ld, A_matrix, A->N,
+                      bml_queue());
+    MAGMA_T *B_matrix = bml_allocate_memory(sizeof(MAGMA_T) * B->N * B->N);
+    MAGMA(getmatrix) (B->N, B->N, B->matrix, B->ld, B_matrix, B->N,
+                      bml_queue());
+    MAGMA_T *C_matrix = bml_allocate_memory(sizeof(MAGMA_T) * C->N * C->N);
+    MAGMA(getmatrix) (C->N, C->N, C->matrix, C->ld, C_matrix, C->N,
+                      bml_queue());
+
+#else
+    REAL_T *A_matrix = A->matrix;
+    REAL_T *B_matrix = B->matrix;
+    REAL_T *C_matrix = C->matrix;
+#endif
+
+    int *A_localRowMin = A->domain->localRowMin;
+    int *A_localRowMax = A->domain->localRowMax;
+
+#ifdef BML_USE_MAGMA
+    MAGMA_T alpha_ = MAGMACOMPLEX(MAKE) (alpha, 0.);
+#else
+    REAL_T alpha_ = (REAL_T) alpha;
+#endif
+
+    int myRank = bml_getMyRank();
+
+#pragma omp parallel for                        \
+  shared(alpha_)                         \
+  shared(N, A_matrix, B_matrix)                 \
+  shared(A_localRowMin, A_localRowMax, myRank)  \
+                                //for (int i = 0; i < N * N; i++)
+    for (int i = A_localRowMin[myRank] * N; i < A_localRowMax[myRank] * N;
+         i++)
+    {
+#ifdef BML_USE_MAGMA
+        MAGMA_T ttemp =
+            MAGMACOMPLEX(MUL) (MAGMACOMPLEX(MUL) (alpha_, A_matrix[i]),
+                               B_matrix[i]);
+        REAL_T temp =
+            MAGMACOMPLEX(REAL) (ttemp) + I * MAGMACOMPLEX(IMAG) (ttemp);
+#else
+        REAL_T temp = alpha_ * A_matrix[i] * B_matrix[i];
+#endif
+        C_matrix[i] = temp;     //* temp;
+    }
+#ifdef BML_USE_MAGMA
+    free(A_matrix);
+    free(B_matrix);
+    free(C_matrix);
+#endif
+}

--- a/src/C-interface/ellpack/CMakeLists.txt
+++ b/src/C-interface/ellpack/CMakeLists.txt
@@ -11,6 +11,7 @@ set(HEADERS-ELLPACK
   bml_introspection_ellpack.h
   bml_inverse_ellpack.h
   bml_multiply_ellpack.h
+  bml_element_multiply_ellpack.h
   bml_normalize_ellpack.h
   bml_norm_ellpack.h
   bml_parallel_ellpack.h
@@ -36,6 +37,7 @@ set(SOURCES-ELLPACK
   bml_introspection_ellpack.c
   bml_inverse_ellpack.c
   bml_multiply_ellpack.c
+  bml_element_multiply_ellpack.c
   bml_normalize_ellpack.c
   bml_norm_ellpack.c
   bml_parallel_ellpack.c
@@ -70,6 +72,7 @@ set(SOURCES-ELLPACK-TYPED
   bml_introspection_ellpack_typed.c
   bml_inverse_ellpack_typed.c
   bml_multiply_ellpack_typed.c
+  bml_element_multiply_ellpack_typed.c
   bml_normalize_ellpack_typed.c
   bml_norm_ellpack_typed.c
   bml_parallel_ellpack_typed.c

--- a/src/C-interface/ellpack/bml_element_multiply_ellpack.c
+++ b/src/C-interface/ellpack/bml_element_multiply_ellpack.c
@@ -1,0 +1,51 @@
+#include "../bml_add.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_types.h"
+#include "bml_add_ellpack.h"
+#include "bml_element_multiply_ellpack.h"
+#include "bml_types_ellpack.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ *  \ingroup multiply_group
+ *
+ *  \param A Matrix A
+ *  \param B Matrix B
+ *  \param C Matrix C
+ *  \param threshold Used for sparse multiply
+ */
+void
+bml_element_multiply_AB_ellpack(
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_element_multiply_AB_ellpack_single_real(A, B, C, threshold);
+            break;
+        case double_real:
+            bml_element_multiply_AB_ellpack_double_real(A, B, C, threshold);
+            break;
+        case single_complex:
+            bml_element_multiply_AB_ellpack_single_complex(A, B, C,
+                                                           threshold);
+            break;
+        case double_complex:
+            bml_element_multiply_AB_ellpack_double_complex(A, B, C,
+                                                           threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellpack/bml_element_multiply_ellpack.h
+++ b/src/C-interface/ellpack/bml_element_multiply_ellpack.h
@@ -1,0 +1,36 @@
+#ifndef __BML_ELEMNET_MULTIPLY_ELLPACK_H
+#define __BML_ELEMNET_MULTIPLY_ELLPACK_H
+
+#include "bml_types_ellpack.h"
+
+void bml_element_multiply_AB_ellpack(
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellpack_single_real(
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellpack_double_real(
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellpack_single_complex(
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellpack_double_complex(
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold);
+
+#endif

--- a/src/C-interface/ellpack/bml_element_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_element_multiply_ellpack_typed.c
@@ -1,0 +1,204 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_add.h"
+#include "../bml_allocate.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "bml_add_ellpack.h"
+#include "bml_allocate_ellpack.h"
+#include "bml_element_multiply_ellpack.h"
+#include "bml_types_ellpack.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <float.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Used for sparse multiply
+ */
+void TYPED_FUNC(
+    bml_element_multiply_AB_ellpack) (
+    bml_matrix_ellpack_t * A,
+    bml_matrix_ellpack_t * B,
+    bml_matrix_ellpack_t * C,
+    double threshold)
+{
+    int A_N = A->N;
+    int A_M = A->M;
+    int *A_nnz = A->nnz;
+    int *A_index = A->index;
+    int *A_localRowMin = A->domain->localRowMin;
+    int *A_localRowMax = A->domain->localRowMax;
+
+    int B_N = B->N;
+    int B_M = B->M;
+    int *B_nnz = B->nnz;
+    int *B_index = B->index;
+
+    int C_N = C->N;
+    int C_M = C->M;
+    int *C_nnz = C->nnz;
+    int *C_index = C->index;
+
+    REAL_T *A_value = (REAL_T *) A->value;
+    REAL_T *B_value = (REAL_T *) B->value;
+    REAL_T *C_value = (REAL_T *) C->value;
+
+    int myRank = bml_getMyRank();
+    int rowMin = A_localRowMin[myRank];
+    int rowMax = A_localRowMax[myRank];
+
+#if !(defined(__IBMC__) || defined(__ibmxl__) || (defined(USE_OMP_OFFLOAD) && (defined(INTEL_SDK) || defined(CRAY_SDK))))
+    int ix[C->N], jx[C->N];
+    REAL_T x[C->N];
+
+    memset(ix, 0, C->N * sizeof(int));
+    memset(jx, 0, C->N * sizeof(int));
+    memset(x, 0.0, C->N * sizeof(REAL_T));
+#endif
+
+#if defined(USE_OMP_OFFLOAD) && (defined(INTEL_SDK) || defined(CRAY_SDK))
+    int num_chunks = MIN(OFFLOAD_NUM_CHUNKS, rowMax - rowMin + 1);
+
+    int all_ix[C_N * num_chunks], all_jx[C_N * num_chunks];
+    REAL_T all_x[C_N * num_chunks];
+
+    memset(all_ix, 0, C_N * num_chunks * sizeof(int));
+    memset(all_jx, 0, C_N * num_chunks * sizeof(int));
+    memset(all_x, 0.0, C_N * num_chunks * sizeof(REAL_T));
+
+#pragma omp target map(to:all_ix[0:C_N*num_chunks],all_jx[0:C_N*num_chunks],all_x[0:C_N*num_chunks])
+
+#endif
+
+#if defined (USE_OMP_OFFLOAD)
+#if defined(INTEL_SDK) || defined(CRAY_SDK)
+#pragma omp teams distribute parallel for \
+    shared(A_N, A_M, A_nnz, A_index, A_value)  \
+    shared(A_localRowMin, A_localRowMax)       \
+    shared(B_N, B_M, B_nnz, B_index, B_value)  \
+    shared(C_N, C_M, C_nnz, C_index, C_value)
+    for (int chunk = 0; chunk < num_chunks; chunk++)
+    {
+        int *ix, *jx;
+        REAL_T *x;
+
+        ix = &all_ix[chunk * C_N];
+        jx = &all_jx[chunk * C_N];
+        x = &all_x[chunk * C_N];
+
+#else
+#pragma omp target teams distribute parallel for \
+    shared(A_N, A_M, A_nnz, A_index, A_value)  \
+    shared(A_localRowMin, A_localRowMax)       \
+    shared(B_N, B_M, B_nnz, B_index, B_value)  \
+    shared(C_N, C_M, C_nnz, C_index, C_value)  \
+    firstprivate(ix, jx, x)
+#endif
+#else
+#if defined(__IBMC__) || defined(__ibmxl__)
+#pragma omp parallel for                       \
+    shared(A_N, A_M, A_nnz, A_index, A_value)  \
+    shared(A_localRowMin, A_localRowMax)       \
+    shared(B_N, B_M, B_nnz, B_index, B_value)  \
+    shared(C_N, C_M, C_nnz, C_index, C_value)
+#else
+#pragma omp parallel for                       \
+    shared(A_N, A_M, A_nnz, A_index, A_value)  \
+    shared(A_localRowMin, A_localRowMax)       \
+    shared(B_N, B_M, B_nnz, B_index, B_value)  \
+    shared(C_N, C_M, C_nnz, C_index, C_value)  \
+    firstprivate(ix, jx, x)
+#endif
+#endif
+    //for (int i = 0; i < A_N; i++)
+#if defined(USE_OMP_OFFLOAD) && (defined(INTEL_SDK) || defined(CRAY_SDK))
+    for (int i = rowMin + chunk; i < rowMax; i = i + num_chunks)
+#else
+    for (int i = rowMin; i < rowMax; i++)
+#endif
+    {
+#if defined(__IBMC__) || defined(__ibmxl__)
+        int ix[C_N], jx[C_N];
+        REAL_T x[C_N];
+
+        memset(ix, 0, C_N * sizeof(int));
+#endif
+
+        int l = 0;
+        for (int jp = 0; jp < A_nnz[i]; jp++)
+        {
+            int k = A_index[ROWMAJOR(i, jp, A_N, A_M)];
+            if (ix[k] == 0)
+            {
+                x[k] = 0.0;
+                jx[l] = k;
+                ix[k] = i + 1;
+                l++;
+            }
+
+            for (int kp = 0; kp < B_nnz[i]; kp++)
+            {
+                int kB = B_index[ROWMAJOR(i, kp, B_N, B_M)];
+                if (k == kB)
+                {
+                    x[k] +=
+                        A_value[ROWMAJOR(i, jp, A_N, A_M)] *
+                        B_value[ROWMAJOR(i, kp, B_N, B_M)];
+                }
+            }
+
+        }
+
+        // Check for number of non-zeroes per row exceeded
+        if (l > C_M)
+        {
+#ifndef USE_OMP_OFFLOAD
+            LOG_ERROR("Number of non-zeroes per row > M, Increase M\n");
+#endif
+        }
+
+        int ll = 0;
+        for (int j = 0; j < l; j++)
+        {
+            //int jp = C_index[ROWMAJOR(i, j, N, M)];
+            int jp = jx[j];
+            REAL_T xtmp = x[jp];
+            if (jp == i)
+            {
+                C_value[ROWMAJOR(i, ll, C_N, C_M)] = xtmp;
+                C_index[ROWMAJOR(i, ll, C_N, C_M)] = jp;
+                ll++;
+            }
+            else if (is_above_threshold(xtmp, threshold))
+            {
+                C_value[ROWMAJOR(i, ll, C_N, C_M)] = xtmp;
+                C_index[ROWMAJOR(i, ll, C_N, C_M)] = jp;
+                ll++;
+            }
+            ix[jp] = 0;
+            x[jp] = 0.0;
+        }
+        C_nnz[i] = ll;
+    }
+#if defined(USE_OMP_OFFLOAD) && (defined(INTEL_SDK) || defined(CRAY_SDK))
+}
+#endif
+}

--- a/src/C-interface/ellsort/CMakeLists.txt
+++ b/src/C-interface/ellsort/CMakeLists.txt
@@ -9,6 +9,7 @@ set(HEADERS-ELLSORT
   bml_import_ellsort.h
   bml_introspection_ellsort.h
   bml_multiply_ellsort.h
+  bml_element_multiply_ellsort.h
   bml_normalize_ellsort.h
   bml_norm_ellsort.h
   bml_parallel_ellsort.h
@@ -32,6 +33,7 @@ set(SOURCES-ELLSORT
   bml_import_ellsort.c
   bml_introspection_ellsort.c
   bml_multiply_ellsort.c
+  bml_element_multiply_ellsort.c
   bml_normalize_ellsort.c
   bml_norm_ellsort.c
   bml_parallel_ellsort.c
@@ -64,6 +66,7 @@ set(SOURCES-ELLSORT-TYPED
   bml_import_ellsort_typed.c
   bml_introspection_ellsort_typed.c
   bml_multiply_ellsort_typed.c
+  bml_element_multiply_ellsort_typed.c
   bml_normalize_ellsort_typed.c
   bml_norm_ellsort_typed.c
   bml_parallel_ellsort_typed.c

--- a/src/C-interface/ellsort/bml_element_multiply_ellsort.c
+++ b/src/C-interface/ellsort/bml_element_multiply_ellsort.c
@@ -1,0 +1,52 @@
+#include "../bml_add.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_types.h"
+#include "bml_add_ellsort.h"
+#include "bml_element_multiply_ellsort.h"
+#include "bml_types_ellsort.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ *  \ingroup multiply_group
+ *
+ *  \param A Matrix A
+ *  \param B Matrix B
+ *  \param C Matrix C
+ *  \param threshold Used for sparse multiply
+ */
+void
+bml_element_multiply_AB_ellsort(
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold)
+{
+    switch (A->matrix_precision)
+    {
+        case single_real:
+            bml_element_multiply_AB_ellsort_single_real(A, B, C, threshold);
+            break;
+        case double_real:
+            bml_element_multiply_AB_ellsort_double_real(A, B, C, threshold);
+            break;
+        case single_complex:
+            bml_element_multiply_AB_ellsort_single_complex(A, B, C,
+                                                           threshold);
+            break;
+        case double_complex:
+            bml_element_multiply_AB_ellsort_double_complex(A, B, C,
+                                                           threshold);
+            break;
+        default:
+            LOG_ERROR("unknown precision\n");
+            break;
+    }
+}

--- a/src/C-interface/ellsort/bml_element_multiply_ellsort.h
+++ b/src/C-interface/ellsort/bml_element_multiply_ellsort.h
@@ -1,0 +1,36 @@
+#ifndef __BML_ELEMNET_MULTIPLY_ELLSORT_H
+#define __BML_ELEMNET_MULTIPLY_ELLSORT_H
+
+#include "bml_types_ellsort.h"
+
+void bml_element_multiply_AB_ellsort(
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellsort_single_real(
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellsort_double_real(
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellsort_single_complex(
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold);
+
+void bml_element_multiply_AB_ellsort_double_complex(
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold);
+
+#endif

--- a/src/C-interface/ellsort/bml_element_multiply_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_element_multiply_ellsort_typed.c
@@ -1,0 +1,155 @@
+#include "../../macros.h"
+#include "../../typed.h"
+#include "../bml_add.h"
+#include "../bml_allocate.h"
+#include "../bml_logger.h"
+#include "../bml_element_multiply.h"
+#include "../bml_parallel.h"
+#include "../bml_types.h"
+#include "bml_add_ellsort.h"
+#include "bml_allocate_ellsort.h"
+#include "bml_element_multiply_ellsort.h"
+#include "bml_types_ellsort.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+/** Element-wise Matrix multiply (Hadamard product)
+ *
+ * \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+ *
+ * \ingroup multiply_group
+ *
+ * \param A Matrix A
+ * \param B Matrix B
+ * \param C Matrix C
+ * \param threshold Used for sparse multiply
+ */
+void TYPED_FUNC(
+    bml_element_multiply_AB_ellsort) (
+    bml_matrix_ellsort_t * A,
+    bml_matrix_ellsort_t * B,
+    bml_matrix_ellsort_t * C,
+    double threshold)
+{
+    int A_N = A->N;
+    int A_M = A->M;
+    int *A_nnz = A->nnz;
+    int *A_index = A->index;
+    int *A_localRowMin = A->domain->localRowMin;
+    int *A_localRowMax = A->domain->localRowMax;
+
+    int B_N = B->N;
+    int B_M = B->M;
+    int *B_nnz = B->nnz;
+    int *B_index = B->index;
+
+    int C_N = C->N;
+    int C_M = C->M;
+    int *C_nnz = C->nnz;
+    int *C_index = C->index;
+
+    REAL_T *A_value = (REAL_T *) A->value;
+    REAL_T *B_value = (REAL_T *) B->value;
+    REAL_T *C_value = (REAL_T *) C->value;
+
+    int myRank = bml_getMyRank();
+
+#if !(defined(__IBMC__) || defined(__ibmxl__))
+    int ix[C->N], jx[C->N];
+    REAL_T x[C->N];
+
+    memset(ix, 0, C->N * sizeof(int));
+    memset(jx, 0, C->N * sizeof(int));
+    memset(x, 0.0, C->N * sizeof(REAL_T));
+#endif
+
+#if defined(__IBMC__) || defined(__ibmxl__)
+#pragma omp parallel for                     \
+  shared(A_N, A_M, A_nnz, A_index, A_value)  \
+  shared(A_localRowMin, A_localRowMax)       \
+  shared(B_N, B_M, B_nnz, B_index, B_value)  \
+  shared(C_N, C_M, C_nnz, C_index, C_value)  \
+  shared(myRank)
+#else
+#pragma omp parallel for                     \
+  shared(A_N, A_M, A_nnz, A_index, A_value)  \
+  shared(A_localRowMin, A_localRowMax)       \
+  shared(B_N, B_M, B_nnz, B_index, B_value)  \
+  shared(C_N, C_M, C_nnz, C_index, C_value)  \
+  shared(myRank)                             \
+  firstprivate(ix, jx, x)
+#endif
+
+    //for (int i = 0; i < A_N; i++)
+    for (int i = A_localRowMin[myRank]; i < A_localRowMax[myRank]; i++)
+    {
+
+#if defined(__IBMC__) || defined(__ibmxl__)
+        int ix[C_N], jx[C_N];
+        REAL_T x[C_N];
+
+        memset(ix, 0, C_N * sizeof(int));
+#endif
+
+        int l = 0;
+        for (int jp = 0; jp < A_nnz[i]; jp++)
+        {
+            REAL_T a = A_value[ROWMAJOR(i, jp, A_N, A_M)];
+            int k = A_index[ROWMAJOR(i, jp, A_N, A_M)];
+            if (ix[k] == 0)
+            {
+                x[k] = 0.0;
+                jx[l] = k;
+                ix[k] = i + 1;
+                l++;
+            }
+
+            for (int kp = 0; kp < B_nnz[i]; kp++)
+            {
+                int kB = B_index[ROWMAJOR(i, kp, B_N, B_M)];
+                if (k == kB)
+                {
+                    x[k] +=
+                        A_value[ROWMAJOR(i, jp, A_N, A_M)] *
+                        B_value[ROWMAJOR(i, kp, B_N, B_M)];
+                }
+            }
+        }
+
+        // Check for number of non-zeroes per row exceeded
+        if (l > C_M)
+        {
+            LOG_ERROR("Number of non-zeroes per row > M, Increase M\n");
+        }
+
+        int ll = 0;
+        for (int j = 0; j < l; j++)
+        {
+            int jp = jx[j];
+            REAL_T xtmp = x[jp];
+            if (jp == i)
+            {
+                C_value[ROWMAJOR(i, ll, C_N, C_M)] = xtmp;
+                C_index[ROWMAJOR(i, ll, C_N, C_M)] = jp;
+                ll++;
+            }
+            else if (is_above_threshold(xtmp, threshold))
+            {
+                C_value[ROWMAJOR(i, ll, C_N, C_M)] = xtmp;
+                C_index[ROWMAJOR(i, ll, C_N, C_M)] = jp;
+                ll++;
+            }
+            ix[jp] = 0;
+            x[jp] = 0.0;
+        }
+        C_nnz[i] = ll;
+    }
+}

--- a/src/Fortran-interface/bml_c_interface_m.F90
+++ b/src/Fortran-interface/bml_c_interface_m.F90
@@ -406,6 +406,15 @@ module bml_c_interface_m
       real(C_DOUBLE), value, intent(in) :: threshold
     end subroutine bml_multiply_C
 
+    subroutine bml_element_multiply_AB_C(a, b, c, threshold) &
+         & bind(C, name="bml_element_multiply_AB")
+      import :: C_PTR, C_DOUBLE
+      type(C_PTR), value, intent(in) :: a
+      type(C_PTR), value, intent(in) :: b
+      type(C_PTR), value, intent(in) :: c
+      real(C_DOUBLE), value, intent(in) :: threshold
+    end subroutine bml_element_multiply_AB_C
+
     function bml_multiply_x2_C(x, x2, threshold) &
          & bind(C, name="bml_multiply_x2")
       import :: C_PTR, C_DOUBLE

--- a/src/Fortran-interface/bml_multiply_m.F90
+++ b/src/Fortran-interface/bml_multiply_m.F90
@@ -8,6 +8,7 @@ module bml_multiply_m
   private
 
   public :: bml_multiply
+  public :: bml_element_multiply_AB
   public :: bml_multiply_x2
 
 contains
@@ -57,6 +58,34 @@ contains
     call bml_multiply_c(a%ptr, b%ptr, c%ptr, alpha_, beta_, threshold_)
 
   end subroutine bml_multiply
+
+  !! Element-wise Matrix multiply (Hadamard product)
+  !!
+  !! \ingroup multiply_group
+  !!
+  !! \f$ C_{ij} \leftarrow A_{ij} * B_{ij} \f$
+  !!
+  !! \param a Matrix \f$ A \f$.
+  !! \param b Matrix \f$ B \f$.
+  !! \param c Matrix \f$ C \f$.
+  !! \param threshold The threshold \f$ threshold \f$.
+  subroutine bml_element_multiply_AB(a, b, c, threshold)
+
+    type(bml_matrix_t), intent(in) :: a, b
+    type(bml_matrix_t), intent(inout) :: c
+    real(C_DOUBLE), optional, intent(in) :: threshold
+
+    real(C_DOUBLE) :: threshold_
+
+    if(present(threshold)) then
+      threshold_ = threshold
+    else
+      threshold_ = 0
+    end if
+    call bml_element_multiply_AB_c(a%ptr, b%ptr, c%ptr, threshold_)
+
+  end subroutine bml_element_multiply_AB
+
 
   !> Square a matrix.
   !!

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES_TYPED
   mpi_sendrecv_typed.c
   multiply_banded_matrix_typed.c
   multiply_matrix_typed.c
+  element_multiply_matrix_typed.c
   multiply_matrix_x2_typed.c
   normalize_matrix_typed.c
   norm_matrix_typed.c
@@ -66,6 +67,7 @@ add_executable(bml-test
   mpi_sendrecv.c
   multiply_banded_matrix.c
   multiply_matrix.c
+  element_multiply_matrix.c
   multiply_matrix_x2.c
   normalize_matrix.c
   norm_matrix.c
@@ -161,6 +163,7 @@ set(testlist
   inverse
   io_matrix
   multiply
+  element_multiply
   multiply_banded
   multiply_x2
   norm
@@ -187,6 +190,9 @@ foreach(N ${testlist})
   endif()
   if(${N} MATCHES set_element)
     set(formats dense ellpack ellsort ellblock csr)
+  endif()
+  if(${N} MATCHES element_multiply)
+    set(formats dense ellpack ellsort csr)
   endif()
 
   test_formats(${formats})

--- a/tests/C-tests/bml_test.c
+++ b/tests/C-tests/bml_test.c
@@ -9,9 +9,9 @@
 #include "bml_test.h"
 
 #ifdef DO_MPI
-const int NUM_TESTS = 30;
+const int NUM_TESTS = 31;
 #else
-const int NUM_TESTS = 29;
+const int NUM_TESTS = 30;
 #endif
 
 typedef struct
@@ -41,6 +41,7 @@ const char *test_name[] = {
     "mpi_sendrecv",
 #endif
     "multiply",
+    "element_multiply",
     "multiply_banded",
     "multiply_x2",
     "norm",
@@ -76,6 +77,7 @@ const char *test_description[] = {
     "Send/Recv matrix with MPI",
 #endif
     "Multiply two bml matrices",
+    "Element-wise multiply two bml matrices",
     "Multiply two banded bml matrices",
     "Multiply two identical matrices",
     "Norm of bml matrix",
@@ -111,6 +113,7 @@ const test_function_t testers[] = {
     test_mpi_sendrecv,
 #endif
     test_multiply,
+    test_element_multiply,
     test_multiply_banded,
     test_multiply_x2,
     test_norm,

--- a/tests/C-tests/bml_test.h
+++ b/tests/C-tests/bml_test.h
@@ -27,6 +27,7 @@ typedef int (
 #include "mpi_sendrecv.h"
 #include "multiply_banded_matrix.h"
 #include "multiply_matrix.h"
+#include "element_multiply_matrix.h"
 #include "multiply_matrix_x2.h"
 #include "normalize_matrix.h"
 #include "norm_matrix.h"

--- a/tests/C-tests/element_multiply_matrix.c
+++ b/tests/C-tests/element_multiply_matrix.c
@@ -1,0 +1,36 @@
+#include "bml.h"
+#include "bml_test.h"
+
+#include <stdio.h>
+
+int
+test_element_multiply(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M)
+{
+    switch (matrix_precision)
+    {
+        case single_real:
+            return test_element_multiply_single_real(N, matrix_type,
+                                                     matrix_precision, M);
+            break;
+        case double_real:
+            return test_element_multiply_double_real(N, matrix_type,
+                                                     matrix_precision, M);
+            break;
+        case single_complex:
+            return test_element_multiply_single_complex(N, matrix_type,
+                                                        matrix_precision, M);
+            break;
+        case double_complex:
+            return test_element_multiply_double_complex(N, matrix_type,
+                                                        matrix_precision, M);
+            break;
+        default:
+            fprintf(stderr, "unknown matrix precision\n");
+            return -1;
+            break;
+    }
+}

--- a/tests/C-tests/element_multiply_matrix.h
+++ b/tests/C-tests/element_multiply_matrix.h
@@ -1,0 +1,36 @@
+#ifndef __ELEMENT_MULTIPLY_MATRIX_H
+#define __ELEMENT_MULTIPLY_MATRIX_H
+
+#include <bml.h>
+
+int test_element_multiply(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_element_multiply_single_real(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_element_multiply_double_real(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_element_multiply_single_complex(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+int test_element_multiply_double_complex(
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M);
+
+#endif

--- a/tests/C-tests/element_multiply_matrix_typed.c
+++ b/tests/C-tests/element_multiply_matrix_typed.c
@@ -1,0 +1,226 @@
+#include "bml.h"
+#include "../macros.h"
+#include "../typed.h"
+#include "ellblock/bml_allocate_ellblock.h"
+#include "bml_utilities.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef _OPENMP
+#include<omp.h>
+#else
+#include<time.h>
+#endif
+
+static void TYPED_FUNC(
+    ref_element_multiply) (
+    const int N,
+    const REAL_T * A,
+    const REAL_T * B,
+    REAL_T * C,
+    const double alpha,
+    const double beta,
+    const double threshold)
+{
+    for (int i = 0; i < N; i++)
+    {
+        for (int j = 0; j < N; j++)
+        {
+            C[ROWMAJOR(i, j, N, N)] *= beta;
+            C[ROWMAJOR(i, j, N, N)] +=
+                alpha * A[ROWMAJOR(i, j, N, N)] * B[ROWMAJOR(i, j, N, N)];
+        }
+    }
+}
+
+#if defined(SINGLE_REAL) || defined(SINGLE_COMPLEX)
+#define ABS_TOL 2e-6
+#else
+#define ABS_TOL 1e-12
+#endif
+
+static int TYPED_FUNC(
+    compare_matrix) (
+    const int N,
+    const bml_matrix_precision_t matrix_precision,
+    REAL_T * A,
+    REAL_T * B)
+{
+    int max_row = MIN(N, PRINT_THRESHOLD);
+    int max_col = MIN(N, PRINT_THRESHOLD);
+
+    LOG_INFO("Compare matrices\n");
+    for (int i = 0; i < N * N; i++)
+    {
+        if (ABS(A[i] - B[i]) > ABS_TOL)
+        {
+            LOG_INFO("First matrix\n");
+            bml_print_dense_matrix(N, matrix_precision, dense_row_major, A, 0,
+                                   max_row, 0, max_col);
+            LOG_INFO("Second matrix\n");
+            bml_print_dense_matrix(N, matrix_precision, dense_row_major, B, 0,
+                                   max_row, 0, max_col);
+            LOG_INFO("element %d outside %1.2e\n", i, ABS_TOL);
+#if defined(SINGLE_COMPLEX) || defined(DOUBLE_COMPLEX)
+            LOG_INFO("A[%d] = %e+%ei\n", i, creal(A[i]), cimag(A[i]));
+            LOG_INFO("B[%d] = %e+%ei\n", i, creal(B[i]), cimag(B[i]));
+            LOG_INFO("abs(A[%d]-B[%d]) = %e\n", i, i, ABS(A[i] - B[i]));
+#else
+            LOG_INFO("A[%d] = %e\n", i, A[i]);
+            LOG_INFO("B[%d] = %e\n", i, B[i]);
+            LOG_INFO("abs(A[%d]-B[%d]) = %e\n", i, i, ABS(A[i] - B[i]));
+#endif
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void TYPED_FUNC(
+    setup_bsizes) (
+    const int N,
+    const int M)
+{
+    int bsizes[N];
+    int count = 0;
+    int nb = 0;
+    for (int i = 0; i < N; i++)
+    {
+        int bsize = (3 + i) % 6 + 1;
+        count += bsize;
+        if (count > N)
+        {
+            bsize -= (count - N);
+            count = N;
+        }
+        bsizes[i] = bsize;
+        if (count == N)
+        {
+            nb = i + 1;
+            break;
+        }
+    }
+    bml_set_block_sizes(bsizes, nb, nb * M / N);
+    for (int i = 0; i < nb; i++)
+    {
+        printf("bsizes[%d] = %d\n", i, bsizes[i]);
+    }
+
+}
+
+int TYPED_FUNC(
+    test_element_multiply) (
+    const int N,
+    const bml_matrix_type_t matrix_type,
+    const bml_matrix_precision_t matrix_precision,
+    const int M)
+{
+    // set block sizes for ellblock tests
+    // (unused by other tests)
+#ifdef DO_MPI
+    if (bml_getNRanks() > 1)
+    {
+        int p2 = bml_getNRanks();
+        int p = bml_sqrtint(p2);
+        TYPED_FUNC(setup_bsizes) (N / p, M / p);
+    }
+    else
+#endif
+    if (matrix_type == ellblock)
+    {
+        LOG_INFO("ellblock type\n");
+        TYPED_FUNC(setup_bsizes) (N, M);
+    }
+
+    bml_distribution_mode_t distrib_mode = sequential;
+#ifdef DO_MPI
+    if (bml_getNRanks() > 1)
+    {
+        LOG_INFO("Use distributed matrix\n");
+        distrib_mode = distributed;
+    }
+#endif
+
+    const double alpha = 1.0;
+    const double beta = 0.0;
+    const double threshold = 0.0;
+
+    int max_row = MIN(N, PRINT_THRESHOLD);
+    int max_col = MIN(N, PRINT_THRESHOLD);
+
+    bml_matrix_t *A =
+        bml_random_matrix(matrix_type, matrix_precision, N, N, distrib_mode);
+    bml_matrix_t *B =
+        bml_random_matrix(matrix_type, matrix_precision, N, N, distrib_mode);
+    bml_matrix_t *C =
+        bml_random_matrix(matrix_type, matrix_precision, N, N, distrib_mode);
+
+    bml_threshold(A, 0.2);
+    bml_threshold(B, 0.2);
+    bml_threshold(C, 0.2);
+
+    REAL_T *A_dense = bml_export_to_dense(A, dense_row_major);
+    REAL_T *B_dense = bml_export_to_dense(B, dense_row_major);
+    REAL_T *C_dense = bml_export_to_dense(C, dense_row_major);
+    REAL_T *D_dense = bml_export_to_dense(C, dense_row_major);
+
+    if (bml_getMyRank() == 0)
+        LOG_INFO("bml_element_multiply\n");
+    bml_element_multiply_AB(A, B, C, threshold);
+    if (bml_getMyRank() == 0)
+    {
+        LOG_INFO("C = (%f * A * B + %f * C) [0: %d][0: %d]\n", alpha, beta, N,
+                 N);
+    }
+    LOG_INFO("A = \n");
+    bml_print_bml_matrix(A, 0, max_row, 0, max_col);
+
+    LOG_INFO("B = \n");
+    bml_print_bml_matrix(B, 0, max_row, 0, max_col);
+
+    LOG_INFO("C = \n");
+    bml_print_bml_matrix(C, 0, max_row, 0, max_col);
+
+    if (bml_getMyRank() == 0)
+        LOG_INFO("bml_export_to_dense\n");
+    REAL_T *E_dense = bml_export_to_dense(C, dense_row_major);
+
+    if (bml_getMyRank() == 0)
+    {
+        TYPED_FUNC(ref_element_multiply) (N, A_dense, B_dense, D_dense, alpha,
+                                          beta, threshold);
+
+        LOG_INFO("E_dense = \n");
+        bml_print_dense_matrix(N, matrix_precision, dense_row_major, E_dense,
+                               0, max_row, 0, max_col);
+
+        LOG_INFO("D_dense (reference) = \n");
+        bml_print_dense_matrix(N, matrix_precision, dense_row_major, D_dense,
+                               0, max_row, 0, max_col);
+
+        if (TYPED_FUNC(compare_matrix) (N, matrix_precision, D_dense, E_dense)
+            != 0)
+        {
+            LOG_ERROR("matrix product incorrect\n");
+            return -1;
+        }
+        LOG_INFO("multiply matrix test passed\n");
+    }
+
+    bml_deallocate(&A);
+    bml_deallocate(&B);
+    bml_deallocate(&C);
+
+    if (bml_getMyRank() == 0)
+    {
+        bml_free_memory(A_dense);
+        bml_free_memory(B_dense);
+        bml_free_memory(C_dense);
+        bml_free_memory(D_dense);
+        bml_free_memory(E_dense);
+    }
+    return 0;
+}

--- a/tests/C-tests/test_element_multiply.c
+++ b/tests/C-tests/test_element_multiply.c
@@ -1,0 +1,6 @@
+int
+test_element_multiply(
+    void)
+{
+    return 0;
+}

--- a/tests/C-tests/test_element_multiply.h
+++ b/tests/C-tests/test_element_multiply.h
@@ -1,0 +1,7 @@
+#ifndef __TEST_ELEMENT_MULTIPLY_H
+#define __TEST_ELEMENT_MULTIPLY_H
+
+int test_element_multiply(
+    void);
+
+#endif

--- a/tests/Fortran-tests/multiply_matrix_typed.F90
+++ b/tests/Fortran-tests/multiply_matrix_typed.F90
@@ -24,6 +24,7 @@ contains
     type(bml_matrix_t) :: d
     type(bml_matrix_t) :: f
     type(bml_matrix_t) :: g
+    type(bml_matrix_t) :: h
 
 
     DUMMY_KIND(DUMMY_PREC), allocatable :: a_dense(:, :)
@@ -33,6 +34,7 @@ contains
     DUMMY_KIND(DUMMY_PREC), allocatable :: e_dense(:, :)
     DUMMY_KIND(DUMMY_PREC), allocatable :: f_dense(:, :)
     DUMMY_KIND(DUMMY_PREC), allocatable :: g_dense(:, :)
+    DUMMY_KIND(DUMMY_PREC), allocatable :: h_dense(:, :)
 
     real(dp), allocatable :: trace(:)
 
@@ -61,8 +63,10 @@ contains
 
     call bml_zero_matrix(matrix_type, element_kind, element_precision, n, m, f)
     call bml_zero_matrix(matrix_type, element_kind, element_precision, n, m, g)
+    call bml_zero_matrix(matrix_type, element_kind, element_precision, n, m, h)
     call bml_multiply_x2(a, f, threshold, trace)
     call bml_multiply(a, a, g, ONE, ZERO, threshold)
+    call bml_element_multiply_AB(a, a, h, threshold)
 
     test_result = .true.
 
@@ -84,6 +88,16 @@ contains
       print *, "max abs diff = ", maxval(abs(e_dense - d_dense))
     endif
 
+    allocate(h_dense(n,n))
+    call bml_export_to_dense(h, h_dense)
+
+    h_dense = h_dense - a_dense * a_dense
+    if(maxval(abs(h_dense)) > abs_tol) then
+      test_result = .false.
+      print *, "incorrect matrix product"
+      print *, "max abs diff = ", maxval(abs(h_dense))
+    endif
+
     call bml_export_to_dense(f, f_dense)
     call bml_export_to_dense(g, g_dense)
     call bml_print_matrix("F", f_dense, 1, n, 1, n)
@@ -100,6 +114,7 @@ contains
     call bml_deallocate(d)
     call bml_deallocate(f)
     call bml_deallocate(g)
+    call bml_deallocate(h)
 
   end function test_multiply_matrix_typed
 


### PR DESCRIPTION
The new response calculation API in qmd/progress for the kernel in LATTE requires element-wise matrix multiply, which is implemented in this PR. 