### PR TITLE
Fix permission issue with stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '30 1 * * *'
   workflow_dispatch:
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:


### PR DESCRIPTION
The permissions might have to be set explicitly in the workflow [1].

[1] https://github.com/actions/stale#recommended-permissions

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>