### PR TITLE
Minor revisions to cuSPARSE code and offload flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
+
 message(STATUS "CMake version ${CMAKE_VERSION}")
 
 set(LANGUAGES C CXX)
@@ -214,7 +215,7 @@ if(BML_OMP_OFFLOAD)
 
   include(CheckCXXCompilerFlag)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(OpenMP_CXX_OFFLOAD_FLAG "-foffload='-lm'")
+    set(OpenMP_CXX_OFFLOAD_FLAG "-foffload=-misa=sm_35 -foffload=nvptx-none -foffload='-lm'")
   elseif(MAKE_CXX_COMPILER_ID STREQUAL "Intel")
     set(OpenMP_CXX_OFFLOAD_FLAG "-foffload='-lm'")
   elseif(MAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -236,7 +237,7 @@ if(BML_OMP_OFFLOAD)
   include(FindCUDA)
 
   set(GPU_ARCH "sm_60" CACHE STRING "LAMMPS GPU CUDA SM architecture")
-  set_property(CACHE GPU_ARCH PROPERTY STRINGS sm_30 sm_50 sm_60 sm_70)
+  set_property(CACHE GPU_ARCH PROPERTY STRINGS sm_50 sm_60 sm_70)
 
   message("CUDA libraries: ${CUDA_LIBRARIES}")
   message("CUDA CUBLAS libraries: ${CUDA_CUBLAS_LIBRARIES}")

--- a/src/C-interface/bml_logger.c.indented
+++ b/src/C-interface/bml_logger.c.indented
@@ -1,1 +1,0 @@
-bml_version(

--- a/src/C-interface/bml_logger.h.indented
+++ b/src/C-interface/bml_logger.h.indented
@@ -1,3 +1,0 @@
-char *bml_version(
-char *bml_version(
-    void);

--- a/src/C-interface/ellpack/bml_add_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_add_ellpack_typed.c
@@ -681,7 +681,7 @@ void TYPED_FUNC(
         // Note: cusparse has either cusparse<t>pruneCsr2csr or cusparse<t>csr2csr_compress to
         // accomplish this. We use cusparse<t>pruneCsr2csr here for convenience.
         // Prune allows the use of device pointers, whereas Compress works with managed memory.
-        if (threshold > BML_REAL_MIN)
+        if (is_above_threshold(threshold, BML_REAL_MIN))
         {
             // Get size of buffer and allocate
 //        BML_CHECK_CUSPARSE( bml_cusparsePruneCSR_bufferSizeExt(handle, C_num_rows, C_num_cols, C_nnz_tmp, (cusparseMatDescr_t)matC,

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -868,7 +868,7 @@ void TYPED_FUNC(
         // Note: cusparse has either cusparse<t>pruneCsr2csr or cusparse<t>csr2csr_compress to
         // accomplish this. We use cusparse<t>pruneCsr2csr here for convenience.
         // Prune allows the use of device pointers, whereas Compress works with managed memory.
-        if (threshold > BML_REAL_MIN)
+        if (is_above_threshold(threshold, BML_REAL_MIN))
         {
             int nnzC = 0;
             size_t lworkInBytes = 0;


### PR DESCRIPTION
  o Use is_above_threshold() to support complex thresholding
  o Add "-foffload=-misa=sm_35" to GNU offload flags to avoid sm_30 arch error