### PR TITLE
Fix for `sphinx<2` (as used on RTD)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ In case the build fails for some reason, please contact the developers by
 opening an issue on GitHub (https://github.com/lanl/bml/issues) and attach the
 files
 
-.. code-block::
+.. code-block:: shell
 
   build/CMakeFiles/CMakeOutput.log
   build/CMakeFiles/CMakeError.log

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,8 @@ release = 'v2.1.2'
 
 # -- General configuration ---------------------------------------------------
 
+master_doc = 'index'
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>