### PR TITLE
Add pre-commit hook script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ compile         - Compile the sources
 install         - Install the compiled sources
 testing         - Run the test suite
 docs            - Generate the API documentation
-indent          - Indent the sources
+indent          - Check the indentation of the sources
 check_indent    - Check the indentation of the sources
 tags            - Create tags file for vim and emacs
 dist            - Generate a tar file (this only works with git)
@@ -277,28 +277,10 @@ testing() {
     cd "${TOP_DIR}"
 }
 
-indent() {
-    cd "${BUILD_DIR}"
-    "${TOP_DIR}/scripts/indent.sh" 2>&1 | tee --append "${LOG_FILE}"
-    check_pipe_error
-}
-
 check_indent() {
     cd "${TOP_DIR}"
-    if which bashate; then
-        git ls-files '*.sh' \
-            | xargs --no-run-if-empty --verbose --max-args 1 bashate \
-            2>&1 | tee --append "${LOG_FILE}"
-    fi
     "${TOP_DIR}/scripts/indent.sh" 2>&1 | tee --append "${LOG_FILE}"
     check_pipe_error
-    git diff 2>&1 | tee --append "${LOG_FILE}"
-    check_pipe_error
-    LINES=$(git diff | wc -l)
-    if test ${LINES} -gt 0; then
-        echo "sources were not formatted correctly"
-        die
-    fi
 }
 
 tags() {
@@ -374,7 +356,7 @@ if [[ $# -gt 0 ]]; then
                 docs
                 ;;
             "indent")
-                indent
+                check_indent
                 ;;
             "check_indent")
                 check_indent

--- a/scripts/build_iris_offload_oneapi.sh
+++ b/scripts/build_iris_offload_oneapi.sh
@@ -3,11 +3,11 @@
 # Make sure all the paths are correct
 
 if [ -e build ];then
-  rm -r build
+    rm -r build
 fi
 
 if [ -e install ];then
-  rm -r install
+    rm -r install
 fi
 
 MY_PATH=$(pwd)

--- a/scripts/build_lassen_xl_offload.sh
+++ b/scripts/build_lassen_xl_offload.sh
@@ -28,10 +28,6 @@ export BLAS_LIBRARIES=${BLAS_LIBRARIES:="-L${LAPACK_DIR} -llapack -lblas"}
 ./build.sh configure
 
 pushd build
-make -j 
+make -j
 make install
 popd
-
-
-                                                                                                                                                                                              
-                                    

--- a/scripts/build_mkl_gpu.sh
+++ b/scripts/build_mkl_gpu.sh
@@ -35,8 +35,6 @@ export CMAKE_C_FLAGS="-O3 -fiopenmp -fopenmp-targets=spir64 -D__STRICT_ANSI__ -D
 
 export EXTRA_LINK_FLAGS="-L/soft/restricted/CNDA/sdk/2021.04.30.001/oneapi/mkl/2021u3_20210525/lib/intel64 -lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_intel_thread -lpthread -lm -lmkl_intel_ilp64  -lmkl_sycl -lstdc++ -Wl,-rpath,/soft/restricted/CNDA/sdk/2021.04.30.001/oneapi/kokkos/20210323-3.1/../../compiler/latest/linux/compiler/lib/intel64 -L/soft/restricted/CNDA/sdk/2021.04.30.001/oneapi/kokkos/20210323-3.1/../../compiler/latest/linux/compiler/lib/intel64 -liomp5 -lsycl -lOpenCL -lm -lpthread -ldl"
 
- 
-
 ./build.sh configure
 #./build.sh install
 cd build
@@ -46,4 +44,3 @@ make install
 
 cd ../install
 ln -s lib64 lib
-

--- a/scripts/example_build.sh
+++ b/scripts/example_build.sh
@@ -19,6 +19,3 @@ export EXTRA_CFLAGS=${EXTRA_CFLAGS:=""}
 export EXTRA_LINK_FLAGS=${EXTRA_LINK_FLAGS:=""}
 
 ./build.sh configure
-
-                                                                                                                                                                                              
-                                    

--- a/scripts/indent.sh
+++ b/scripts/indent.sh
@@ -1,49 +1,90 @@
 #!/bin/bash
 
-set -x
-
 : ${EMACS:=$(command -v emacs)}
 : ${INDENT_ARGS:="-gnu -nut -i4 -bli0 -cli4 -ppi0 -cbi0 -npcs -bfda"}
 
+declare -a SH_FILES
 declare -a C_FILES
 declare -a FORTRAN_FILES
 
 if ! git status > /dev/null; then
-  cat <<EOF
+    cat <<EOF
 We are not inside a git repository. Please specify the files to indent
 manually.
 EOF
-  exit 1
+    exit 1
 fi
 
 if (( $# > 0 )); then
-  for file in "$@"; do
-    case "${file##*.}" in
-      "c" | "h")
-        C_FILES[${#C_FILES[@]}]="$file"
-        ;;
-      "F90")
-        FORTRAN_FILES[${#FORTRAN_FILES[@]}]="$file"
-        ;;
-      *)
-        echo "unknown suffix"
-        ;;
-    esac
-  done
+    while (( $# > 0 )); do
+        case "${1##*.}" in
+            "c" | "h")
+                C_FILES[${#C_FILES[@]}]="$1"
+                ;;
+            "F90")
+                FORTRAN_FILES[${#FORTRAN_FILES[@]}]="$1"
+                ;;
+            "sh")
+                SH_FILES[${#SH_FILES[@]}]="$1"
+                ;;
+            *)
+                echo "unknown suffix"
+                ;;
+        esac
+    done
 else
-  readarray -t C_FILES < <(git ls-files -- '*.c' '*.h')
-  readarray -t FORTRAN_FILES < <(git ls-files -- '*.F90')
+    readarray -t SH_FILES < <(git ls-files -- '*.sh')
+    readarray -t C_FILES < <(git ls-files -- '*.c' '*.h')
+    readarray -t FORTRAN_FILES < <(git ls-files -- '*.F90')
 fi
 
-for f in "${C_FILES[@]}"; do
-  sed -i -e 's:\s\+$::' "${f}"
-  indent ${INDENT_ARGS} "${f}"
+success=0
+declare -a FAILED_FILES=()
+
+for file in "${SH_FILES[@]}"; do
+    if ! bashate --ignore E006 "${file}"; then
+        success=1
+        FAILED_FILES[${#FAILED_FILES[@]}]=${file}
+    fi
 done
 
-for f in "${FORTRAN_FILES[@]}"; do
-  ${EMACS} --batch \
-    "${f}" \
-    --eval "(whitespace-cleanup)" \
-    --eval "(indent-region (minibuffer-prompt-end) (point-max) nil)" \
-    -f save-buffer
+for file in "${C_FILES[@]}"; do
+    indent ${INDENT_ARGS} "${file}" -o "${file}.indented"
+    sed -i -e 's:\s\+$::' "${file}.indented"
+    if (( $(diff --brief "${file}" "${file}.indented" | wc -l) > 0 )); then
+        success=1
+        FAILED_FILES[${#FAILED_FILES[@]}]=${file}
+    else
+        rm -f "${file}.indented"
+    fi
 done
+
+for file in "${FORTRAN_FILES[@]}"; do
+    ${EMACS} --batch \
+        "${file}" \
+        --eval "(whitespace-cleanup)" \
+        --eval "(indent-region (minibuffer-prompt-end) (point-max) nil)" \
+        --eval "(write-file (concat (buffer-name) \".indented\"))"
+    if (( $(diff --brief "${file}" "${file}.indented" | wc -l) > 0 )); then
+        success=1
+        FAILED_FILES[${#FAILED_FILES[@]}]=${file}
+    else
+        rm -f "${file}.indented"
+    fi
+done
+
+if (( ${#FAILED_FILES[@]} > 0 )); then
+    echo
+    echo "Please inspect the following files for linting issues:"
+    echo
+    for file in "${FAILED_FILES[@]}"; do
+        if [[ ${file} =~ .sh$ ]]; then
+            echo "bashate ${file}"
+        else
+            echo "diff -Naur ${file} ${file}.indented"
+        fi
+    done
+    echo
+fi
+
+exit ${success}

--- a/scripts/magma_build.sh
+++ b/scripts/magma_build.sh
@@ -19,5 +19,3 @@ export MAGMA_ROOT=$OLCF_MAGMA_ROOT
 
 ./build.sh testing
 #./build.sh install
-                                                                                                                                                                                              
-                                    

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+debug=0
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        --debug)
+            debug=1
+            ;;
+        *)
+            # Ignoring
+            ;;
+    esac
+    shift
+done
+
+if [ ${debug} -ne 0 ]; then
+    set -x
+fi
+
+if ! ./scripts/run-local-docker-container.sh ./build.sh indent > ./indent.output 2>&1; then
+    cat <<EOF
+The linter found issues with this commit. Please verify the suggested
+changes:
+
+EOF
+    cat indent.output
+    exit 1
+fi

--- a/scripts/prepare-container-focal.sh
+++ b/scripts/prepare-container-focal.sh
@@ -5,14 +5,14 @@ set -e -u -x
 SUDO=$(which sudo || true)
 
 for i in $(seq 5); do
-  ${SUDO} apt-get update && break
+    ${SUDO} apt-get update && break
 done
 
 ${SUDO} apt-get install --assume-yes --no-install-recommends \
-  apt-transport-https \
-  ca-certificates \
-  gnupg \
-  wget
+    apt-transport-https \
+    ca-certificates \
+    gnupg \
+    wget
 
 cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/clang.list
 # i386 not available
@@ -32,7 +32,7 @@ deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main
 # deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main
 EOF
 gpg --keyserver keyserver.ubuntu.com \
-  --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+    --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
 ${SUDO} cat > /etc/apt/trusted.gpg.d/toolchain.gpg < <(gpg --export 60C317803A41BA51845E371A1E9377A2BA9EF27F)
 
 cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/emacs.list
@@ -40,42 +40,42 @@ deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu focal main
 # deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu focal main
 EOF
 gpg --keyserver keyserver.ubuntu.com \
-  --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
+    --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
 ${SUDO} cat > /etc/apt/trusted.gpg.d/emacs.gpg < <(gpg --export 873503A090750CDAEB0754D93FF0E01EEAAFC9CD)
 
 apt-key list
 
 for i in $(seq 5); do
-  ${SUDO} apt-get update && break
+    ${SUDO} apt-get update && break
 done
 
 ${SUDO} ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 ${SUDO} apt-get install --assume-yes tzdata
 DEBIAN_FRONTEND=noninteractive ${SUDO} dpkg-reconfigure \
-  --frontend noninteractive tzdata
+    --frontend noninteractive tzdata
 
 ${SUDO} apt-get install --assume-yes --no-install-recommends \
-  apt-utils \
-  build-essential \
-  gfortran \
-  bundler \
-  cmake cmake-data \
-  emacs27 \
-  clang-9 llvm-9-dev libomp-9-dev \
-  gcc-9 g++-9 gfortran-9 \
-  gcc-10 g++-10 gfortran-10 \
-  gcc-11 g++-11 gfortran-11 \
-  git-core \
-  indent \
-  libblas-dev liblapack-dev \
-  libscalapack-openmpi-dev \
-  mpi-default-dev \
-  openmpi-bin \
-  openssh-client \
-  python python3-pip python3-wheel python3-pkg-resources \
-  sudo \
-  texlive \
-  valgrind \
-  vim
+    apt-utils \
+    build-essential \
+    gfortran \
+    bundler \
+    cmake cmake-data \
+    emacs27 \
+    clang-9 llvm-9-dev libomp-9-dev \
+    gcc-9 g++-9 gfortran-9 \
+    gcc-10 g++-10 gfortran-10 \
+    gcc-11 g++-11 gfortran-11 \
+    git-core \
+    indent \
+    libblas-dev liblapack-dev \
+    libscalapack-openmpi-dev \
+    mpi-default-dev \
+    openmpi-bin \
+    openssh-client \
+    python python3-pip python3-wheel python3-pkg-resources \
+    sudo \
+    texlive \
+    valgrind \
+    vim
 
 ${SUDO} pip install --system bashate

--- a/scripts/prepare-container.sh
+++ b/scripts/prepare-container.sh
@@ -5,14 +5,14 @@ set -e -u -x
 SUDO=$(which sudo || true)
 
 for i in $(seq 5); do
-  ${SUDO} apt-get update && break
+    ${SUDO} apt-get update && break
 done
 
 ${SUDO} apt-get install --assume-yes --no-install-recommends \
-  apt-transport-https \
-  ca-certificates \
-  gnupg \
-  wget
+    apt-transport-https \
+    ca-certificates \
+    gnupg \
+    wget
 
 cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/clang.list
 # i386 not available
@@ -32,7 +32,7 @@ deb http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main
 # deb-src http://ppa.launchpad.net/janisozaur/cmake-update-bionic/ubuntu bionic main
 EOF
 gpg --keyserver keyserver.ubuntu.com \
-  --recv-keys DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4
+    --recv-keys DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4
 ${SUDO} bash -c "cat > /etc/apt/trusted.gpg.d/cmake.gpg" < <(gpg --export DBA92F17B25AD78F9F2D9F713DEC686D130FF5E4)
 
 cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/toolchain.list
@@ -40,7 +40,7 @@ deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main
 # deb-src http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main
 EOF
 gpg --keyserver keyserver.ubuntu.com \
-  --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+    --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
 ${SUDO} bash -c "cat > /etc/apt/trusted.gpg.d/toolchain.gpg" < <(gpg --export 60C317803A41BA51845E371A1E9377A2BA9EF27F)
 
 cat <<EOF | ${SUDO} tee /etc/apt/sources.list.d/emacs.list
@@ -48,43 +48,43 @@ deb http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main
 # deb-src http://ppa.launchpad.net/kelleyk/emacs/ubuntu bionic main
 EOF
 gpg --keyserver keyserver.ubuntu.com \
-  --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
+    --recv-keys 873503A090750CDAEB0754D93FF0E01EEAAFC9CD
 ${SUDO} bash -c "cat > /etc/apt/trusted.gpg.d/emacs.gpg" < <(gpg --export 873503A090750CDAEB0754D93FF0E01EEAAFC9CD)
 
 apt-key list
 
 for i in $(seq 5); do
-  ${SUDO} apt-get update && break
+    ${SUDO} apt-get update && break
 done
 
 ${SUDO} ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 ${SUDO} apt-get install --assume-yes tzdata
 DEBIAN_FRONTEND=noninteractive ${SUDO} dpkg-reconfigure \
-  --frontend noninteractive tzdata
+    --frontend noninteractive tzdata
 
 ${SUDO} apt-get install --assume-yes --no-install-recommends \
-  apt-utils \
-  build-essential \
-  gfortran \
-  bundler \
-  cmake cmake-data \
-  emacs27 \
-  clang-11 llvm-11-dev libomp-11-dev \
-  gcc-4.8 g++-4.8 gfortran-4.8 \
-  gcc-9 g++-9 gfortran-9 \
-  gcc-10 g++-10 gfortran-10 \
-  gcc-11 g++-11 gfortran-11 \
-  git-core \
-  indent \
-  libblas-dev liblapack-dev \
-  libscalapack-openmpi-dev \
-  mpi-default-dev \
-  openmpi-bin \
-  openssh-client \
-  python python-pip python-wheel python-pkg-resources \
-  sudo \
-  texlive \
-  valgrind \
-  vim
+    apt-utils \
+    build-essential \
+    gfortran \
+    bundler \
+    cmake cmake-data \
+    emacs27 \
+    clang-11 llvm-11-dev libomp-11-dev \
+    gcc-4.8 g++-4.8 gfortran-4.8 \
+    gcc-9 g++-9 gfortran-9 \
+    gcc-10 g++-10 gfortran-10 \
+    gcc-11 g++-11 gfortran-11 \
+    git-core \
+    indent \
+    libblas-dev liblapack-dev \
+    libscalapack-openmpi-dev \
+    mpi-default-dev \
+    openmpi-bin \
+    openssh-client \
+    python python-pip python-wheel python-pkg-resources \
+    sudo \
+    texlive \
+    valgrind \
+    vim
 
 ${SUDO} pip install --system bashate

--- a/scripts/run-local-docker-container.sh
+++ b/scripts/run-local-docker-container.sh
@@ -3,7 +3,9 @@
 : ${IMAGE:=nicolasbock/bml:latest}
 
 docker pull ${IMAGE}
-docker run --interactive --tty --rm \
-  --volume ${PWD}:/bml --workdir /bml \
-  --user $(id --user):$(id --group) \
-  ${IMAGE}
+docker run --rm \
+    $( (( $# == 0 )) && echo "--interactive --tty") \
+    --volume "${PWD}":/bml \
+    --workdir /bml \
+    --user $(id --user):$(id --group) \
+    ${IMAGE} "$@"


### PR DESCRIPTION
The pre-commit hook script needs to be copied locally to:

  $ cp scripts/pre-commit .git/hooks/pre-commit

It will run the linter before committing.

Since the linter takes a while to complete, it can be helpful to disable
this check if desired. Adding the `--no-verify` command line option to
`git commit` will do that:

  $ git commit --no-verify [options]

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>