### PR TITLE
Only check `push` events on `master` branch

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -6,6 +6,8 @@ on:
     type:
       - created
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Pull requests will be checked in CI anyway. The additional `push` even
check duplicates CI runs for pull requests that live in the `lanl/bml`
repository.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>