### PR TITLE
Turn complex code off when BML_COMPLEX off

### DIFF
--- a/src/C-interface/bml_elemental.c
+++ b/src/C-interface/bml_elemental.c
@@ -69,6 +69,7 @@ bml_get_element_double_real(
     return -1;
 }
 
+#ifdef BML_COMPLEX
 /** Return a single matrix element.
  *
  * \param i The row index
@@ -131,3 +132,4 @@ bml_get_element_double_complex(
     }
     return -1;
 }
+#endif

--- a/src/C-interface/csr/CMakeLists.txt
+++ b/src/C-interface/csr/CMakeLists.txt
@@ -88,8 +88,10 @@ set(SOURCES-CSR-TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bml-csr single_real "${SOURCES-CSR-TYPED}")
 bml_add_typed_library(bml-csr double_real "${SOURCES-CSR-TYPED}")
-bml_add_typed_library(bml-csr single_complex "${SOURCES-CSR-TYPED}")
-bml_add_typed_library(bml-csr double_complex "${SOURCES-CSR-TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bml-csr single_complex "${SOURCES-CSR-TYPED}")
+  bml_add_typed_library(bml-csr double_complex "${SOURCES-CSR-TYPED}")
+endif()
 if(OPENMP_FOUND)
   set_target_properties(bml-csr-single_real
     PROPERTIES
@@ -97,10 +99,12 @@ if(OPENMP_FOUND)
   set_target_properties(bml-csr-double_real
     PROPERTIES
     COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-csr-single_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-csr-double_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  if(BML_COMPLEX)
+    set_target_properties(bml-csr-single_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    set_target_properties(bml-csr-double_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  endif()
 endif()

--- a/src/C-interface/csr/bml_add_csr.c
+++ b/src/C-interface/csr/bml_add_csr.c
@@ -35,12 +35,14 @@ bml_add_csr(
         case double_real:
             bml_add_csr_double_real(A, B, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_csr_single_complex(A, B, alpha, beta, threshold);
             break;
         case double_complex:
             bml_add_csr_double_complex(A, B, alpha, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -79,6 +81,7 @@ bml_add_norm_csr(
             trnorm =
                 bml_add_norm_csr_double_real(A, B, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trnorm =
                 bml_add_norm_csr_single_complex(A, B, alpha, beta, threshold);
@@ -87,6 +90,7 @@ bml_add_norm_csr(
             trnorm =
                 bml_add_norm_csr_double_complex(A, B, alpha, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -118,12 +122,14 @@ bml_add_identity_csr(
         case double_real:
             bml_add_identity_csr_double_real(A, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_identity_csr_single_complex(A, beta, threshold);
             break;
         case double_complex:
             bml_add_identity_csr_double_complex(A, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -155,6 +161,7 @@ bml_scale_add_identity_csr(
         case double_real:
             bml_scale_add_identity_csr_double_real(A, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_add_identity_csr_single_complex(A, alpha, beta,
                                                       threshold);
@@ -163,6 +170,7 @@ bml_scale_add_identity_csr(
             bml_scale_add_identity_csr_double_complex(A, alpha, beta,
                                                       threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_allocate_csr.c
+++ b/src/C-interface/csr/bml_allocate_csr.c
@@ -219,12 +219,14 @@ bml_clear_csr(
         case double_real:
             bml_clear_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_clear_csr_single_complex(A);
             break;
         case double_complex:
             bml_clear_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -264,6 +266,7 @@ bml_noinit_matrix_csr(
             A = bml_noinit_matrix_csr_double_real(matrix_dimension,
                                                   distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_noinit_matrix_csr_single_complex(matrix_dimension,
                                                      distrib_mode);
@@ -272,6 +275,7 @@ bml_noinit_matrix_csr(
             A = bml_noinit_matrix_csr_double_complex(matrix_dimension,
                                                      distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -310,12 +314,14 @@ bml_zero_matrix_csr(
         case double_real:
             A = bml_zero_matrix_csr_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_zero_matrix_csr_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             A = bml_zero_matrix_csr_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -354,12 +360,14 @@ bml_banded_matrix_csr(
         case double_real:
             return bml_banded_matrix_csr_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_banded_matrix_csr_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             return bml_banded_matrix_csr_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -398,12 +406,14 @@ bml_random_matrix_csr(
         case double_real:
             return bml_random_matrix_csr_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_random_matrix_csr_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             return bml_random_matrix_csr_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -440,12 +450,14 @@ bml_identity_matrix_csr(
         case double_real:
             return bml_identity_matrix_csr_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_identity_matrix_csr_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             return bml_identity_matrix_csr_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_convert_csr.c
+++ b/src/C-interface/csr/bml_convert_csr.c
@@ -20,6 +20,7 @@ bml_convert_csr(
             return bml_convert_csr_double_real(A, matrix_precision, M,
                                                distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_convert_csr_single_complex(A, matrix_precision, M,
                                                   distrib_mode);
@@ -28,6 +29,7 @@ bml_convert_csr(
             return bml_convert_csr_double_complex(A, matrix_precision, M,
                                                   distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_copy_csr.c
+++ b/src/C-interface/csr/bml_copy_csr.c
@@ -30,12 +30,14 @@ bml_copy_csr_new(
         case double_real:
             B = bml_copy_csr_new_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_copy_csr_new_single_complex(A);
             break;
         case double_complex:
             B = bml_copy_csr_new_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,12 +66,14 @@ bml_copy_csr(
         case double_real:
             bml_copy_csr_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_copy_csr_single_complex(A, B);
             break;
         case double_complex:
             bml_copy_csr_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -97,12 +101,14 @@ bml_reorder_csr(
         case double_real:
             bml_reorder_csr_double_real(A, perm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_reorder_csr_single_complex(A, perm);
             break;
         case double_complex:
             bml_reorder_csr_double_complex(A, perm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_diagonalize_csr.c
+++ b/src/C-interface/csr/bml_diagonalize_csr.c
@@ -25,12 +25,14 @@ bml_diagonalize_csr(
         case double_real:
             bml_diagonalize_csr_double_real(A, eigenvalues, eigenvectors);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_diagonalize_csr_single_complex(A, eigenvalues, eigenvectors);
             break;
         case double_complex:
             bml_diagonalize_csr_double_complex(A, eigenvalues, eigenvectors);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_element_multiply_csr.c
+++ b/src/C-interface/csr/bml_element_multiply_csr.c
@@ -36,12 +36,14 @@ bml_element_multiply_AB_csr(
         case double_real:
             bml_element_multiply_AB_csr_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_element_multiply_AB_csr_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_element_multiply_AB_csr_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_export_csr.c
+++ b/src/C-interface/csr/bml_export_csr.c
@@ -28,12 +28,14 @@ bml_export_to_dense_csr(
         case double_real:
             return bml_export_to_dense_csr_double_real(A, order);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_export_to_dense_csr_single_complex(A, order);
             break;
         case double_complex:
             return bml_export_to_dense_csr_double_complex(A, order);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_getters_csr.c
+++ b/src/C-interface/csr/bml_getters_csr.c
@@ -17,12 +17,14 @@ bml_get_csr(
         case double_real:
             return bml_get_csr_double_real(A, i, j);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_csr_single_complex(A, i, j);
             break;
         case double_complex:
             return bml_get_csr_double_complex(A, i, j);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_csr\n");
             break;
@@ -43,12 +45,14 @@ bml_get_row_csr(
         case double_real:
             return bml_get_row_csr_double_real(A, i);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_row_csr_single_complex(A, i);
             break;
         case double_complex:
             return bml_get_row_csr_double_complex(A, i);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_row_csr\n");
             break;
@@ -68,12 +72,14 @@ bml_get_diagonal_csr(
         case double_real:
             return bml_get_diagonal_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_diagonal_csr_single_complex(A);
             break;
         case double_complex:
             return bml_get_diagonal_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_diagonal_csr\n");
             break;

--- a/src/C-interface/csr/bml_import_csr.c
+++ b/src/C-interface/csr/bml_import_csr.c
@@ -40,6 +40,7 @@ bml_import_from_dense_csr(
                                                          threshold, M,
                                                          distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_import_from_dense_csr_single_complex(order, N, A,
                                                             threshold,
@@ -50,6 +51,7 @@ bml_import_from_dense_csr(
                                                             threshold,
                                                             M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_introspection_csr.c
+++ b/src/C-interface/csr/bml_introspection_csr.c
@@ -157,6 +157,7 @@ bml_get_sparsity_csr(
         case double_real:
             return bml_get_sparsity_csr_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_sparsity_csr_single_complex(A, threshold);
             break;
@@ -166,6 +167,7 @@ bml_get_sparsity_csr(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;

--- a/src/C-interface/csr/bml_inverse_csr.c
+++ b/src/C-interface/csr/bml_inverse_csr.c
@@ -25,12 +25,14 @@ bml_inverse_csr(
         case double_real:
             B = bml_inverse_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_inverse_csr_single_complex(A);
             break;
         case double_complex:
             B = bml_inverse_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_multiply_csr.c
+++ b/src/C-interface/csr/bml_multiply_csr.c
@@ -40,12 +40,14 @@ bml_multiply_csr(
         case double_real:
             bml_multiply_csr_double_real(A, B, C, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_csr_single_complex(A, B, C, alpha, beta, threshold);
             break;
         case double_complex:
             bml_multiply_csr_double_complex(A, B, C, alpha, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -76,12 +78,14 @@ bml_multiply_x2_csr(
         case double_real:
             return bml_multiply_x2_csr_double_real(X, X2, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_multiply_x2_csr_single_complex(X, X2, threshold);
             break;
         case double_complex:
             return bml_multiply_x2_csr_double_complex(X, X2, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -115,12 +119,14 @@ bml_multiply_AB_csr(
         case double_real:
             bml_multiply_AB_csr_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_AB_csr_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_AB_csr_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -153,12 +159,14 @@ bml_multiply_adjust_AB_csr(
         case double_real:
             bml_multiply_adjust_AB_csr_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_adjust_AB_csr_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_adjust_AB_csr_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_norm_csr.c
+++ b/src/C-interface/csr/bml_norm_csr.c
@@ -27,12 +27,14 @@ bml_sum_squares_csr(
         case double_real:
             return bml_sum_squares_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_csr_single_complex(A);
             break;
         case double_complex:
             return bml_sum_squares_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -62,12 +64,14 @@ bml_sum_squares_submatrix_csr(
         case double_real:
             return bml_sum_squares_submatrix_csr_double_real(A, core_size);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_submatrix_csr_single_complex(A, core_size);
             break;
         case double_complex:
             return bml_sum_squares_submatrix_csr_double_complex(A, core_size);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -101,12 +105,14 @@ bml_sum_AB_csr(
         case double_real:
             return bml_sum_AB_csr_double_real(A, B, alpha, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_AB_csr_single_complex(A, B, alpha, threshold);
             break;
         case double_complex:
             return bml_sum_AB_csr_double_complex(A, B, alpha, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -145,6 +151,7 @@ bml_sum_squares2_csr(
             return bml_sum_squares2_csr_double_real(A, B, alpha, beta,
                                                     threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares2_csr_single_complex(A, B, alpha, beta,
                                                        threshold);
@@ -153,6 +160,7 @@ bml_sum_squares2_csr(
             return bml_sum_squares2_csr_double_complex(A, B, alpha, beta,
                                                        threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -180,12 +188,14 @@ bml_fnorm_csr(
         case double_real:
             return bml_fnorm_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm_csr_single_complex(A);
             break;
         case double_complex:
             return bml_fnorm_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -215,12 +225,14 @@ bml_fnorm2_csr(
         case double_real:
             return bml_fnorm2_csr_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm2_csr_single_complex(A, B);
             break;
         case double_complex:
             return bml_fnorm2_csr_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_normalize_csr.c
+++ b/src/C-interface/csr/bml_normalize_csr.c
@@ -20,12 +20,14 @@ bml_accumulate_offdiag_csr(
         case double_real:
             return bml_accumulate_offdiag_csr_double_real(A, flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_accumulate_offdiag_csr_single_complex(A, flag);
             break;
         case double_complex:
             return bml_accumulate_offdiag_csr_double_complex(A, flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -54,12 +56,14 @@ bml_normalize_csr(
         case double_real:
             bml_normalize_csr_double_real(A, mineval, maxeval);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_normalize_csr_single_complex(A, mineval, maxeval);
             break;
         case double_complex:
             bml_normalize_csr_double_complex(A, mineval, maxeval);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -86,12 +90,14 @@ bml_gershgorin_csr(
         case double_real:
             return bml_gershgorin_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_csr_single_complex(A);
             break;
         case double_complex:
             return bml_gershgorin_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -121,12 +127,14 @@ bml_gershgorin_partial_csr(
         case double_real:
             return bml_gershgorin_partial_csr_double_real(A, nrows);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_partial_csr_single_complex(A, nrows);
             break;
         case double_complex:
             return bml_gershgorin_partial_csr_double_complex(A, nrows);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_parallel_csr.c
+++ b/src/C-interface/csr/bml_parallel_csr.c
@@ -22,12 +22,14 @@ bml_mpi_send_csr(
         case double_real:
             bml_mpi_send_csr_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_send_csr_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_send_csr_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -48,12 +50,14 @@ bml_mpi_recv_csr(
         case double_real:
             bml_mpi_recv_csr_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_recv_csr_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_recv_csr_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -74,12 +78,14 @@ bml_mpi_irecv_csr(
         case double_real:
             bml_mpi_irecv_csr_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_csr_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_irecv_csr_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -98,12 +104,14 @@ bml_mpi_irecv_complete_csr(
         case double_real:
             bml_mpi_irecv_complete_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_complete_csr_single_complex(A);
             break;
         case double_complex:
             bml_mpi_irecv_complete_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -126,12 +134,14 @@ bml_mpi_recv_matrix_csr(
         case double_real:
             return bml_mpi_recv_matrix_csr_double_real(N, M, src, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_recv_matrix_csr_single_complex(N, M, src, comm);
             break;
         case double_complex:
             return bml_mpi_recv_matrix_csr_double_complex(N, M, src, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -152,12 +162,14 @@ bml_mpi_bcast_matrix_csr(
         case double_real:
             return bml_mpi_bcast_matrix_csr_double_real(A, root, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_bcast_matrix_csr_single_complex(A, root, comm);
             break;
         case double_complex:
             return bml_mpi_bcast_matrix_csr_double_complex(A, root, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_scale_csr.c
+++ b/src/C-interface/csr/bml_scale_csr.c
@@ -29,12 +29,14 @@ bml_scale_csr_new(
         case double_real:
             B = bml_scale_csr_new_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_scale_csr_new_single_complex(scale_factor, A);
             break;
         case double_complex:
             B = bml_scale_csr_new_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_scale_csr(
         case double_real:
             bml_scale_csr_double_real(scale_factor, A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_csr_single_complex(scale_factor, A, B);
             break;
         case double_complex:
             bml_scale_csr_double_complex(scale_factor, A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -88,12 +92,14 @@ bml_scale_inplace_csr(
         case double_real:
             bml_scale_inplace_csr_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_inplace_csr_single_complex(scale_factor, A);
             break;
         case double_complex:
             bml_scale_inplace_csr_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_setters_csr.c
+++ b/src/C-interface/csr/bml_setters_csr.c
@@ -19,12 +19,14 @@ bml_set_element_new_csr(
         case double_real:
             bml_set_element_new_csr_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_new_csr_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_new_csr_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_new_csr\n");
             break;
@@ -47,12 +49,14 @@ bml_set_element_csr(
         case double_real:
             bml_set_element_csr_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_csr_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_csr_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_csr\n");
             break;
@@ -74,12 +78,14 @@ bml_set_row_csr(
         case double_real:
             bml_set_row_csr_double_real(A, i, row, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_row_csr_single_complex(A, i, row, threshold);
             break;
         case double_complex:
             bml_set_row_csr_double_complex(A, i, row, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -100,12 +106,14 @@ bml_set_diagonal_csr(
         case double_real:
             bml_set_diagonal_csr_double_real(A, diagonal, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_diagonal_csr_single_complex(A, diagonal, threshold);
             break;
         case double_complex:
             bml_set_diagonal_csr_double_complex(A, diagonal, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -131,6 +139,7 @@ bml_set_sparse_row_csr(
             bml_set_sparse_row_csr_double_real(A, i, count, cols, row,
                                                threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_sparse_row_csr_single_complex(A, i, count, cols, row,
                                                   threshold);
@@ -139,6 +148,7 @@ bml_set_sparse_row_csr(
             bml_set_sparse_row_csr_double_complex(A, i, count, cols, row,
                                                   threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;

--- a/src/C-interface/csr/bml_submatrix_csr.c
+++ b/src/C-interface/csr/bml_submatrix_csr.c
@@ -35,6 +35,7 @@ bml_extract_submatrix_csr(
             return bml_extract_submatrix_csr_double_real(A, irow, icol,
                                                          B_N, B_M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_extract_submatrix_csr_single_complex(A, irow, icol,
                                                             B_N, B_M);
@@ -43,6 +44,7 @@ bml_extract_submatrix_csr(
             return bml_extract_submatrix_csr_double_complex(A, irow, icol,
                                                             B_N, B_M);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_assign_submatrix_csr(
         case double_real:
             bml_assign_submatrix_csr_double_real(A, B, irow, icol);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_assign_submatrix_csr_single_complex(A, B, irow, icol);
             break;
         case double_complex:
             bml_assign_submatrix_csr_double_complex(A, B, irow, icol);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_threshold_csr.c
+++ b/src/C-interface/csr/bml_threshold_csr.c
@@ -28,12 +28,14 @@ bml_matrix_csr_t
         case double_real:
             B = bml_threshold_new_csr_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_threshold_new_csr_single_complex(A, threshold);
             break;
         case double_complex:
             B = bml_threshold_new_csr_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_threshold_csr(
         case double_real:
             bml_threshold_csr_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_threshold_csr_single_complex(A, threshold);
             break;
         case double_complex:
             bml_threshold_csr_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_trace_csr.c
+++ b/src/C-interface/csr/bml_trace_csr.c
@@ -28,12 +28,14 @@ bml_trace_csr(
         case double_real:
             trace = bml_trace_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_csr_single_complex(A);
             break;
         case double_complex:
             trace = bml_trace_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_trace_mult_csr(
         case double_real:
             trace = bml_trace_mult_csr_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_mult_csr_single_complex(A, B);
             break;
         case double_complex:
             trace = bml_trace_mult_csr_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_transpose_csr.c
+++ b/src/C-interface/csr/bml_transpose_csr.c
@@ -28,12 +28,14 @@ bml_transpose_new_csr(
         case double_real:
             B = bml_transpose_new_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_transpose_new_csr_single_complex(A);
             break;
         case double_complex:
             B = bml_transpose_new_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -61,12 +63,14 @@ bml_transpose_csr(
         case double_real:
             bml_transpose_csr_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_transpose_csr_single_complex(A);
             break;
         case double_complex:
             bml_transpose_csr_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/csr/bml_utilities_csr.c
+++ b/src/C-interface/csr/bml_utilities_csr.c
@@ -16,12 +16,14 @@ bml_read_bml_matrix_csr(
         case double_real:
             bml_read_bml_matrix_csr_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_read_bml_matrix_csr_single_complex(A, filename);
             break;
         case double_complex:
             bml_read_bml_matrix_csr_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -41,12 +43,14 @@ bml_write_bml_matrix_csr(
         case double_real:
             bml_write_bml_matrix_csr_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_write_bml_matrix_csr_single_complex(A, filename);
             break;
         case double_complex:
             bml_write_bml_matrix_csr_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/CMakeLists.txt
+++ b/src/C-interface/dense/CMakeLists.txt
@@ -89,8 +89,10 @@ set(SOURCES-DENSE-TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bml-dense single_real "${SOURCES-DENSE-TYPED}")
 bml_add_typed_library(bml-dense double_real "${SOURCES-DENSE-TYPED}")
-bml_add_typed_library(bml-dense single_complex "${SOURCES-DENSE-TYPED}")
-bml_add_typed_library(bml-dense double_complex "${SOURCES-DENSE-TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bml-dense single_complex "${SOURCES-DENSE-TYPED}")
+  bml_add_typed_library(bml-dense double_complex "${SOURCES-DENSE-TYPED}")
+endif()
 if(OPENMP_FOUND)
   set_target_properties(bml-dense-single_real
     PROPERTIES
@@ -98,10 +100,12 @@ if(OPENMP_FOUND)
   set_target_properties(bml-dense-double_real
     PROPERTIES
     COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-dense-single_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-dense-double_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  if(BML_COMPLEX)
+    set_target_properties(bml-dense-single_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    set_target_properties(bml-dense-double_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  endif()
 endif()

--- a/src/C-interface/dense/bml_add_dense.c
+++ b/src/C-interface/dense/bml_add_dense.c
@@ -33,12 +33,14 @@ bml_add_dense(
         case double_real:
             bml_add_dense_double_real(A, B, alpha, beta);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_dense_single_complex(A, B, alpha, beta);
             break;
         case double_complex:
             bml_add_dense_double_complex(A, B, alpha, beta);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -73,12 +75,14 @@ bml_add_norm_dense(
         case double_real:
             trnorm = bml_add_norm_dense_double_real(A, B, alpha, beta);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trnorm = bml_add_norm_dense_single_complex(A, B, alpha, beta);
             break;
         case double_complex:
             trnorm = bml_add_norm_dense_double_complex(A, B, alpha, beta);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -108,12 +112,14 @@ bml_add_identity_dense(
         case double_real:
             bml_add_identity_dense_double_real(A, beta);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_identity_dense_single_complex(A, beta);
             break;
         case double_complex:
             bml_add_identity_dense_double_complex(A, beta);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -144,12 +150,14 @@ bml_scale_add_identity_dense(
         case double_real:
             bml_scale_add_identity_dense_double_real(A, alpha, beta);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_add_identity_dense_single_complex(A, alpha, beta);
             break;
         case double_complex:
             bml_scale_add_identity_dense_double_complex(A, alpha, beta);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_adjungate_triangle_dense.c
+++ b/src/C-interface/dense/bml_adjungate_triangle_dense.c
@@ -33,12 +33,14 @@ bml_adjungate_triangle_dense(
         case double_real:
             bml_adjungate_triangle_dense_double_real(A, triangle);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_adjungate_triangle_dense_single_complex(A, triangle);
             break;
         case double_complex:
             bml_adjungate_triangle_dense_double_complex(A, triangle);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_allocate_dense.c
+++ b/src/C-interface/dense/bml_allocate_dense.c
@@ -68,12 +68,14 @@ bml_clear_dense(
         case double_real:
             return bml_clear_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_clear_dense_single_complex(A);
             break;
         case double_complex:
             return bml_clear_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision (%d)\n", A->matrix_precision);
             break;
@@ -110,6 +112,7 @@ bml_zero_matrix_dense(
             return bml_zero_matrix_dense_double_real(matrix_dimension,
                                                      distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_zero_matrix_dense_single_complex(matrix_dimension,
                                                         distrib_mode);
@@ -118,6 +121,7 @@ bml_zero_matrix_dense(
             return bml_zero_matrix_dense_double_complex(matrix_dimension,
                                                         distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision (%d)\n", matrix_precision);
             break;
@@ -155,12 +159,14 @@ bml_banded_matrix_dense(
         case double_real:
             return bml_banded_matrix_dense_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_banded_matrix_dense_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             return bml_banded_matrix_dense_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision (%d)\n", matrix_precision);
             break;
@@ -196,12 +202,14 @@ bml_random_matrix_dense(
         case double_real:
             return bml_random_matrix_dense_double_real(N, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_random_matrix_dense_single_complex(N, distrib_mode);
             break;
         case double_complex:
             return bml_random_matrix_dense_double_complex(N, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision (%d)\n", matrix_precision);
             break;
@@ -237,12 +245,14 @@ bml_identity_matrix_dense(
         case double_real:
             return bml_identity_matrix_dense_double_real(N, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_identity_matrix_dense_single_complex(N, distrib_mode);
             break;
         case double_complex:
             return bml_identity_matrix_dense_double_complex(N, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision (%d)\n", matrix_precision);
             break;

--- a/src/C-interface/dense/bml_convert_dense.c
+++ b/src/C-interface/dense/bml_convert_dense.c
@@ -19,6 +19,7 @@ bml_convert_dense(
             return bml_convert_dense_double_real(A, matrix_precision,
                                                  distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_convert_dense_single_complex(A, matrix_precision,
                                                     distrib_mode);
@@ -27,6 +28,7 @@ bml_convert_dense(
             return bml_convert_dense_double_complex(A, matrix_precision,
                                                     distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_copy_dense.c
+++ b/src/C-interface/dense/bml_copy_dense.c
@@ -31,12 +31,14 @@ bml_copy_dense_new(
         case double_real:
             B = bml_copy_dense_new_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_copy_dense_new_single_complex(A);
             break;
         case double_complex:
             B = bml_copy_dense_new_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -66,12 +68,14 @@ bml_copy_dense(
         case double_real:
             bml_copy_dense_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_copy_dense_single_complex(A, B);
             break;
         case double_complex:
             bml_copy_dense_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -98,12 +102,14 @@ bml_reorder_dense(
         case double_real:
             bml_reorder_dense_double_real(A, perm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_reorder_dense_single_complex(A, perm);
             break;
         case double_complex:
             bml_reorder_dense_double_complex(A, perm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_diagonalize_dense.c
+++ b/src/C-interface/dense/bml_diagonalize_dense.c
@@ -565,6 +565,7 @@ bml_diagonalize_dense(
         case double_real:
             bml_diagonalize_dense_double_real(A, eigenvalues, eigenvectors);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_diagonalize_dense_single_complex(A, eigenvalues,
                                                  eigenvectors);
@@ -573,6 +574,7 @@ bml_diagonalize_dense(
             bml_diagonalize_dense_double_complex(A, eigenvalues,
                                                  eigenvectors);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_element_multiply_dense.c
+++ b/src/C-interface/dense/bml_element_multiply_dense.c
@@ -31,12 +31,14 @@ bml_element_multiply_AB_dense(
         case double_real:
             bml_element_multiply_AB_dense_double_real(A, B, C);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_element_multiply_AB_dense_single_complex(A, B, C);
             break;
         case double_complex:
             bml_element_multiply_AB_dense_double_complex(A, B, C);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_export_dense.c
+++ b/src/C-interface/dense/bml_export_dense.c
@@ -32,12 +32,14 @@ bml_export_to_dense_dense(
         case double_real:
             return bml_export_to_dense_dense_double_real(A, order);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_export_to_dense_dense_single_complex(A, order);
             break;
         case double_complex:
             return bml_export_to_dense_dense_double_complex(A, order);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_getters_dense.c
+++ b/src/C-interface/dense/bml_getters_dense.c
@@ -17,12 +17,14 @@ bml_get_element_dense(
         case double_real:
             return bml_get_element_dense_double_real(A, i, j);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_element_dense_single_complex(A, i, j);
             break;
         case double_complex:
             return bml_get_element_dense_double_complex(A, i, j);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -43,12 +45,14 @@ bml_get_row_dense(
         case double_real:
             return bml_get_row_dense_double_real(A, i);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_row_dense_single_complex(A, i);
             break;
         case double_complex:
             return bml_get_row_dense_double_complex(A, i);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -68,12 +72,14 @@ bml_get_diagonal_dense(
         case double_real:
             return bml_get_diagonal_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_diagonal_dense_single_complex(A);
             break;
         case double_complex:
             return bml_get_diagonal_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_diagonal_dense\n");
             break;

--- a/src/C-interface/dense/bml_import_dense.c
+++ b/src/C-interface/dense/bml_import_dense.c
@@ -41,6 +41,7 @@ bml_import_from_dense_dense(
                 bml_import_from_dense_dense_double_real(order, N, A,
                                                         distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A_bml =
                 bml_import_from_dense_dense_single_complex(order, N, A,
@@ -51,6 +52,7 @@ bml_import_from_dense_dense(
                 bml_import_from_dense_dense_double_complex(order, N, A,
                                                            distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_introspection_dense.c
+++ b/src/C-interface/dense/bml_introspection_dense.c
@@ -98,6 +98,7 @@ bml_get_row_bandwidth_dense(
         case double_real:
             return bml_get_row_bandwidth_dense_double_real(A, i);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_row_bandwidth_dense_single_complex(A, i);
             break;
@@ -107,6 +108,7 @@ bml_get_row_bandwidth_dense(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;
@@ -131,6 +133,7 @@ bml_get_bandwidth_dense(
         case double_real:
             return bml_get_bandwidth_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_bandwidth_dense_single_complex(A);
             break;
@@ -140,6 +143,7 @@ bml_get_bandwidth_dense(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;
@@ -172,6 +176,7 @@ bml_get_sparsity_dense(
         case double_real:
             return bml_get_sparsity_dense_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_sparsity_dense_single_complex(A, threshold);
             break;
@@ -181,6 +186,7 @@ bml_get_sparsity_dense(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;

--- a/src/C-interface/dense/bml_inverse_dense.c
+++ b/src/C-interface/dense/bml_inverse_dense.c
@@ -29,12 +29,14 @@ bml_inverse_dense(
         case double_real:
             B = bml_inverse_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_inverse_dense_single_complex(A);
             break;
         case double_complex:
             B = bml_inverse_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_inverse_inplace_dense(
         case double_real:
             bml_inverse_inplace_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_inverse_inplace_dense_single_complex(A);
             break;
         case double_complex:
             bml_inverse_inplace_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_multiply_dense.c
+++ b/src/C-interface/dense/bml_multiply_dense.c
@@ -35,12 +35,14 @@ bml_multiply_dense(
         case double_real:
             bml_multiply_dense_double_real(A, B, C, alpha, beta);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_dense_single_complex(A, B, C, alpha, beta);
             break;
         case double_complex:
             bml_multiply_dense_double_complex(A, B, C, alpha, beta);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -69,12 +71,14 @@ bml_multiply_x2_dense(
         case double_real:
             return bml_multiply_x2_dense_double_real(X, X2);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_multiply_x2_dense_single_complex(X, X2);
             break;
         case double_complex:
             return bml_multiply_x2_dense_double_complex(X, X2);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -106,12 +110,14 @@ bml_multiply_AB_dense(
         case double_real:
             bml_multiply_AB_dense_double_real(A, B, C);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_AB_dense_single_complex(A, B, C);
             break;
         case double_complex:
             bml_multiply_AB_dense_double_complex(A, B, C);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -144,12 +150,14 @@ bml_multiply_adjust_AB_dense(
         case double_real:
             bml_multiply_AB_dense_double_real(A, B, C);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_AB_dense_single_complex(A, B, C);
             break;
         case double_complex:
             bml_multiply_AB_dense_double_complex(A, B, C);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_norm_dense.c
+++ b/src/C-interface/dense/bml_norm_dense.c
@@ -29,12 +29,14 @@ bml_sum_squares_dense(
         case double_real:
             return bml_sum_squares_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_dense_single_complex(A);
             break;
         case double_complex:
             return bml_sum_squares_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,6 +66,7 @@ bml_sum_squares_submatrix_dense(
         case double_real:
             return bml_sum_squares_submatrix_dense_double_real(A, core_size);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_submatrix_dense_single_complex(A,
                                                                   core_size);
@@ -72,6 +75,7 @@ bml_sum_squares_submatrix_dense(
             return bml_sum_squares_submatrix_dense_double_complex(A,
                                                                   core_size);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -105,12 +109,14 @@ bml_sum_AB_dense(
         case double_real:
             return bml_sum_AB_dense_double_real(A, B, alpha, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_AB_dense_single_complex(A, B, alpha, threshold);
             break;
         case double_complex:
             return bml_sum_AB_dense_double_complex(A, B, alpha, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -148,6 +154,7 @@ bml_sum_squares2_dense(
             return bml_sum_squares2_dense_double_real(A, B, alpha, beta,
                                                       threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares2_dense_single_complex(A, B, alpha, beta,
                                                          threshold);
@@ -156,6 +163,7 @@ bml_sum_squares2_dense(
             return bml_sum_squares2_dense_double_complex(A, B, alpha, beta,
                                                          threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -182,12 +190,14 @@ bml_fnorm_dense(
         case double_real:
             return bml_fnorm_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm_dense_single_complex(A);
             break;
         case double_complex:
             return bml_fnorm_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision");
             break;
@@ -216,12 +226,14 @@ bml_fnorm2_dense(
         case double_real:
             return bml_fnorm2_dense_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm2_dense_single_complex(A, B);
             break;
         case double_complex:
             return bml_fnorm2_dense_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision");
             break;

--- a/src/C-interface/dense/bml_normalize_dense.c
+++ b/src/C-interface/dense/bml_normalize_dense.c
@@ -23,12 +23,14 @@ bml_accumulate_offdiag_dense(
         case double_real:
             return bml_accumulate_offdiag_dense_double_real(A, flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_accumulate_offdiag_dense_single_complex(A, flag);
             break;
         case double_complex:
             return bml_accumulate_offdiag_dense_double_complex(A, flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -59,12 +61,14 @@ bml_normalize_dense(
         case double_real:
             bml_normalize_dense_double_real(A, mineval, maxeval);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_normalize_dense_single_complex(A, mineval, maxeval);
             break;
         case double_complex:
             bml_normalize_dense_double_complex(A, mineval, maxeval);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -93,12 +97,14 @@ bml_gershgorin_dense(
         case double_real:
             return bml_gershgorin_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_dense_single_complex(A);
             break;
         case double_complex:
             return bml_gershgorin_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -130,12 +136,14 @@ bml_gershgorin_partial_dense(
         case double_real:
             return bml_gershgorin_partial_dense_double_real(A, nrows);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_partial_dense_single_complex(A, nrows);
             break;
         case double_complex:
             return bml_gershgorin_partial_dense_double_complex(A, nrows);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_parallel_dense.c
+++ b/src/C-interface/dense/bml_parallel_dense.c
@@ -29,12 +29,14 @@ bml_allGatherVParallel_dense(
         case double_real:
             bml_allGatherVParallel_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_allGatherVParallel_dense_single_complex(A);
             break;
         case double_complex:
             bml_allGatherVParallel_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -56,12 +58,14 @@ bml_mpi_type_create_struct_dense(
         case double_real:
             bml_mpi_type_create_struct_dense_double_real(A, newtype);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_type_create_struct_dense_single_complex(A, newtype);
             break;
         case double_complex:
             bml_mpi_type_create_struct_dense_double_complex(A, newtype);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -82,12 +86,14 @@ bml_mpi_send_dense(
         case double_real:
             bml_mpi_send_dense_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_send_dense_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_send_dense_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -108,12 +114,14 @@ bml_mpi_recv_dense(
         case double_real:
             bml_mpi_recv_dense_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_recv_dense_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_recv_dense_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -134,12 +142,14 @@ bml_mpi_irecv_dense(
         case double_real:
             bml_mpi_irecv_dense_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_dense_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_irecv_dense_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -158,12 +168,14 @@ bml_mpi_irecv_complete_dense(
         case double_real:
             bml_mpi_irecv_complete_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_complete_dense_single_complex(A);
             break;
         case double_complex:
             bml_mpi_irecv_complete_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -186,12 +198,14 @@ bml_mpi_recv_matrix_dense(
         case double_real:
             return bml_mpi_recv_matrix_dense_double_real(N, M, src, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_recv_matrix_dense_single_complex(N, M, src, comm);
             break;
         case double_complex:
             return bml_mpi_recv_matrix_dense_double_complex(N, M, src, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -212,12 +226,14 @@ bml_mpi_bcast_matrix_dense(
         case double_real:
             return bml_mpi_bcast_matrix_dense_double_real(A, root, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_bcast_matrix_dense_single_complex(A, root, comm);
             break;
         case double_complex:
             return bml_mpi_bcast_matrix_dense_double_complex(A, root, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_scale_dense.c
+++ b/src/C-interface/dense/bml_scale_dense.c
@@ -35,12 +35,14 @@ bml_scale_dense_new(
         case double_real:
             B = bml_scale_dense_new_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_scale_dense_new_single_complex(scale_factor, A);
             break;
         case double_complex:
             B = bml_scale_dense_new_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -71,12 +73,14 @@ bml_scale_dense(
         case double_real:
             bml_scale_dense_double_real(scale_factor, A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_dense_single_complex(scale_factor, A, B);
             break;
         case double_complex:
             bml_scale_dense_double_complex(scale_factor, A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -96,12 +100,14 @@ bml_scale_inplace_dense(
         case double_real:
             bml_scale_inplace_dense_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_inplace_dense_single_complex(scale_factor, A);
             break;
         case double_complex:
             bml_scale_inplace_dense_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_setters_dense.c
+++ b/src/C-interface/dense/bml_setters_dense.c
@@ -18,12 +18,14 @@ bml_set_element_dense(
         case double_real:
             bml_set_element_dense_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_dense_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_dense_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision for bml_set_element_dense\n");
             break;
@@ -44,12 +46,14 @@ bml_set_row_dense(
         case double_real:
             bml_set_row_dense_double_real(A, i, row);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_row_dense_single_complex(A, i, row);
             break;
         case double_complex:
             bml_set_row_dense_double_complex(A, i, row);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -74,12 +78,14 @@ bml_set_diagonal_dense(
         case double_real:
             bml_set_diagonal_dense_double_real(A, diagonal);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_diagonal_dense_single_complex(A, diagonal);
             break;
         case double_complex:
             bml_set_diagonal_dense_double_complex(A, diagonal);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;

--- a/src/C-interface/dense/bml_submatrix_dense.c
+++ b/src/C-interface/dense/bml_submatrix_dense.c
@@ -35,6 +35,7 @@ bml_extract_submatrix_dense(
             return bml_extract_submatrix_dense_double_real(A, irow, icol,
                                                            B_N, B_M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_extract_submatrix_dense_single_complex(A, irow, icol,
                                                               B_N, B_M);
@@ -43,6 +44,7 @@ bml_extract_submatrix_dense(
             return bml_extract_submatrix_dense_double_complex(A, irow, icol,
                                                               B_N, B_M);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_assign_submatrix_dense(
         case double_real:
             bml_assign_submatrix_dense_double_real(A, B, irow, icol);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_assign_submatrix_dense_single_complex(A, B, irow, icol);
             break;
         case double_complex:
             bml_assign_submatrix_dense_double_complex(A, B, irow, icol);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_threshold_dense.c
+++ b/src/C-interface/dense/bml_threshold_dense.c
@@ -32,12 +32,14 @@ bml_threshold_new_dense(
         case double_real:
             return bml_threshold_new_dense_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_threshold_new_dense_single_complex(A, threshold);
             break;
         case double_complex:
             return bml_threshold_new_dense_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -66,12 +68,14 @@ bml_threshold_dense(
         case double_real:
             bml_threshold_dense_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_threshold_dense_single_complex(A, threshold);
             break;
         case double_complex:
             bml_threshold_dense_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_trace_dense.c
+++ b/src/C-interface/dense/bml_trace_dense.c
@@ -30,12 +30,14 @@ bml_trace_dense(
         case double_real:
             return bml_trace_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_trace_dense_single_complex(A);
             break;
         case double_complex:
             return bml_trace_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_trace_mult_dense(
         case double_real:
             return bml_trace_mult_dense_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_trace_mult_dense_single_complex(A, B);
             break;
         case double_complex:
             return bml_trace_mult_dense_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_transpose_dense.c
+++ b/src/C-interface/dense/bml_transpose_dense.c
@@ -30,12 +30,14 @@ bml_transpose_new_dense(
         case double_real:
             return bml_transpose_new_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_transpose_new_dense_single_complex(A);
             break;
         case double_complex:
             return bml_transpose_new_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -62,12 +64,14 @@ bml_transpose_dense(
         case double_real:
             bml_transpose_dense_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_transpose_dense_single_complex(A);
             break;
         case double_complex:
             bml_transpose_dense_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_transpose_triangle_dense.c
+++ b/src/C-interface/dense/bml_transpose_triangle_dense.c
@@ -32,12 +32,14 @@ bml_transpose_triangle_dense(
         case double_real:
             bml_transpose_triangle_dense_double_real(A, triangle);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_transpose_triangle_dense_single_complex(A, triangle);
             break;
         case double_complex:
             bml_transpose_triangle_dense_double_complex(A, triangle);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/dense/bml_utilities_dense.c
+++ b/src/C-interface/dense/bml_utilities_dense.c
@@ -16,12 +16,14 @@ bml_read_bml_matrix_dense(
         case double_real:
             bml_read_bml_matrix_dense_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_read_bml_matrix_dense_single_complex(A, filename);
             break;
         case double_complex:
             bml_read_bml_matrix_dense_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -41,12 +43,14 @@ bml_write_bml_matrix_dense(
         case double_real:
             bml_write_bml_matrix_dense_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_write_bml_matrix_dense_single_complex(A, filename);
             break;
         case double_complex:
             bml_write_bml_matrix_dense_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -69,12 +73,14 @@ bml_print_bml_matrix_dense(
         case double_real:
             bml_print_bml_matrix_dense_double_real(A, i_l, i_u, j_l, j_u);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_print_bml_matrix_dense_single_complex(A, i_l, i_u, j_l, j_u);
             break;
         case double_complex:
             bml_print_bml_matrix_dense_double_complex(A, i_l, i_u, j_l, j_u);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/distributed2d/CMakeLists.txt
+++ b/src/C-interface/distributed2d/CMakeLists.txt
@@ -62,8 +62,10 @@ set(SOURCES-DISTRIBUTED-TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bml-distributed2d single_real "${SOURCES-DISTRIBUTED-TYPED}")
 bml_add_typed_library(bml-distributed2d double_real "${SOURCES-DISTRIBUTED-TYPED}")
-bml_add_typed_library(bml-distributed2d single_complex "${SOURCES-DISTRIBUTED-TYPED}")
-bml_add_typed_library(bml-distributed2d double_complex "${SOURCES-DISTRIBUTED-TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bml-distributed2d single_complex "${SOURCES-DISTRIBUTED-TYPED}")
+  bml_add_typed_library(bml-distributed2d double_complex "${SOURCES-DISTRIBUTED-TYPED}")
+endif()
 if(OPENMP_FOUND)
   set_target_properties(bml-distributed2d-single_real
     PROPERTIES
@@ -71,10 +73,12 @@ if(OPENMP_FOUND)
   set_target_properties(bml-distributed2d-double_real
     PROPERTIES
     COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-distributed2d-single_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-distributed2d-double_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  if(BML_COMPLEX)
+    set_target_properties(bml-distributed2d-single_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    set_target_properties(bml-distributed2d-double_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  endif()
 endif()

--- a/src/C-interface/ellblock/CMakeLists.txt
+++ b/src/C-interface/ellblock/CMakeLists.txt
@@ -83,8 +83,10 @@ set(SOURCES-ELLBLOCK-TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bml-ellblock single_real "${SOURCES-ELLBLOCK-TYPED}")
 bml_add_typed_library(bml-ellblock double_real "${SOURCES-ELLBLOCK-TYPED}")
-bml_add_typed_library(bml-ellblock single_complex "${SOURCES-ELLBLOCK-TYPED}")
-bml_add_typed_library(bml-ellblock double_complex "${SOURCES-ELLBLOCK-TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bml-ellblock single_complex "${SOURCES-ELLBLOCK-TYPED}")
+  bml_add_typed_library(bml-ellblock double_complex "${SOURCES-ELLBLOCK-TYPED}")
+endif()
 if(OPENMP_FOUND)
   set_target_properties(bml-ellblock-single_real
     PROPERTIES
@@ -92,10 +94,12 @@ if(OPENMP_FOUND)
   set_target_properties(bml-ellblock-double_real
     PROPERTIES
     COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-ellblock-single_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-ellblock-double_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  if(BML_COMPLEX)
+    set_target_properties(bml-ellblock-single_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    set_target_properties(bml-ellblock-double_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  endif()
 endif()

--- a/src/C-interface/ellblock/bml_add_ellblock.c
+++ b/src/C-interface/ellblock/bml_add_ellblock.c
@@ -35,12 +35,14 @@ bml_add_ellblock(
         case double_real:
             bml_add_ellblock_double_real(A, B, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_ellblock_single_complex(A, B, alpha, beta, threshold);
             break;
         case double_complex:
             bml_add_ellblock_double_complex(A, B, alpha, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -81,6 +83,7 @@ bml_add_norm_ellblock(
                 bml_add_norm_ellblock_double_real(A, B, alpha, beta,
                                                   threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trnorm =
                 bml_add_norm_ellblock_single_complex(A, B, alpha, beta,
@@ -91,6 +94,7 @@ bml_add_norm_ellblock(
                 bml_add_norm_ellblock_double_complex(A, B, alpha, beta,
                                                      threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -122,12 +126,14 @@ bml_add_identity_ellblock(
         case double_real:
             bml_add_identity_ellblock_double_real(A, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_identity_ellblock_single_complex(A, beta, threshold);
             break;
         case double_complex:
             bml_add_identity_ellblock_double_complex(A, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -161,6 +167,7 @@ bml_scale_add_identity_ellblock(
             bml_scale_add_identity_ellblock_double_real(A, alpha, beta,
                                                         threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_add_identity_ellblock_single_complex(A, alpha, beta,
                                                            threshold);
@@ -169,6 +176,7 @@ bml_scale_add_identity_ellblock(
             bml_scale_add_identity_ellblock_double_complex(A, alpha, beta,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_allocate_ellblock.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock.c
@@ -157,12 +157,14 @@ bml_clear_ellblock(
         case double_real:
             bml_clear_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_clear_ellblock_single_complex(A);
             break;
         case double_complex:
             bml_clear_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -187,6 +189,7 @@ bml_noinit_matrix_ellblock(
             A = bml_noinit_matrix_ellblock_double_real(matrix_dimension,
                                                        distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_noinit_matrix_ellblock_single_complex(matrix_dimension,
                                                           distrib_mode);
@@ -195,6 +198,7 @@ bml_noinit_matrix_ellblock(
             A = bml_noinit_matrix_ellblock_double_complex(matrix_dimension,
                                                           distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -236,12 +240,14 @@ bml_zero_matrix_ellblock(
         case double_real:
             A = bml_zero_matrix_ellblock_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_zero_matrix_ellblock_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             A = bml_zero_matrix_ellblock_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -270,6 +276,7 @@ bml_block_matrix_ellblock(
             A = bml_block_matrix_ellblock_double_real(NB, MB, M, bsizes,
                                                       distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_block_matrix_ellblock_single_complex(NB, MB, M, bsizes,
                                                          distrib_mode);
@@ -278,6 +285,7 @@ bml_block_matrix_ellblock(
             A = bml_block_matrix_ellblock_double_complex(NB, MB, M, bsizes,
                                                          distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -315,6 +323,7 @@ bml_banded_matrix_ellblock(
         case double_real:
             return bml_banded_matrix_ellblock_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_banded_matrix_ellblock_single_complex(N, M,
                                                              distrib_mode);
@@ -323,6 +332,7 @@ bml_banded_matrix_ellblock(
             return bml_banded_matrix_ellblock_double_complex(N, M,
                                                              distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -360,6 +370,7 @@ bml_random_matrix_ellblock(
         case double_real:
             return bml_random_matrix_ellblock_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_random_matrix_ellblock_single_complex(N, M,
                                                              distrib_mode);
@@ -368,6 +379,7 @@ bml_random_matrix_ellblock(
             return bml_random_matrix_ellblock_double_complex(N, M,
                                                              distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -407,6 +419,7 @@ bml_identity_matrix_ellblock(
             return bml_identity_matrix_ellblock_double_real(N, M,
                                                             distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_identity_matrix_ellblock_single_complex(N, M,
                                                                distrib_mode);
@@ -415,6 +428,7 @@ bml_identity_matrix_ellblock(
             return bml_identity_matrix_ellblock_double_complex(N, M,
                                                                distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_convert_ellblock.c
+++ b/src/C-interface/ellblock/bml_convert_ellblock.c
@@ -20,6 +20,7 @@ bml_convert_ellblock(
             return bml_convert_ellblock_double_real(A, matrix_precision, M,
                                                     distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_convert_ellblock_single_complex(A, matrix_precision, M,
                                                        distrib_mode);
@@ -28,6 +29,7 @@ bml_convert_ellblock(
             return bml_convert_ellblock_double_complex(A, matrix_precision, M,
                                                        distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_copy_ellblock.c
+++ b/src/C-interface/ellblock/bml_copy_ellblock.c
@@ -30,12 +30,14 @@ bml_copy_ellblock_new(
         case double_real:
             B = bml_copy_ellblock_new_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_copy_ellblock_new_single_complex(A);
             break;
         case double_complex:
             B = bml_copy_ellblock_new_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,12 +66,14 @@ bml_copy_ellblock(
         case double_real:
             bml_copy_ellblock_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_copy_ellblock_single_complex(A, B);
             break;
         case double_complex:
             bml_copy_ellblock_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -97,12 +101,14 @@ bml_reorder_ellblock(
         case double_real:
             bml_reorder_ellblock_double_real(A, perm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_reorder_ellblock_single_complex(A, perm);
             break;
         case double_complex:
             bml_reorder_ellblock_double_complex(A, perm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_diagonalize_ellblock.c
+++ b/src/C-interface/ellblock/bml_diagonalize_ellblock.c
@@ -27,6 +27,7 @@ bml_diagonalize_ellblock(
             bml_diagonalize_ellblock_double_real(A, eigenvalues,
                                                  eigenvectors);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_diagonalize_ellblock_single_complex(A, eigenvalues,
                                                     eigenvectors);
@@ -35,6 +36,7 @@ bml_diagonalize_ellblock(
             bml_diagonalize_ellblock_double_complex(A, eigenvalues,
                                                     eigenvectors);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_export_ellblock.c
+++ b/src/C-interface/ellblock/bml_export_ellblock.c
@@ -28,12 +28,14 @@ bml_export_to_dense_ellblock(
         case double_real:
             return bml_export_to_dense_ellblock_double_real(A, order);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_export_to_dense_ellblock_single_complex(A, order);
             break;
         case double_complex:
             return bml_export_to_dense_ellblock_double_complex(A, order);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_getters_ellblock.c
+++ b/src/C-interface/ellblock/bml_getters_ellblock.c
@@ -17,12 +17,14 @@ bml_get_element_ellblock(
         case double_real:
             return bml_get_element_ellblock_double_real(A, i, j);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_element_ellblock_single_complex(A, i, j);
             break;
         case double_complex:
             return bml_get_element_ellblock_double_complex(A, i, j);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_element_ellblock\n");
             break;
@@ -43,12 +45,14 @@ bml_get_row_ellblock(
         case double_real:
             return bml_get_row_ellblock_double_real(A, i);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_row_ellblock_single_complex(A, i);
             break;
         case double_complex:
             return bml_get_row_ellblock_double_complex(A, i);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_row_ellblock\n");
             break;
@@ -68,12 +72,14 @@ bml_get_diagonal_ellblock(
         case double_real:
             return bml_get_diagonal_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_diagonal_ellblock_single_complex(A);
             break;
         case double_complex:
             return bml_get_diagonal_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_diagonal_ellblock\n");
             break;

--- a/src/C-interface/ellblock/bml_import_ellblock.c
+++ b/src/C-interface/ellblock/bml_import_ellblock.c
@@ -40,6 +40,7 @@ bml_import_from_dense_ellblock(
                                                               threshold, M,
                                                               distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_import_from_dense_ellblock_single_complex(order, N, A,
                                                                  threshold,
@@ -52,6 +53,7 @@ bml_import_from_dense_ellblock(
                                                                  M,
                                                                  distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_introspection_ellblock.c
+++ b/src/C-interface/ellblock/bml_introspection_ellblock.c
@@ -175,6 +175,7 @@ bml_get_sparsity_ellblock(
         case double_real:
             return bml_get_sparsity_ellblock_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_sparsity_ellblock_single_complex(A, threshold);
             break;
@@ -184,6 +185,7 @@ bml_get_sparsity_ellblock(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;

--- a/src/C-interface/ellblock/bml_inverse_ellblock.c
+++ b/src/C-interface/ellblock/bml_inverse_ellblock.c
@@ -25,12 +25,14 @@ bml_inverse_ellblock(
         case double_real:
             B = bml_inverse_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_inverse_ellblock_single_complex(A);
             break;
         case double_complex:
             B = bml_inverse_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_multiply_ellblock.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock.c
@@ -42,6 +42,7 @@ bml_multiply_ellblock(
             bml_multiply_ellblock_double_real(A, B, C, alpha, beta,
                                               threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_ellblock_single_complex(A, B, C, alpha, beta,
                                                  threshold);
@@ -50,6 +51,7 @@ bml_multiply_ellblock(
             bml_multiply_ellblock_double_complex(A, B, C, alpha, beta,
                                                  threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -80,12 +82,14 @@ bml_multiply_x2_ellblock(
         case double_real:
             return bml_multiply_x2_ellblock_double_real(X, X2, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_multiply_x2_ellblock_single_complex(X, X2, threshold);
             break;
         case double_complex:
             return bml_multiply_x2_ellblock_double_complex(X, X2, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -119,12 +123,14 @@ bml_multiply_AB_ellblock(
         case double_real:
             bml_multiply_AB_ellblock_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_AB_ellblock_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_AB_ellblock_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -157,6 +163,7 @@ bml_multiply_adjust_AB_ellblock(
         case double_real:
             bml_multiply_adjust_AB_ellblock_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_adjust_AB_ellblock_single_complex(A, B, C,
                                                            threshold);
@@ -165,6 +172,7 @@ bml_multiply_adjust_AB_ellblock(
             bml_multiply_adjust_AB_ellblock_double_complex(A, B, C,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_norm_ellblock.c
+++ b/src/C-interface/ellblock/bml_norm_ellblock.c
@@ -27,12 +27,14 @@ bml_sum_squares_ellblock(
         case double_real:
             return bml_sum_squares_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_ellblock_single_complex(A);
             break;
         case double_complex:
             return bml_sum_squares_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -66,12 +68,14 @@ bml_sum_AB_ellblock(
         case double_real:
             return bml_sum_AB_ellblock_double_real(A, B, alpha, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_AB_ellblock_single_complex(A, B, alpha, threshold);
             break;
         case double_complex:
             return bml_sum_AB_ellblock_double_complex(A, B, alpha, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -109,6 +113,7 @@ bml_sum_squares2_ellblock(
             return bml_sum_squares2_ellblock_double_real(A, B, alpha, beta,
                                                          threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares2_ellblock_single_complex(A, B, alpha, beta,
                                                             threshold);
@@ -117,6 +122,7 @@ bml_sum_squares2_ellblock(
             return bml_sum_squares2_ellblock_double_complex(A, B, alpha, beta,
                                                             threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -144,12 +150,14 @@ bml_fnorm_ellblock(
         case double_real:
             return bml_fnorm_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm_ellblock_single_complex(A);
             break;
         case double_complex:
             return bml_fnorm_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -179,12 +187,14 @@ bml_fnorm2_ellblock(
         case double_real:
             return bml_fnorm2_ellblock_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm2_ellblock_single_complex(A, B);
             break;
         case double_complex:
             return bml_fnorm2_ellblock_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_normalize_ellblock.c
+++ b/src/C-interface/ellblock/bml_normalize_ellblock.c
@@ -20,12 +20,14 @@ bml_accumulate_offdiag_ellblock(
         case double_real:
             return bml_accumulate_offdiag_ellblock_double_real(A, flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_accumulate_offdiag_ellblock_single_complex(A, flag);
             break;
         case double_complex:
             return bml_accumulate_offdiag_ellblock_double_complex(A, flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -54,12 +56,14 @@ bml_normalize_ellblock(
         case double_real:
             bml_normalize_ellblock_double_real(A, mineval, maxeval);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_normalize_ellblock_single_complex(A, mineval, maxeval);
             break;
         case double_complex:
             bml_normalize_ellblock_double_complex(A, mineval, maxeval);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -86,12 +90,14 @@ bml_gershgorin_ellblock(
         case double_real:
             return bml_gershgorin_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_ellblock_single_complex(A);
             break;
         case double_complex:
             return bml_gershgorin_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_parallel_ellblock.c
+++ b/src/C-interface/ellblock/bml_parallel_ellblock.c
@@ -22,12 +22,14 @@ bml_mpi_send_ellblock(
         case double_real:
             bml_mpi_send_ellblock_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_send_ellblock_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_send_ellblock_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -48,12 +50,14 @@ bml_mpi_recv_ellblock(
         case double_real:
             bml_mpi_recv_ellblock_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_recv_ellblock_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_recv_ellblock_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -74,12 +78,14 @@ bml_mpi_irecv_ellblock(
         case double_real:
             bml_mpi_irecv_ellblock_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_ellblock_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_irecv_ellblock_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -98,12 +104,14 @@ bml_mpi_irecv_complete_ellblock(
         case double_real:
             bml_mpi_irecv_complete_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_complete_ellblock_single_complex(A);
             break;
         case double_complex:
             bml_mpi_irecv_complete_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -126,6 +134,7 @@ bml_mpi_recv_matrix_ellblock(
         case double_real:
             return bml_mpi_recv_matrix_ellblock_double_real(N, M, src, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_recv_matrix_ellblock_single_complex(N, M, src,
                                                                comm);
@@ -134,6 +143,7 @@ bml_mpi_recv_matrix_ellblock(
             return bml_mpi_recv_matrix_ellblock_double_complex(N, M, src,
                                                                comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -154,6 +164,7 @@ bml_mpi_bcast_matrix_ellblock(
         case double_real:
             return bml_mpi_bcast_matrix_ellblock_double_real(A, root, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_bcast_matrix_ellblock_single_complex(A, root,
                                                                 comm);
@@ -162,6 +173,7 @@ bml_mpi_bcast_matrix_ellblock(
             return bml_mpi_bcast_matrix_ellblock_double_complex(A, root,
                                                                 comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_scale_ellblock.c
+++ b/src/C-interface/ellblock/bml_scale_ellblock.c
@@ -29,12 +29,14 @@ bml_scale_ellblock_new(
         case double_real:
             B = bml_scale_ellblock_new_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_scale_ellblock_new_single_complex(scale_factor, A);
             break;
         case double_complex:
             B = bml_scale_ellblock_new_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_scale_ellblock(
         case double_real:
             bml_scale_ellblock_double_real(scale_factor, A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_ellblock_single_complex(scale_factor, A, B);
             break;
         case double_complex:
             bml_scale_ellblock_double_complex(scale_factor, A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -88,12 +92,14 @@ bml_scale_inplace_ellblock(
         case double_real:
             bml_scale_inplace_ellblock_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_inplace_ellblock_single_complex(scale_factor, A);
             break;
         case double_complex:
             bml_scale_inplace_ellblock_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_setters_ellblock.c
+++ b/src/C-interface/ellblock/bml_setters_ellblock.c
@@ -19,12 +19,14 @@ bml_set_element_new_ellblock(
         case double_real:
             bml_set_element_new_ellblock_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_new_ellblock_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_new_ellblock_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_new_ellblock\n");
             break;
@@ -47,12 +49,14 @@ bml_set_element_ellblock(
         case double_real:
             bml_set_element_ellblock_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_ellblock_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_ellblock_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_ellblock\n");
             break;
@@ -74,12 +78,14 @@ bml_set_row_ellblock(
         case double_real:
             bml_set_row_ellblock_double_real(A, i, row, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_row_ellblock_single_complex(A, i, row, threshold);
             break;
         case double_complex:
             bml_set_row_ellblock_double_complex(A, i, row, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -100,12 +106,14 @@ bml_set_diagonal_ellblock(
         case double_real:
             bml_set_diagonal_ellblock_double_real(A, diagonal, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_diagonal_ellblock_single_complex(A, diagonal, threshold);
             break;
         case double_complex:
             bml_set_diagonal_ellblock_double_complex(A, diagonal, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -127,12 +135,14 @@ bml_set_block_ellblock(
         case double_real:
             bml_set_block_ellblock_double_real(A, ib, jb, values);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_block_ellblock_single_complex(A, ib, jb, values);
             break;
         case double_complex:
             bml_set_block_ellblock_double_complex(A, ib, jb, values);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;

--- a/src/C-interface/ellblock/bml_submatrix_ellblock.c
+++ b/src/C-interface/ellblock/bml_submatrix_ellblock.c
@@ -37,6 +37,7 @@ bml_extract_submatrix_ellblock(
             return bml_extract_submatrix_ellblock_double_real(A, irow, icol,
                                                               B_N, B_M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_extract_submatrix_ellblock_single_complex(A, irow,
                                                                  icol, B_N,
@@ -47,6 +48,7 @@ bml_extract_submatrix_ellblock(
                                                                  icol, B_N,
                                                                  B_M);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -69,12 +71,14 @@ bml_assign_submatrix_ellblock(
         case double_real:
             bml_assign_submatrix_ellblock_double_real(A, B, irow, icol);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_assign_submatrix_ellblock_single_complex(A, B, irow, icol);
             break;
         case double_complex:
             bml_assign_submatrix_ellblock_double_complex(A, B, irow, icol);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_threshold_ellblock.c
+++ b/src/C-interface/ellblock/bml_threshold_ellblock.c
@@ -28,12 +28,14 @@ bml_matrix_ellblock_t
         case double_real:
             B = bml_threshold_new_ellblock_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_threshold_new_ellblock_single_complex(A, threshold);
             break;
         case double_complex:
             B = bml_threshold_new_ellblock_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_threshold_ellblock(
         case double_real:
             bml_threshold_ellblock_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_threshold_ellblock_single_complex(A, threshold);
             break;
         case double_complex:
             bml_threshold_ellblock_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_trace_ellblock.c
+++ b/src/C-interface/ellblock/bml_trace_ellblock.c
@@ -28,12 +28,14 @@ bml_trace_ellblock(
         case double_real:
             trace = bml_trace_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_ellblock_single_complex(A);
             break;
         case double_complex:
             trace = bml_trace_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_trace_mult_ellblock(
         case double_real:
             trace = bml_trace_mult_ellblock_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_mult_ellblock_single_complex(A, B);
             break;
         case double_complex:
             trace = bml_trace_mult_ellblock_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_transpose_ellblock.c
+++ b/src/C-interface/ellblock/bml_transpose_ellblock.c
@@ -28,12 +28,14 @@ bml_transpose_new_ellblock(
         case double_real:
             B = bml_transpose_new_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_transpose_new_ellblock_single_complex(A);
             break;
         case double_complex:
             B = bml_transpose_new_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -61,12 +63,14 @@ bml_transpose_ellblock(
         case double_real:
             bml_transpose_ellblock_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_transpose_ellblock_single_complex(A);
             break;
         case double_complex:
             bml_transpose_ellblock_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellblock/bml_utilities_ellblock.c
+++ b/src/C-interface/ellblock/bml_utilities_ellblock.c
@@ -16,12 +16,14 @@ bml_read_bml_matrix_ellblock(
         case double_real:
             bml_read_bml_matrix_ellblock_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_read_bml_matrix_ellblock_single_complex(A, filename);
             break;
         case double_complex:
             bml_read_bml_matrix_ellblock_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -41,12 +43,14 @@ bml_write_bml_matrix_ellblock(
         case double_real:
             bml_write_bml_matrix_ellblock_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_write_bml_matrix_ellblock_single_complex(A, filename);
             break;
         case double_complex:
             bml_write_bml_matrix_ellblock_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/CMakeLists.txt
+++ b/src/C-interface/ellpack/CMakeLists.txt
@@ -87,8 +87,10 @@ set(SOURCES-ELLPACK-TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bml-ellpack single_real "${SOURCES-ELLPACK-TYPED}")
 bml_add_typed_library(bml-ellpack double_real "${SOURCES-ELLPACK-TYPED}")
-bml_add_typed_library(bml-ellpack single_complex "${SOURCES-ELLPACK-TYPED}")
-bml_add_typed_library(bml-ellpack double_complex "${SOURCES-ELLPACK-TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bml-ellpack single_complex "${SOURCES-ELLPACK-TYPED}")
+  bml_add_typed_library(bml-ellpack double_complex "${SOURCES-ELLPACK-TYPED}")
+endif()
 if(OPENMP_FOUND)
   set_target_properties(bml-ellpack-single_real
     PROPERTIES
@@ -96,10 +98,12 @@ if(OPENMP_FOUND)
   set_target_properties(bml-ellpack-double_real
     PROPERTIES
     COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-ellpack-single_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-ellpack-double_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  if(BML_COMPLEX)
+    set_target_properties(bml-ellpack-single_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    set_target_properties(bml-ellpack-double_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  endif()
 endif()

--- a/src/C-interface/ellpack/bml_add_ellpack.c
+++ b/src/C-interface/ellpack/bml_add_ellpack.c
@@ -35,12 +35,14 @@ bml_add_ellpack(
         case double_real:
             bml_add_ellpack_double_real(A, B, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_ellpack_single_complex(A, B, alpha, beta, threshold);
             break;
         case double_complex:
             bml_add_ellpack_double_complex(A, B, alpha, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -81,6 +83,7 @@ bml_add_norm_ellpack(
                 bml_add_norm_ellpack_double_real(A, B, alpha, beta,
                                                  threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trnorm =
                 bml_add_norm_ellpack_single_complex(A, B, alpha, beta,
@@ -91,6 +94,7 @@ bml_add_norm_ellpack(
                 bml_add_norm_ellpack_double_complex(A, B, alpha, beta,
                                                     threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -122,12 +126,14 @@ bml_add_identity_ellpack(
         case double_real:
             bml_add_identity_ellpack_double_real(A, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_identity_ellpack_single_complex(A, beta, threshold);
             break;
         case double_complex:
             bml_add_identity_ellpack_double_complex(A, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -161,6 +167,7 @@ bml_scale_add_identity_ellpack(
             bml_scale_add_identity_ellpack_double_real(A, alpha, beta,
                                                        threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_add_identity_ellpack_single_complex(A, alpha, beta,
                                                           threshold);
@@ -169,6 +176,7 @@ bml_scale_add_identity_ellpack(
             bml_scale_add_identity_ellpack_double_complex(A, alpha, beta,
                                                           threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_adjungate_triangle_ellpack.c
+++ b/src/C-interface/ellpack/bml_adjungate_triangle_ellpack.c
@@ -27,12 +27,14 @@ bml_adjungate_triangle_ellpack(
         case double_real:
             bml_adjungate_triangle_ellpack_double_real(A, triangle);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_adjungate_triangle_ellpack_single_complex(A, triangle);
             break;
         case double_complex:
             bml_adjungate_triangle_ellpack_double_complex(A, triangle);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision for bml_adjungate_triangle\n");
             break;

--- a/src/C-interface/ellpack/bml_allocate_ellpack.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack.c
@@ -25,12 +25,14 @@ bml_deallocate_ellpack(
         case double_real:
             bml_deallocate_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_deallocate_ellpack_single_complex(A);
             break;
         case double_complex:
             bml_deallocate_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -55,12 +57,14 @@ bml_clear_ellpack(
         case double_real:
             bml_clear_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_clear_ellpack_single_complex(A);
             break;
         case double_complex:
             bml_clear_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -99,6 +103,7 @@ bml_noinit_matrix_ellpack(
             A = bml_noinit_matrix_ellpack_double_real(matrix_dimension,
                                                       distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_noinit_matrix_ellpack_single_complex(matrix_dimension,
                                                          distrib_mode);
@@ -107,6 +112,7 @@ bml_noinit_matrix_ellpack(
             A = bml_noinit_matrix_ellpack_double_complex(matrix_dimension,
                                                          distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -146,12 +152,14 @@ bml_zero_matrix_ellpack(
         case double_real:
             A = bml_zero_matrix_ellpack_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_zero_matrix_ellpack_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             A = bml_zero_matrix_ellpack_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -189,6 +197,7 @@ bml_banded_matrix_ellpack(
         case double_real:
             return bml_banded_matrix_ellpack_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_banded_matrix_ellpack_single_complex(N, M,
                                                             distrib_mode);
@@ -197,6 +206,7 @@ bml_banded_matrix_ellpack(
             return bml_banded_matrix_ellpack_double_complex(N, M,
                                                             distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -234,6 +244,7 @@ bml_random_matrix_ellpack(
         case double_real:
             return bml_random_matrix_ellpack_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_random_matrix_ellpack_single_complex(N, M,
                                                             distrib_mode);
@@ -242,6 +253,7 @@ bml_random_matrix_ellpack(
             return bml_random_matrix_ellpack_double_complex(N, M,
                                                             distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -281,6 +293,7 @@ bml_identity_matrix_ellpack(
             return bml_identity_matrix_ellpack_double_real(N, M,
                                                            distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_identity_matrix_ellpack_single_complex(N, M,
                                                               distrib_mode);
@@ -289,6 +302,7 @@ bml_identity_matrix_ellpack(
             return bml_identity_matrix_ellpack_double_complex(N, M,
                                                               distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_convert_ellpack.c
+++ b/src/C-interface/ellpack/bml_convert_ellpack.c
@@ -20,6 +20,7 @@ bml_convert_ellpack(
             return bml_convert_ellpack_double_real(A, matrix_precision, M,
                                                    distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_convert_ellpack_single_complex(A, matrix_precision, M,
                                                       distrib_mode);
@@ -28,6 +29,7 @@ bml_convert_ellpack(
             return bml_convert_ellpack_double_complex(A, matrix_precision, M,
                                                       distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_copy_ellpack.c
+++ b/src/C-interface/ellpack/bml_copy_ellpack.c
@@ -30,12 +30,14 @@ bml_copy_ellpack_new(
         case double_real:
             B = bml_copy_ellpack_new_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_copy_ellpack_new_single_complex(A);
             break;
         case double_complex:
             B = bml_copy_ellpack_new_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,12 +66,14 @@ bml_copy_ellpack(
         case double_real:
             bml_copy_ellpack_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_copy_ellpack_single_complex(A, B);
             break;
         case double_complex:
             bml_copy_ellpack_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -97,12 +101,14 @@ bml_reorder_ellpack(
         case double_real:
             bml_reorder_ellpack_double_real(A, perm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_reorder_ellpack_single_complex(A, perm);
             break;
         case double_complex:
             bml_reorder_ellpack_double_complex(A, perm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_diagonalize_ellpack.c
+++ b/src/C-interface/ellpack/bml_diagonalize_ellpack.c
@@ -25,6 +25,7 @@ bml_diagonalize_ellpack(
         case double_real:
             bml_diagonalize_ellpack_double_real(A, eigenvalues, eigenvectors);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_diagonalize_ellpack_single_complex(A, eigenvalues,
                                                    eigenvectors);
@@ -33,6 +34,7 @@ bml_diagonalize_ellpack(
             bml_diagonalize_ellpack_double_complex(A, eigenvalues,
                                                    eigenvectors);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_element_multiply_ellpack.c
+++ b/src/C-interface/ellpack/bml_element_multiply_ellpack.c
@@ -36,6 +36,7 @@ bml_element_multiply_AB_ellpack(
         case double_real:
             bml_element_multiply_AB_ellpack_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_element_multiply_AB_ellpack_single_complex(A, B, C,
                                                            threshold);
@@ -44,6 +45,7 @@ bml_element_multiply_AB_ellpack(
             bml_element_multiply_AB_ellpack_double_complex(A, B, C,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_export_ellpack.c
+++ b/src/C-interface/ellpack/bml_export_ellpack.c
@@ -28,12 +28,14 @@ bml_export_to_dense_ellpack(
         case double_real:
             return bml_export_to_dense_ellpack_double_real(A, order);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_export_to_dense_ellpack_single_complex(A, order);
             break;
         case double_complex:
             return bml_export_to_dense_ellpack_double_complex(A, order);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_getters_ellpack.c
+++ b/src/C-interface/ellpack/bml_getters_ellpack.c
@@ -17,12 +17,14 @@ bml_get_element_ellpack(
         case double_real:
             return bml_get_element_ellpack_double_real(A, i, j);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_element_ellpack_single_complex(A, i, j);
             break;
         case double_complex:
             return bml_get_element_ellpack_double_complex(A, i, j);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_element_ellpack\n");
             break;
@@ -43,12 +45,14 @@ bml_get_row_ellpack(
         case double_real:
             return bml_get_row_ellpack_double_real(A, i);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_row_ellpack_single_complex(A, i);
             break;
         case double_complex:
             return bml_get_row_ellpack_double_complex(A, i);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_row_ellpack\n");
             break;
@@ -68,12 +72,14 @@ bml_get_diagonal_ellpack(
         case double_real:
             return bml_get_diagonal_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_diagonal_ellpack_single_complex(A);
             break;
         case double_complex:
             return bml_get_diagonal_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_diagonal_ellpack\n");
             break;

--- a/src/C-interface/ellpack/bml_import_ellpack.c
+++ b/src/C-interface/ellpack/bml_import_ellpack.c
@@ -40,6 +40,7 @@ bml_import_from_dense_ellpack(
                                                              threshold, M,
                                                              distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_import_from_dense_ellpack_single_complex(order, N, A,
                                                                 threshold,
@@ -52,6 +53,7 @@ bml_import_from_dense_ellpack(
                                                                 M,
                                                                 distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_introspection_ellpack.c
+++ b/src/C-interface/ellpack/bml_introspection_ellpack.c
@@ -145,6 +145,7 @@ bml_get_sparsity_ellpack(
         case double_real:
             return bml_get_sparsity_ellpack_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_sparsity_ellpack_single_complex(A, threshold);
             break;
@@ -154,6 +155,7 @@ bml_get_sparsity_ellpack(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;

--- a/src/C-interface/ellpack/bml_inverse_ellpack.c
+++ b/src/C-interface/ellpack/bml_inverse_ellpack.c
@@ -25,12 +25,14 @@ bml_inverse_ellpack(
         case double_real:
             B = bml_inverse_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_inverse_ellpack_single_complex(A);
             break;
         case double_complex:
             B = bml_inverse_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_multiply_ellpack.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack.c
@@ -40,6 +40,7 @@ bml_multiply_ellpack(
         case double_real:
             bml_multiply_ellpack_double_real(A, B, C, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_ellpack_single_complex(A, B, C, alpha, beta,
                                                 threshold);
@@ -48,6 +49,7 @@ bml_multiply_ellpack(
             bml_multiply_ellpack_double_complex(A, B, C, alpha, beta,
                                                 threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -78,12 +80,14 @@ bml_multiply_x2_ellpack(
         case double_real:
             return bml_multiply_x2_ellpack_double_real(X, X2, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_multiply_x2_ellpack_single_complex(X, X2, threshold);
             break;
         case double_complex:
             return bml_multiply_x2_ellpack_double_complex(X, X2, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -117,12 +121,14 @@ bml_multiply_AB_ellpack(
         case double_real:
             bml_multiply_AB_ellpack_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_AB_ellpack_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_AB_ellpack_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -155,12 +161,14 @@ bml_multiply_adjust_AB_ellpack(
         case double_real:
             bml_multiply_adjust_AB_ellpack_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_adjust_AB_ellpack_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_adjust_AB_ellpack_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_norm_ellpack.c
+++ b/src/C-interface/ellpack/bml_norm_ellpack.c
@@ -27,12 +27,14 @@ bml_sum_squares_ellpack(
         case double_real:
             return bml_sum_squares_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_ellpack_single_complex(A);
             break;
         case double_complex:
             return bml_sum_squares_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,6 +66,7 @@ bml_sum_squares_submatrix_ellpack(
             return bml_sum_squares_submatrix_ellpack_double_real(A,
                                                                  core_size);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_submatrix_ellpack_single_complex(A,
                                                                     core_size);
@@ -72,6 +75,7 @@ bml_sum_squares_submatrix_ellpack(
             return bml_sum_squares_submatrix_ellpack_double_complex(A,
                                                                     core_size);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -105,12 +109,14 @@ bml_sum_AB_ellpack(
         case double_real:
             return bml_sum_AB_ellpack_double_real(A, B, alpha, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_AB_ellpack_single_complex(A, B, alpha, threshold);
             break;
         case double_complex:
             return bml_sum_AB_ellpack_double_complex(A, B, alpha, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -149,6 +155,7 @@ bml_sum_squares2_ellpack(
             return bml_sum_squares2_ellpack_double_real(A, B, alpha, beta,
                                                         threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares2_ellpack_single_complex(A, B, alpha, beta,
                                                            threshold);
@@ -157,6 +164,7 @@ bml_sum_squares2_ellpack(
             return bml_sum_squares2_ellpack_double_complex(A, B, alpha, beta,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -184,12 +192,14 @@ bml_fnorm_ellpack(
         case double_real:
             return bml_fnorm_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm_ellpack_single_complex(A);
             break;
         case double_complex:
             return bml_fnorm_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -219,12 +229,14 @@ bml_fnorm2_ellpack(
         case double_real:
             return bml_fnorm2_ellpack_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm2_ellpack_single_complex(A, B);
             break;
         case double_complex:
             return bml_fnorm2_ellpack_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_normalize_ellpack.c
+++ b/src/C-interface/ellpack/bml_normalize_ellpack.c
@@ -20,12 +20,14 @@ bml_accumulate_offdiag_ellpack(
         case double_real:
             return bml_accumulate_offdiag_ellpack_double_real(A, flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_accumulate_offdiag_ellpack_single_complex(A, flag);
             break;
         case double_complex:
             return bml_accumulate_offdiag_ellpack_double_complex(A, flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -55,12 +57,14 @@ bml_normalize_ellpack(
         case double_real:
             bml_normalize_ellpack_double_real(A, mineval, maxeval);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_normalize_ellpack_single_complex(A, mineval, maxeval);
             break;
         case double_complex:
             bml_normalize_ellpack_double_complex(A, mineval, maxeval);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -87,12 +91,14 @@ bml_gershgorin_ellpack(
         case double_real:
             return bml_gershgorin_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_ellpack_single_complex(A);
             break;
         case double_complex:
             return bml_gershgorin_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -122,12 +128,14 @@ bml_gershgorin_partial_ellpack(
         case double_real:
             return bml_gershgorin_partial_ellpack_double_real(A, nrows);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_partial_ellpack_single_complex(A, nrows);
             break;
         case double_complex:
             return bml_gershgorin_partial_ellpack_double_complex(A, nrows);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_parallel_ellpack.c
+++ b/src/C-interface/ellpack/bml_parallel_ellpack.c
@@ -26,12 +26,14 @@ bml_allGatherVParallel_ellpack(
         case double_real:
             bml_allGatherVParallel_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_allGatherVParallel_ellpack_single_complex(A);
             break;
         case double_complex:
             bml_allGatherVParallel_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -53,12 +55,14 @@ bml_mpi_type_create_struct_ellpack(
         case double_real:
             bml_mpi_type_create_struct_ellpack_double_real(A, newtype);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_type_create_struct_ellpack_single_complex(A, newtype);
             break;
         case double_complex:
             bml_mpi_type_create_struct_ellpack_double_complex(A, newtype);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -79,12 +83,14 @@ bml_mpi_send_ellpack(
         case double_real:
             bml_mpi_send_ellpack_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_send_ellpack_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_send_ellpack_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -105,12 +111,14 @@ bml_mpi_recv_ellpack(
         case double_real:
             bml_mpi_recv_ellpack_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_recv_ellpack_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_recv_ellpack_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -131,12 +139,14 @@ bml_mpi_irecv_ellpack(
         case double_real:
             bml_mpi_irecv_ellpack_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_ellpack_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_irecv_ellpack_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -155,12 +165,14 @@ bml_mpi_irecv_complete_ellpack(
         case double_real:
             bml_mpi_irecv_complete_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_complete_ellpack_single_complex(A);
             break;
         case double_complex:
             bml_mpi_irecv_complete_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -183,6 +195,7 @@ bml_mpi_recv_matrix_ellpack(
         case double_real:
             return bml_mpi_recv_matrix_ellpack_double_real(N, M, src, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_recv_matrix_ellpack_single_complex(N, M, src,
                                                               comm);
@@ -191,6 +204,7 @@ bml_mpi_recv_matrix_ellpack(
             return bml_mpi_recv_matrix_ellpack_double_complex(N, M, src,
                                                               comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_scale_ellpack.c
+++ b/src/C-interface/ellpack/bml_scale_ellpack.c
@@ -29,12 +29,14 @@ bml_scale_ellpack_new(
         case double_real:
             B = bml_scale_ellpack_new_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_scale_ellpack_new_single_complex(scale_factor, A);
             break;
         case double_complex:
             B = bml_scale_ellpack_new_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_scale_ellpack(
         case double_real:
             bml_scale_ellpack_double_real(scale_factor, A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_ellpack_single_complex(scale_factor, A, B);
             break;
         case double_complex:
             bml_scale_ellpack_double_complex(scale_factor, A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -88,12 +92,14 @@ bml_scale_inplace_ellpack(
         case double_real:
             bml_scale_inplace_ellpack_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_inplace_ellpack_single_complex(scale_factor, A);
             break;
         case double_complex:
             bml_scale_inplace_ellpack_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_setters_ellpack.c
+++ b/src/C-interface/ellpack/bml_setters_ellpack.c
@@ -19,12 +19,14 @@ bml_set_element_new_ellpack(
         case double_real:
             bml_set_element_new_ellpack_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_new_ellpack_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_new_ellpack_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_new_ellpack\n");
             break;
@@ -47,12 +49,14 @@ bml_set_element_ellpack(
         case double_real:
             bml_set_element_ellpack_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_ellpack_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_ellpack_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_ellpack\n");
             break;
@@ -74,12 +78,14 @@ bml_set_row_ellpack(
         case double_real:
             bml_set_row_ellpack_double_real(A, i, row, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_row_ellpack_single_complex(A, i, row, threshold);
             break;
         case double_complex:
             bml_set_row_ellpack_double_complex(A, i, row, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -100,12 +106,14 @@ bml_set_diagonal_ellpack(
         case double_real:
             bml_set_diagonal_ellpack_double_real(A, diagonal, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_diagonal_ellpack_single_complex(A, diagonal, threshold);
             break;
         case double_complex:
             bml_set_diagonal_ellpack_double_complex(A, diagonal, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;

--- a/src/C-interface/ellpack/bml_submatrix_ellpack.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack.c
@@ -53,6 +53,7 @@ bml_matrix2submatrix_index_ellpack(
                                                            vsize,
                                                            double_jump_flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_matrix2submatrix_index_ellpack_single_complex(A, B, nodelist,
                                                               nsize,
@@ -67,6 +68,7 @@ bml_matrix2submatrix_index_ellpack(
                                                               vsize,
                                                               double_jump_flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -109,6 +111,7 @@ bml_matrix2submatrix_index_graph_ellpack(
                                                                  vsize,
                                                                  double_jump_flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_matrix2submatrix_index_graph_ellpack_double_complex(B,
                                                                     nodelist,
@@ -125,6 +128,7 @@ bml_matrix2submatrix_index_graph_ellpack(
                                                                     vsize,
                                                                     double_jump_flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -157,6 +161,7 @@ bml_matrix2submatrix_ellpack(
             bml_matrix2submatrix_ellpack_double_real(A, B, core_halo_index,
                                                      lsize);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_matrix2submatrix_ellpack_single_complex(A, B, core_halo_index,
                                                         lsize);
@@ -165,6 +170,7 @@ bml_matrix2submatrix_ellpack(
             bml_matrix2submatrix_ellpack_double_complex(A, B, core_halo_index,
                                                         lsize);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -203,6 +209,7 @@ bml_submatrix2matrix_ellpack(
                                                      lsize, llsize,
                                                      threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_submatrix2matrix_ellpack_single_complex(A, B, core_halo_index,
                                                         lsize,
@@ -213,6 +220,7 @@ bml_submatrix2matrix_ellpack(
                                                         lsize,
                                                         llsize, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -244,12 +252,14 @@ bml_getVector_ellpack(
         case double_real:
             return bml_getVector_ellpack_double_real(A, jj, irow, colCnt);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_getVector_ellpack_single_complex(A, jj, irow, colCnt);
             break;
         case double_complex:
             return bml_getVector_ellpack_double_complex(A, jj, irow, colCnt);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -283,6 +293,7 @@ bml_group_matrix_ellpack(
             return bml_group_matrix_ellpack_double_real(A, hindex, ngroups,
                                                         threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_group_matrix_ellpack_single_complex(A, hindex, ngroups,
                                                            threshold);
@@ -291,6 +302,7 @@ bml_group_matrix_ellpack(
             return bml_group_matrix_ellpack_double_complex(A, hindex, ngroups,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -527,6 +539,7 @@ bml_extract_submatrix_ellpack(
             return bml_extract_submatrix_ellpack_double_real(A, irow, icol,
                                                              B_N, B_M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_extract_submatrix_ellpack_single_complex(A, irow, icol,
                                                                 B_N, B_M);
@@ -535,6 +548,7 @@ bml_extract_submatrix_ellpack(
             return bml_extract_submatrix_ellpack_double_complex(A, irow, icol,
                                                                 B_N, B_M);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -557,12 +571,14 @@ bml_assign_submatrix_ellpack(
         case double_real:
             bml_assign_submatrix_ellpack_double_real(A, B, irow, icol);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_assign_submatrix_ellpack_single_complex(A, B, irow, icol);
             break;
         case double_complex:
             bml_assign_submatrix_ellpack_double_complex(A, B, irow, icol);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_threshold_ellpack.c
+++ b/src/C-interface/ellpack/bml_threshold_ellpack.c
@@ -28,12 +28,14 @@ bml_matrix_ellpack_t
         case double_real:
             B = bml_threshold_new_ellpack_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_threshold_new_ellpack_single_complex(A, threshold);
             break;
         case double_complex:
             B = bml_threshold_new_ellpack_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_threshold_ellpack(
         case double_real:
             bml_threshold_ellpack_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_threshold_ellpack_single_complex(A, threshold);
             break;
         case double_complex:
             bml_threshold_ellpack_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_trace_ellpack.c
+++ b/src/C-interface/ellpack/bml_trace_ellpack.c
@@ -28,12 +28,14 @@ bml_trace_ellpack(
         case double_real:
             trace = bml_trace_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_ellpack_single_complex(A);
             break;
         case double_complex:
             trace = bml_trace_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_trace_mult_ellpack(
         case double_real:
             trace = bml_trace_mult_ellpack_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_mult_ellpack_single_complex(A, B);
             break;
         case double_complex:
             trace = bml_trace_mult_ellpack_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_transpose_ellpack.c
+++ b/src/C-interface/ellpack/bml_transpose_ellpack.c
@@ -28,12 +28,14 @@ bml_transpose_new_ellpack(
         case double_real:
             B = bml_transpose_new_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_transpose_new_ellpack_single_complex(A);
             break;
         case double_complex:
             B = bml_transpose_new_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -61,12 +63,14 @@ bml_transpose_ellpack(
         case double_real:
             bml_transpose_ellpack_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_transpose_ellpack_single_complex(A);
             break;
         case double_complex:
             bml_transpose_ellpack_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellpack/bml_utilities_ellpack.c
+++ b/src/C-interface/ellpack/bml_utilities_ellpack.c
@@ -16,12 +16,14 @@ bml_read_bml_matrix_ellpack(
         case double_real:
             bml_read_bml_matrix_ellpack_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_read_bml_matrix_ellpack_single_complex(A, filename);
             break;
         case double_complex:
             bml_read_bml_matrix_ellpack_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -41,12 +43,14 @@ bml_write_bml_matrix_ellpack(
         case double_real:
             bml_write_bml_matrix_ellpack_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_write_bml_matrix_ellpack_single_complex(A, filename);
             break;
         case double_complex:
             bml_write_bml_matrix_ellpack_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/CMakeLists.txt
+++ b/src/C-interface/ellsort/CMakeLists.txt
@@ -81,8 +81,10 @@ set(SOURCES-ELLSORT-TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bml-ellsort single_real "${SOURCES-ELLSORT-TYPED}")
 bml_add_typed_library(bml-ellsort double_real "${SOURCES-ELLSORT-TYPED}")
-bml_add_typed_library(bml-ellsort single_complex "${SOURCES-ELLSORT-TYPED}")
-bml_add_typed_library(bml-ellsort double_complex "${SOURCES-ELLSORT-TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bml-ellsort single_complex "${SOURCES-ELLSORT-TYPED}")
+  bml_add_typed_library(bml-ellsort double_complex "${SOURCES-ELLSORT-TYPED}")
+endif()
 if(OPENMP_FOUND)
   set_target_properties(bml-ellsort-single_real
     PROPERTIES
@@ -90,10 +92,12 @@ if(OPENMP_FOUND)
   set_target_properties(bml-ellsort-double_real
     PROPERTIES
     COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-ellsort-single_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
-  set_target_properties(bml-ellsort-double_complex
-    PROPERTIES
-    COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  if(BML_COMPLEX)
+    set_target_properties(bml-ellsort-single_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+    set_target_properties(bml-ellsort-double_complex
+      PROPERTIES
+      COMPILE_FLAGS ${OpenMP_C_FLAGS})
+  endif()
 endif()

--- a/src/C-interface/ellsort/bml_add_ellsort.c
+++ b/src/C-interface/ellsort/bml_add_ellsort.c
@@ -35,12 +35,14 @@ bml_add_ellsort(
         case double_real:
             bml_add_ellsort_double_real(A, B, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_ellsort_single_complex(A, B, alpha, beta, threshold);
             break;
         case double_complex:
             bml_add_ellsort_double_complex(A, B, alpha, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -81,6 +83,7 @@ bml_add_norm_ellsort(
                 bml_add_norm_ellsort_double_real(A, B, alpha, beta,
                                                  threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trnorm =
                 bml_add_norm_ellsort_single_complex(A, B, alpha, beta,
@@ -91,6 +94,7 @@ bml_add_norm_ellsort(
                 bml_add_norm_ellsort_double_complex(A, B, alpha, beta,
                                                     threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -122,12 +126,14 @@ bml_add_identity_ellsort(
         case double_real:
             bml_add_identity_ellsort_double_real(A, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_add_identity_ellsort_single_complex(A, beta, threshold);
             break;
         case double_complex:
             bml_add_identity_ellsort_double_complex(A, beta, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -161,6 +167,7 @@ bml_scale_add_identity_ellsort(
             bml_scale_add_identity_ellsort_double_real(A, alpha, beta,
                                                        threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_add_identity_ellsort_single_complex(A, alpha, beta,
                                                           threshold);
@@ -169,6 +176,7 @@ bml_scale_add_identity_ellsort(
             bml_scale_add_identity_ellsort_double_complex(A, alpha, beta,
                                                           threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_adjungate_triangle_ellsort.c
+++ b/src/C-interface/ellsort/bml_adjungate_triangle_ellsort.c
@@ -25,12 +25,14 @@ bml_adjungate_triangle_ellsort(
         case double_real:
             bml_adjungate_triangle_ellsort_double_real(A, triangle);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_adjungate_triangle_ellsort_single_complex(A, triangle);
             break;
         case double_complex:
             bml_adjungate_triangle_ellsort_double_complex(A, triangle);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision for bml_adjungate_triangle\n");
             break;

--- a/src/C-interface/ellsort/bml_allocate_ellsort.c
+++ b/src/C-interface/ellsort/bml_allocate_ellsort.c
@@ -43,12 +43,14 @@ bml_clear_ellsort(
         case double_real:
             bml_clear_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_clear_ellsort_single_complex(A);
             break;
         case double_complex:
             bml_clear_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -87,6 +89,7 @@ bml_noinit_matrix_ellsort(
             A = bml_noinit_matrix_ellsort_double_real(matrix_dimension,
                                                       distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_noinit_matrix_ellsort_single_complex(matrix_dimension,
                                                          distrib_mode);
@@ -95,6 +98,7 @@ bml_noinit_matrix_ellsort(
             A = bml_noinit_matrix_ellsort_double_complex(matrix_dimension,
                                                          distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -134,12 +138,14 @@ bml_zero_matrix_ellsort(
         case double_real:
             A = bml_zero_matrix_ellsort_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A = bml_zero_matrix_ellsort_single_complex(N, M, distrib_mode);
             break;
         case double_complex:
             A = bml_zero_matrix_ellsort_double_complex(N, M, distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -177,6 +183,7 @@ bml_banded_matrix_ellsort(
         case double_real:
             return bml_banded_matrix_ellsort_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_banded_matrix_ellsort_single_complex(N, M,
                                                             distrib_mode);
@@ -185,6 +192,7 @@ bml_banded_matrix_ellsort(
             return bml_banded_matrix_ellsort_double_complex(N, M,
                                                             distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -222,6 +230,7 @@ bml_random_matrix_ellsort(
         case double_real:
             return bml_random_matrix_ellsort_double_real(N, M, distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_random_matrix_ellsort_single_complex(N, M,
                                                             distrib_mode);
@@ -230,6 +239,7 @@ bml_random_matrix_ellsort(
             return bml_random_matrix_ellsort_double_complex(N, M,
                                                             distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -269,6 +279,7 @@ bml_identity_matrix_ellsort(
             return bml_identity_matrix_ellsort_double_real(N, M,
                                                            distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_identity_matrix_ellsort_single_complex(N, M,
                                                               distrib_mode);
@@ -277,6 +288,7 @@ bml_identity_matrix_ellsort(
             return bml_identity_matrix_ellsort_double_complex(N, M,
                                                               distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_convert_ellsort.c
+++ b/src/C-interface/ellsort/bml_convert_ellsort.c
@@ -20,6 +20,7 @@ bml_convert_ellsort(
             return bml_convert_ellsort_double_real(A, matrix_precision, M,
                                                    distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_convert_ellsort_single_complex(A, matrix_precision, M,
                                                       distrib_mode);
@@ -28,6 +29,7 @@ bml_convert_ellsort(
             return bml_convert_ellsort_double_complex(A, matrix_precision, M,
                                                       distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_copy_ellsort.c
+++ b/src/C-interface/ellsort/bml_copy_ellsort.c
@@ -30,12 +30,14 @@ bml_copy_ellsort_new(
         case double_real:
             B = bml_copy_ellsort_new_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_copy_ellsort_new_single_complex(A);
             break;
         case double_complex:
             B = bml_copy_ellsort_new_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,12 +66,14 @@ bml_copy_ellsort(
         case double_real:
             bml_copy_ellsort_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_copy_ellsort_single_complex(A, B);
             break;
         case double_complex:
             bml_copy_ellsort_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -97,12 +101,14 @@ bml_reorder_ellsort(
         case double_real:
             bml_reorder_ellsort_double_real(A, perm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_reorder_ellsort_single_complex(A, perm);
             break;
         case double_complex:
             bml_reorder_ellsort_double_complex(A, perm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_element_multiply_ellsort.c
+++ b/src/C-interface/ellsort/bml_element_multiply_ellsort.c
@@ -37,6 +37,7 @@ bml_element_multiply_AB_ellsort(
         case double_real:
             bml_element_multiply_AB_ellsort_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_element_multiply_AB_ellsort_single_complex(A, B, C,
                                                            threshold);
@@ -45,6 +46,7 @@ bml_element_multiply_AB_ellsort(
             bml_element_multiply_AB_ellsort_double_complex(A, B, C,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_export_ellsort.c
+++ b/src/C-interface/ellsort/bml_export_ellsort.c
@@ -28,12 +28,14 @@ bml_export_to_dense_ellsort(
         case double_real:
             return bml_export_to_dense_ellsort_double_real(A, order);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_export_to_dense_ellsort_single_complex(A, order);
             break;
         case double_complex:
             return bml_export_to_dense_ellsort_double_complex(A, order);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_getters_ellsort.c
+++ b/src/C-interface/ellsort/bml_getters_ellsort.c
@@ -17,12 +17,14 @@ bml_get_element_ellsort(
         case double_real:
             return bml_get_element_ellsort_double_real(A, i, j);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_element_ellsort_single_complex(A, i, j);
             break;
         case double_complex:
             return bml_get_element_ellsort_double_complex(A, i, j);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_element_ellsort\n");
             break;
@@ -43,12 +45,14 @@ bml_get_row_ellsort(
         case double_real:
             return bml_get_row_ellsort_double_real(A, i);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_row_ellsort_single_complex(A, i);
             break;
         case double_complex:
             return bml_get_row_ellsort_double_complex(A, i);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_row_ellsort\n");
             break;
@@ -68,12 +72,14 @@ bml_get_diagonal_ellsort(
         case double_real:
             return bml_get_diagonal_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_diagonal_ellsort_single_complex(A);
             break;
         case double_complex:
             return bml_get_diagonal_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_get_diagonal_ellsort\n");
             break;

--- a/src/C-interface/ellsort/bml_import_ellsort.c
+++ b/src/C-interface/ellsort/bml_import_ellsort.c
@@ -40,6 +40,7 @@ bml_import_from_dense_ellsort(
                                                              threshold, M,
                                                              distrib_mode);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_import_from_dense_ellsort_single_complex(order, N, A,
                                                                 threshold,
@@ -52,6 +53,7 @@ bml_import_from_dense_ellsort(
                                                                 M,
                                                                 distrib_mode);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_introspection_ellsort.c
+++ b/src/C-interface/ellsort/bml_introspection_ellsort.c
@@ -144,6 +144,7 @@ bml_get_sparsity_ellsort(
         case double_real:
             return bml_get_sparsity_ellsort_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_get_sparsity_ellsort_single_complex(A, threshold);
             break;
@@ -153,6 +154,7 @@ bml_get_sparsity_ellsort(
         case precision_uninitialized:
             LOG_ERROR("precision not initialized");
             break;
+#endif
         default:
             LOG_ERROR("fatal logic error\n");
             break;

--- a/src/C-interface/ellsort/bml_multiply_ellsort.c
+++ b/src/C-interface/ellsort/bml_multiply_ellsort.c
@@ -40,6 +40,7 @@ bml_multiply_ellsort(
         case double_real:
             bml_multiply_ellsort_double_real(A, B, C, alpha, beta, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_ellsort_single_complex(A, B, C, alpha, beta,
                                                 threshold);
@@ -48,6 +49,7 @@ bml_multiply_ellsort(
             bml_multiply_ellsort_double_complex(A, B, C, alpha, beta,
                                                 threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -78,12 +80,14 @@ bml_multiply_x2_ellsort(
         case double_real:
             return bml_multiply_x2_ellsort_double_real(X, X2, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_multiply_x2_ellsort_single_complex(X, X2, threshold);
             break;
         case double_complex:
             return bml_multiply_x2_ellsort_double_complex(X, X2, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -117,12 +121,14 @@ bml_multiply_AB_ellsort(
         case double_real:
             bml_multiply_AB_ellsort_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_AB_ellsort_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_AB_ellsort_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -155,12 +161,14 @@ bml_multiply_adjust_AB_ellsort(
         case double_real:
             bml_multiply_adjust_AB_ellsort_double_real(A, B, C, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_multiply_adjust_AB_ellsort_single_complex(A, B, C, threshold);
             break;
         case double_complex:
             bml_multiply_adjust_AB_ellsort_double_complex(A, B, C, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_norm_ellsort.c
+++ b/src/C-interface/ellsort/bml_norm_ellsort.c
@@ -27,12 +27,14 @@ bml_sum_squares_ellsort(
         case double_real:
             return bml_sum_squares_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_ellsort_single_complex(A);
             break;
         case double_complex:
             return bml_sum_squares_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -64,6 +66,7 @@ bml_sum_squares_submatrix_ellsort(
             return bml_sum_squares_submatrix_ellsort_double_real(A,
                                                                  core_size);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares_submatrix_ellsort_single_complex(A,
                                                                     core_size);
@@ -72,6 +75,7 @@ bml_sum_squares_submatrix_ellsort(
             return bml_sum_squares_submatrix_ellsort_double_complex(A,
                                                                     core_size);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -105,12 +109,14 @@ bml_sum_AB_ellsort(
         case double_real:
             return bml_sum_AB_ellsort_double_real(A, B, alpha, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_AB_ellsort_single_complex(A, B, alpha, threshold);
             break;
         case double_complex:
             return bml_sum_AB_ellsort_double_complex(A, B, alpha, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -149,6 +155,7 @@ bml_sum_squares2_ellsort(
             return bml_sum_squares2_ellsort_double_real(A, B, alpha, beta,
                                                         threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_sum_squares2_ellsort_single_complex(A, B, alpha, beta,
                                                            threshold);
@@ -157,6 +164,7 @@ bml_sum_squares2_ellsort(
             return bml_sum_squares2_ellsort_double_complex(A, B, alpha, beta,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -184,12 +192,14 @@ bml_fnorm_ellsort(
         case double_real:
             return bml_fnorm_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm_ellsort_single_complex(A);
             break;
         case double_complex:
             return bml_fnorm_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -219,12 +229,14 @@ bml_fnorm2_ellsort(
         case double_real:
             return bml_fnorm2_ellsort_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_fnorm2_ellsort_single_complex(A, B);
             break;
         case double_complex:
             return bml_fnorm2_ellsort_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_normalize_ellsort.c
+++ b/src/C-interface/ellsort/bml_normalize_ellsort.c
@@ -20,12 +20,14 @@ bml_accumulate_offdiag_ellsort(
         case double_real:
             return bml_accumulate_offdiag_ellsort_double_real(A, flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_accumulate_offdiag_ellsort_single_complex(A, flag);
             break;
         case double_complex:
             return bml_accumulate_offdiag_ellsort_double_complex(A, flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -54,12 +56,14 @@ bml_normalize_ellsort(
         case double_real:
             bml_normalize_ellsort_double_real(A, mineval, maxeval);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_normalize_ellsort_single_complex(A, mineval, maxeval);
             break;
         case double_complex:
             bml_normalize_ellsort_double_complex(A, mineval, maxeval);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -86,12 +90,14 @@ bml_gershgorin_ellsort(
         case double_real:
             return bml_gershgorin_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_ellsort_single_complex(A);
             break;
         case double_complex:
             return bml_gershgorin_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -121,12 +127,14 @@ bml_gershgorin_partial_ellsort(
         case double_real:
             return bml_gershgorin_partial_ellsort_double_real(A, nrows);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_gershgorin_partial_ellsort_single_complex(A, nrows);
             break;
         case double_complex:
             return bml_gershgorin_partial_ellsort_double_complex(A, nrows);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_parallel_ellsort.c
+++ b/src/C-interface/ellsort/bml_parallel_ellsort.c
@@ -26,12 +26,14 @@ bml_allGatherVParallel_ellsort(
         case double_real:
             bml_allGatherVParallel_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_allGatherVParallel_ellsort_single_complex(A);
             break;
         case double_complex:
             bml_allGatherVParallel_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -53,12 +55,14 @@ bml_mpi_type_create_struct_ellsort(
         case double_real:
             bml_mpi_type_create_struct_ellsort_double_real(A, newtype);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_type_create_struct_ellsort_single_complex(A, newtype);
             break;
         case double_complex:
             bml_mpi_type_create_struct_ellsort_double_complex(A, newtype);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -79,12 +83,14 @@ bml_mpi_send_ellsort(
         case double_real:
             bml_mpi_send_ellsort_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_send_ellsort_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_send_ellsort_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -105,12 +111,14 @@ bml_mpi_recv_ellsort(
         case double_real:
             bml_mpi_recv_ellsort_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_recv_ellsort_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_recv_ellsort_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -131,12 +139,14 @@ bml_mpi_irecv_ellsort(
         case double_real:
             bml_mpi_irecv_ellsort_double_real(A, dst, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_ellsort_single_complex(A, dst, comm);
             break;
         case double_complex:
             bml_mpi_irecv_ellsort_double_complex(A, dst, comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -155,12 +165,14 @@ bml_mpi_irecv_complete_ellsort(
         case double_real:
             bml_mpi_irecv_complete_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_mpi_irecv_complete_ellsort_single_complex(A);
             break;
         case double_complex:
             bml_mpi_irecv_complete_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -183,6 +195,7 @@ bml_mpi_recv_matrix_ellsort(
         case double_real:
             return bml_mpi_recv_matrix_ellsort_double_real(N, M, src, comm);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_mpi_recv_matrix_ellsort_single_complex(N, M, src,
                                                               comm);
@@ -191,6 +204,7 @@ bml_mpi_recv_matrix_ellsort(
             return bml_mpi_recv_matrix_ellsort_double_complex(N, M, src,
                                                               comm);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_scale_ellsort.c
+++ b/src/C-interface/ellsort/bml_scale_ellsort.c
@@ -29,12 +29,14 @@ bml_scale_ellsort_new(
         case double_real:
             B = bml_scale_ellsort_new_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_scale_ellsort_new_single_complex(scale_factor, A);
             break;
         case double_complex:
             B = bml_scale_ellsort_new_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_scale_ellsort(
         case double_real:
             bml_scale_ellsort_double_real(scale_factor, A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_ellsort_single_complex(scale_factor, A, B);
             break;
         case double_complex:
             bml_scale_ellsort_double_complex(scale_factor, A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -88,12 +92,14 @@ bml_scale_inplace_ellsort(
         case double_real:
             bml_scale_inplace_ellsort_double_real(scale_factor, A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_scale_inplace_ellsort_single_complex(scale_factor, A);
             break;
         case double_complex:
             bml_scale_inplace_ellsort_double_complex(scale_factor, A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_setters_ellsort.c
+++ b/src/C-interface/ellsort/bml_setters_ellsort.c
@@ -19,12 +19,14 @@ bml_set_element_new_ellsort(
         case double_real:
             bml_set_element_new_ellsort_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_new_ellsort_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_new_ellsort_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_new_ellsort\n");
             break;
@@ -47,12 +49,14 @@ bml_set_element_ellsort(
         case double_real:
             bml_set_element_ellsort_double_real(A, i, j, value);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_element_ellsort_single_complex(A, i, j, value);
             break;
         case double_complex:
             bml_set_element_ellsort_double_complex(A, i, j, value);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision in bml_set_element_ellsort\n");
             break;
@@ -74,12 +78,14 @@ bml_set_row_ellsort(
         case double_real:
             bml_set_row_ellsort_double_real(A, i, row, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_row_ellsort_single_complex(A, i, row, threshold);
             break;
         case double_complex:
             bml_set_row_ellsort_double_complex(A, i, row, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;
@@ -100,12 +106,14 @@ bml_set_diagonal_ellsort(
         case double_real:
             bml_set_diagonal_ellsort_double_real(A, diagonal, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_set_diagonal_ellsort_single_complex(A, diagonal, threshold);
             break;
         case double_complex:
             bml_set_diagonal_ellsort_double_complex(A, diagonal, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unkonwn precision\n");
             break;

--- a/src/C-interface/ellsort/bml_submatrix_ellsort.c
+++ b/src/C-interface/ellsort/bml_submatrix_ellsort.c
@@ -52,6 +52,7 @@ bml_matrix2submatrix_index_ellsort(
                                                            vsize,
                                                            double_jump_flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_matrix2submatrix_index_ellsort_single_complex(A, B, nodelist,
                                                               nsize,
@@ -66,6 +67,7 @@ bml_matrix2submatrix_index_ellsort(
                                                               vsize,
                                                               double_jump_flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -108,6 +110,7 @@ bml_matrix2submatrix_index_graph_ellsort(
                                                                  vsize,
                                                                  double_jump_flag);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_matrix2submatrix_index_graph_ellsort_double_complex(B,
                                                                     nodelist,
@@ -124,6 +127,7 @@ bml_matrix2submatrix_index_graph_ellsort(
                                                                     vsize,
                                                                     double_jump_flag);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -156,6 +160,7 @@ bml_matrix2submatrix_ellsort(
             bml_matrix2submatrix_ellsort_double_real(A, B, core_halo_index,
                                                      lsize);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_matrix2submatrix_ellsort_single_complex(A, B, core_halo_index,
                                                         lsize);
@@ -164,6 +169,7 @@ bml_matrix2submatrix_ellsort(
             bml_matrix2submatrix_ellsort_double_complex(A, B, core_halo_index,
                                                         lsize);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -202,6 +208,7 @@ bml_submatrix2matrix_ellsort(
                                                      lsize, llsize,
                                                      threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_submatrix2matrix_ellsort_single_complex(A, B, core_halo_index,
                                                         lsize,
@@ -212,6 +219,7 @@ bml_submatrix2matrix_ellsort(
                                                         lsize,
                                                         llsize, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -243,12 +251,14 @@ bml_getVector_ellsort(
         case double_real:
             return bml_getVector_ellsort_double_real(A, jj, irow, colCnt);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_getVector_ellsort_single_complex(A, jj, irow, colCnt);
             break;
         case double_complex:
             return bml_getVector_ellsort_double_complex(A, jj, irow, colCnt);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -282,6 +292,7 @@ bml_group_matrix_ellsort(
             return bml_group_matrix_ellsort_double_real(A, hindex, ngroups,
                                                         threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_group_matrix_ellsort_single_complex(A, hindex, ngroups,
                                                            threshold);
@@ -290,6 +301,7 @@ bml_group_matrix_ellsort(
             return bml_group_matrix_ellsort_double_complex(A, hindex, ngroups,
                                                            threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -475,6 +487,7 @@ bml_extract_submatrix_ellsort(
             return bml_extract_submatrix_ellsort_double_real(A, irow, icol,
                                                              B_N, B_M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return bml_extract_submatrix_ellsort_single_complex(A, irow, icol,
                                                                 B_N, B_M);
@@ -483,6 +496,7 @@ bml_extract_submatrix_ellsort(
             return bml_extract_submatrix_ellsort_double_complex(A, irow, icol,
                                                                 B_N, B_M);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -505,12 +519,14 @@ bml_assign_submatrix_ellsort(
         case double_real:
             bml_assign_submatrix_ellsort_double_real(A, B, irow, icol);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_assign_submatrix_ellsort_single_complex(A, B, irow, icol);
             break;
         case double_complex:
             bml_assign_submatrix_ellsort_double_complex(A, B, irow, icol);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_threshold_ellsort.c
+++ b/src/C-interface/ellsort/bml_threshold_ellsort.c
@@ -28,12 +28,14 @@ bml_matrix_ellsort_t
         case double_real:
             B = bml_threshold_new_ellsort_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_threshold_new_ellsort_single_complex(A, threshold);
             break;
         case double_complex:
             B = bml_threshold_new_ellsort_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -63,12 +65,14 @@ bml_threshold_ellsort(
         case double_real:
             bml_threshold_ellsort_double_real(A, threshold);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_threshold_ellsort_single_complex(A, threshold);
             break;
         case double_complex:
             bml_threshold_ellsort_double_complex(A, threshold);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_trace_ellsort.c
+++ b/src/C-interface/ellsort/bml_trace_ellsort.c
@@ -28,12 +28,14 @@ bml_trace_ellsort(
         case double_real:
             trace = bml_trace_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_ellsort_single_complex(A);
             break;
         case double_complex:
             trace = bml_trace_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -65,12 +67,14 @@ bml_trace_mult_ellsort(
         case double_real:
             trace = bml_trace_mult_ellsort_double_real(A, B);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             trace = bml_trace_mult_ellsort_single_complex(A, B);
             break;
         case double_complex:
             trace = bml_trace_mult_ellsort_double_complex(A, B);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_transpose_ellsort.c
+++ b/src/C-interface/ellsort/bml_transpose_ellsort.c
@@ -28,12 +28,14 @@ bml_transpose_new_ellsort(
         case double_real:
             B = bml_transpose_new_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             B = bml_transpose_new_ellsort_single_complex(A);
             break;
         case double_complex:
             B = bml_transpose_new_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -61,12 +63,14 @@ bml_transpose_ellsort(
         case double_real:
             bml_transpose_ellsort_double_real(A);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_transpose_ellsort_single_complex(A);
             break;
         case double_complex:
             bml_transpose_ellsort_double_complex(A);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_utilities_ellsort.c
+++ b/src/C-interface/ellsort/bml_utilities_ellsort.c
@@ -16,12 +16,14 @@ bml_read_bml_matrix_ellsort(
         case double_real:
             bml_read_bml_matrix_ellsort_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_read_bml_matrix_ellsort_single_complex(A, filename);
             break;
         case double_complex:
             bml_read_bml_matrix_ellsort_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;
@@ -41,12 +43,14 @@ bml_write_bml_matrix_ellsort(
         case double_real:
             bml_write_bml_matrix_ellsort_double_real(A, filename);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             bml_write_bml_matrix_ellsort_single_complex(A, filename);
             break;
         case double_complex:
             bml_write_bml_matrix_ellsort_double_complex(A, filename);
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/C-interface/ellsort/bml_utilities_ellsort_typed.c
+++ b/src/C-interface/ellsort/bml_utilities_ellsort_typed.c
@@ -62,12 +62,14 @@ void TYPED_FUNC(
         case double_real:
             FMT = "%d %d %lg\n";
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             FMT = "%d %d %g\n";
             break;
         case double_complex:
             FMT = "%d %d %lg\n";
             break;
+#endif
         default:
             LOG_ERROR("unknown precision\n");
             break;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,8 @@ add_subdirectory(Fortran-interface)
 add_subdirectory(C-interface)
 add_subdirectory(internal-blas)
 
-set(LIBRARY_SOURCES
+if(BML_COMPLEX)
+  set(LIBRARY_SOURCES
   $<TARGET_OBJECTS:bml-c>
   $<TARGET_OBJECTS:bml-internal-blas-double_complex>
   $<TARGET_OBJECTS:bml-internal-blas-double_real>
@@ -39,6 +40,31 @@ set(MPI_LIBRARY_SOURCES
   $<TARGET_OBJECTS:bml-distributed2d-single_complex>
   $<TARGET_OBJECTS:bml-distributed2d-single_real>
   $<TARGET_OBJECTS:bml-distributed2d>)
+else()
+  set(LIBRARY_SOURCES
+    $<TARGET_OBJECTS:bml-c>
+    $<TARGET_OBJECTS:bml-internal-blas-double_real>
+    $<TARGET_OBJECTS:bml-internal-blas-single_real>
+    $<TARGET_OBJECTS:bml-dense-double_real>
+    $<TARGET_OBJECTS:bml-dense-single_real>
+    $<TARGET_OBJECTS:bml-dense>
+    $<TARGET_OBJECTS:bml-ellpack-double_real>
+    $<TARGET_OBJECTS:bml-ellpack-single_real>
+    $<TARGET_OBJECTS:bml-ellpack>
+    $<TARGET_OBJECTS:bml-ellblock-double_real>
+    $<TARGET_OBJECTS:bml-ellblock-single_real>
+    $<TARGET_OBJECTS:bml-ellblock>
+    $<TARGET_OBJECTS:bml-ellsort-double_real>
+    $<TARGET_OBJECTS:bml-ellsort-single_real>
+    $<TARGET_OBJECTS:bml-ellsort>
+    $<TARGET_OBJECTS:bml-csr-double_real>
+    $<TARGET_OBJECTS:bml-csr-single_real>
+    $<TARGET_OBJECTS:bml-csr>)
+  set(MPI_LIBRARY_SOURCES
+    $<TARGET_OBJECTS:bml-distributed2d-double_real>
+    $<TARGET_OBJECTS:bml-distributed2d-single_real>
+    $<TARGET_OBJECTS:bml-distributed2d>)
+endif()
 if(BML_MPI)
   add_library(bml
     ${LIBRARY_SOURCES}

--- a/src/Fortran-interface/bml_elemental_m.F90
+++ b/src/Fortran-interface/bml_elemental_m.F90
@@ -9,8 +9,10 @@ module bml_elemental_m
   interface bml_get_element
     module procedure bml_get_element_single_real
     module procedure bml_get_element_double_real
+#ifdef BML_COMPLEX
     module procedure bml_get_element_single_complex
     module procedure bml_get_element_double_complex
+#endif
   end interface bml_get_element
 
   public :: bml_get_element
@@ -51,6 +53,7 @@ contains
 
   end subroutine bml_get_element_double_real
 
+#ifdef BML_COMPLEX
   !> Get a single matrix element.
   !!
   !! \param a_ij The matrix element
@@ -84,5 +87,6 @@ contains
     a_ij = bml_get_element_double_complex_C(a%ptr, i-1, j-1)
 
   end subroutine bml_get_element_double_complex
+#endif
 
 end module bml_elemental_m

--- a/src/typed.h
+++ b/src/typed.h
@@ -17,7 +17,7 @@
 #endif
 
 /* Define numeric types. */
-#if defined(SINGLE_REAL) || (defined(SINGLE_COMPLEX) && ! defined(BML_COMPLEX))
+#if defined(SINGLE_REAL)
 #define REAL_T float
 #define MAGMA_T float
 #define MKL_T float
@@ -47,7 +47,7 @@
 #define bml_cusparsePruneCSRNnz cusparseSpruneCsr2csrNnz
 #define bml_cusparsePruneCSR cusparseSpruneCsr2csr
 #endif
-#elif defined(DOUBLE_REAL) || (defined(DOUBLE_COMPLEX) && ! defined(BML_COMPLEX))
+#elif defined(DOUBLE_REAL)
 #define REAL_T double
 #define MAGMA_T double
 #define MKL_T  double

--- a/tests/C-tests/CMakeLists.txt
+++ b/tests/C-tests/CMakeLists.txt
@@ -47,14 +47,22 @@ set(SOURCES_TYPED
 include(${PROJECT_SOURCE_DIR}/cmake/bmlAddTypedLibrary.cmake)
 bml_add_typed_library(bmltests single_real "${SOURCES_TYPED}")
 bml_add_typed_library(bmltests double_real "${SOURCES_TYPED}")
-bml_add_typed_library(bmltests single_complex "${SOURCES_TYPED}")
-bml_add_typed_library(bmltests double_complex "${SOURCES_TYPED}")
+if(BML_COMPLEX)
+  bml_add_typed_library(bmltests single_complex "${SOURCES_TYPED}")
+  bml_add_typed_library(bmltests double_complex "${SOURCES_TYPED}")
+endif()
 
-add_library(bmltests
-  $<TARGET_OBJECTS:bmltests-single_real>
-  $<TARGET_OBJECTS:bmltests-double_real>
-  $<TARGET_OBJECTS:bmltests-single_complex>
-  $<TARGET_OBJECTS:bmltests-double_complex>)
+if(BML_COMPLEX)
+  add_library(bmltests
+    $<TARGET_OBJECTS:bmltests-single_real>
+    $<TARGET_OBJECTS:bmltests-double_real>
+    $<TARGET_OBJECTS:bmltests-single_complex>
+    $<TARGET_OBJECTS:bmltests-double_complex>)
+else()
+  add_library(bmltests
+    $<TARGET_OBJECTS:bmltests-single_real>
+    $<TARGET_OBJECTS:bmltests-double_real>)
+endif()
 set_target_properties(bmltests
   PROPERTIES
   POSITION_INDEPENDENT_CODE yes)
@@ -113,9 +121,14 @@ endif()
 
 message(STATUS "BML_NONMPI_PRECOMMAND=${BML_NONMPI_PRECOMMAND}")
 message(STATUS "BML_NONMPI_PRECOMMAND_ARGS=${BML_NONMPI_PRECOMMAND_ARGS}")
+if(BML_COMPLEX)
+  set(precisions single_real double_real single_complex double_complex)
+else()
+  set(precisions single_real double_real)
+endif()
 function(test_formats ${formats})
   foreach(T ${formats} )
-    foreach(P single_real double_real single_complex double_complex)
+    foreach(P ${precisions})
       add_test(NAME C-${N}-${T}-${P}
         COMMAND ${BML_NONMPI_PRECOMMAND} ${BML_NONMPI_PRECOMMAND_ARGS}
         ${CMAKE_CURRENT_BINARY_DIR}/bml-test -n ${N} -t ${T} -p ${P})
@@ -129,7 +142,7 @@ endfunction(test_formats)
 
 function(test_formats_mpi ${formats})
   foreach(T ${formats} )
-    foreach(P single_real double_real single_complex double_complex)
+    foreach(P ${precisions})
       add_test(MPI-C-${N}-${T}-${P}
         ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROCS_FLAG} ${MPIEXEC_NUMPROCS} ${MPIEXEC_PREFLAGS}
         ${CMAKE_CURRENT_BINARY_DIR}/bml-test -n ${N} -t ${T} -p ${P})

--- a/tests/C-tests/add_matrix.c
+++ b/tests/C-tests/add_matrix.c
@@ -18,6 +18,7 @@ test_add(
         case double_real:
             return test_add_double_real(N, matrix_type, matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_add_single_complex(N, matrix_type, matrix_precision,
                                            M);
@@ -26,6 +27,7 @@ test_add(
             return test_add_double_complex(N, matrix_type, matrix_precision,
                                            M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/adjacency_matrix.c
+++ b/tests/C-tests/adjacency_matrix.c
@@ -20,6 +20,7 @@ test_adjacency(
             return test_adjacency_double_real(N, matrix_type,
                                               matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_adjacency_single_complex(N, matrix_type,
                                                  matrix_precision, M);
@@ -28,6 +29,7 @@ test_adjacency(
             return test_adjacency_double_complex(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/adjungate_triangle_matrix.c
+++ b/tests/C-tests/adjungate_triangle_matrix.c
@@ -20,6 +20,7 @@ test_adjungate_triangle(
             return test_adjungate_triangle_double_real(N, matrix_type,
                                                        matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_adjungate_triangle_single_complex(N, matrix_type,
                                                           matrix_precision,
@@ -30,6 +31,7 @@ test_adjungate_triangle(
                                                           matrix_precision,
                                                           M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/allocate_matrix.c
+++ b/tests/C-tests/allocate_matrix.c
@@ -20,6 +20,7 @@ test_allocate(
             return test_allocate_double_real(N, matrix_type, matrix_precision,
                                              M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_allocate_single_complex(N, matrix_type,
                                                 matrix_precision, M);
@@ -28,6 +29,7 @@ test_allocate(
             return test_allocate_double_complex(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/bml_gemm.c
+++ b/tests/C-tests/bml_gemm.c
@@ -26,6 +26,7 @@ test_bml_gemm(
             return test_bml_gemm_double_real(N, matrix_type, matrix_precision,
                                              M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_bml_gemm_single_complex(N, matrix_type,
                                                 matrix_precision, M);
@@ -34,6 +35,7 @@ test_bml_gemm(
             return test_bml_gemm_double_complex(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/convert_matrix.c
+++ b/tests/C-tests/convert_matrix.c
@@ -20,6 +20,7 @@ test_convert(
             return test_convert_double_real(N, matrix_type, matrix_precision,
                                             M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_convert_single_complex(N, matrix_type,
                                                matrix_precision, M);
@@ -28,6 +29,7 @@ test_convert(
             return test_convert_double_complex(N, matrix_type,
                                                matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/copy_matrix.c
+++ b/tests/C-tests/copy_matrix.c
@@ -18,6 +18,7 @@ test_copy(
         case double_real:
             return test_copy_double_real(N, matrix_type, matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_copy_single_complex(N, matrix_type, matrix_precision,
                                             M);
@@ -26,6 +27,7 @@ test_copy(
             return test_copy_double_complex(N, matrix_type, matrix_precision,
                                             M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/diagonalize_matrix.c
+++ b/tests/C-tests/diagonalize_matrix.c
@@ -20,6 +20,7 @@ test_diagonalize(
             return test_diagonalize_double_real(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_diagonalize_single_complex(N, matrix_type,
                                                    matrix_precision, M);
@@ -28,6 +29,7 @@ test_diagonalize(
             return test_diagonalize_double_complex(N, matrix_type,
                                                    matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/diagonalize_matrix_typed.c
+++ b/tests/C-tests/diagonalize_matrix_typed.c
@@ -88,6 +88,7 @@ int TYPED_FUNC(
             }
 #endif
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             eigenvalues = bml_allocate_memory(N * sizeof(float complex));
 #ifdef INTEL_OPT
@@ -112,6 +113,7 @@ int TYPED_FUNC(
             }
 #endif
             break;
+#endif
         default:
             LOG_DEBUG("matrix_precision is not set");
             break;

--- a/tests/C-tests/element_multiply_matrix.c
+++ b/tests/C-tests/element_multiply_matrix.c
@@ -20,6 +20,7 @@ test_element_multiply(
             return test_element_multiply_double_real(N, matrix_type,
                                                      matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_element_multiply_single_complex(N, matrix_type,
                                                         matrix_precision, M);
@@ -28,6 +29,7 @@ test_element_multiply(
             return test_element_multiply_double_complex(N, matrix_type,
                                                         matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/get_element.c
+++ b/tests/C-tests/get_element.c
@@ -20,6 +20,7 @@ test_get_element(
             return test_get_element_double_real(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_get_element_single_complex(N, matrix_type,
                                                    matrix_precision, M);
@@ -28,6 +29,7 @@ test_get_element(
             return test_get_element_double_complex(N, matrix_type,
                                                    matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/get_set_diagonal.c
+++ b/tests/C-tests/get_set_diagonal.c
@@ -20,6 +20,7 @@ test_get_set_diagonal(
             return test_get_set_diagonal_double_real(N, matrix_type,
                                                      matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_get_set_diagonal_single_complex(N, matrix_type,
                                                         matrix_precision, M);
@@ -28,6 +29,7 @@ test_get_set_diagonal(
             return test_get_set_diagonal_double_complex(N, matrix_type,
                                                         matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/get_set_diagonal_typed.c
+++ b/tests/C-tests/get_set_diagonal_typed.c
@@ -28,12 +28,14 @@ int TYPED_FUNC(
         case double_real:
             A_diagonal = calloc(N, sizeof(double));
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A_diagonal = calloc(N, sizeof(float complex));
             break;
         case double_complex:
             A_diagonal = calloc(N, sizeof(double complex));
             break;
+#endif
         default:
             LOG_DEBUG("matrix_precision is not set");
             break;

--- a/tests/C-tests/get_sparsity.c
+++ b/tests/C-tests/get_sparsity.c
@@ -20,6 +20,7 @@ test_get_sparsity(
             return test_get_sparsity_double_real(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_get_sparsity_single_complex(N, matrix_type,
                                                     matrix_precision, M);
@@ -28,6 +29,7 @@ test_get_sparsity(
             return test_get_sparsity_double_complex(N, matrix_type,
                                                     matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/import_export_matrix.c
+++ b/tests/C-tests/import_export_matrix.c
@@ -20,6 +20,7 @@ test_import_export(
             return test_import_export_double_real(N, matrix_type,
                                                   matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_import_export_single_complex(N, matrix_type,
                                                      matrix_precision, M);
@@ -28,6 +29,7 @@ test_import_export(
             return test_import_export_double_complex(N, matrix_type,
                                                      matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/introspection.c
+++ b/tests/C-tests/introspection.c
@@ -20,6 +20,7 @@ test_introspection(
             return test_introspection_double_real(N, matrix_type,
                                                   matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_introspection_single_complex(N, matrix_type,
                                                      matrix_precision, M);
@@ -28,6 +29,7 @@ test_introspection(
             return test_introspection_double_complex(N, matrix_type,
                                                      matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/introspection_typed.c
+++ b/tests/C-tests/introspection_typed.c
@@ -79,12 +79,14 @@ int TYPED_FUNC(
         case double_real:
             LOG_INFO("precision is double_real\n");
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             LOG_INFO("precision is single_complex\n");
             break;
         case double_complex:
             LOG_INFO("precision is double_complex\n");
             break;
+#endif
         default:
             LOG_ERROR("unknown matrix precision\n");
     }

--- a/tests/C-tests/inverse_matrix.c
+++ b/tests/C-tests/inverse_matrix.c
@@ -20,6 +20,7 @@ test_inverse(
             return test_inverse_double_real(N, matrix_type,
                                             matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_inverse_single_complex(N, matrix_type,
                                                matrix_precision, M);
@@ -28,6 +29,7 @@ test_inverse(
             return test_inverse_double_complex(N, matrix_type,
                                                matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/io_matrix.c
+++ b/tests/C-tests/io_matrix.c
@@ -20,6 +20,7 @@ test_io_matrix(
             return test_io_matrix_double_real(N, matrix_type,
                                               matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_io_matrix_single_complex(N, matrix_type,
                                                  matrix_precision, M);
@@ -28,6 +29,7 @@ test_io_matrix(
             return test_io_matrix_double_complex(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/mpi_sendrecv.c
+++ b/tests/C-tests/mpi_sendrecv.c
@@ -22,6 +22,7 @@ test_mpi_sendrecv(
             return test_mpi_sendrecv_double_real(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_mpi_sendrecv_single_complex(N, matrix_type,
                                                     matrix_precision, M);
@@ -30,6 +31,7 @@ test_mpi_sendrecv(
             return test_mpi_sendrecv_double_complex(N, matrix_type,
                                                     matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/multiply_banded_matrix.c
+++ b/tests/C-tests/multiply_banded_matrix.c
@@ -20,6 +20,7 @@ test_multiply_banded(
             return test_multiply_banded_double_real(N, matrix_type,
                                                     matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_multiply_banded_single_complex(N, matrix_type,
                                                        matrix_precision, M);
@@ -28,6 +29,7 @@ test_multiply_banded(
             return test_multiply_banded_double_complex(N, matrix_type,
                                                        matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/multiply_matrix.c
+++ b/tests/C-tests/multiply_matrix.c
@@ -20,6 +20,7 @@ test_multiply(
             return test_multiply_double_real(N, matrix_type, matrix_precision,
                                              M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_multiply_single_complex(N, matrix_type,
                                                 matrix_precision, M);
@@ -28,6 +29,7 @@ test_multiply(
             return test_multiply_double_complex(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/multiply_matrix_x2.c
+++ b/tests/C-tests/multiply_matrix_x2.c
@@ -20,6 +20,7 @@ test_multiply_x2(
             return test_multiply_x2_double_real(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_multiply_x2_single_complex(N, matrix_type,
                                                    matrix_precision, M);
@@ -28,6 +29,7 @@ test_multiply_x2(
             return test_multiply_x2_double_complex(N, matrix_type,
                                                    matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/norm_matrix.c
+++ b/tests/C-tests/norm_matrix.c
@@ -18,6 +18,7 @@ test_norm(
         case double_real:
             return test_norm_double_real(N, matrix_type, matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_norm_single_complex(N, matrix_type,
                                             matrix_precision, M);
@@ -26,6 +27,7 @@ test_norm(
             return test_norm_double_complex(N, matrix_type,
                                             matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/normalize_matrix.c
+++ b/tests/C-tests/normalize_matrix.c
@@ -20,6 +20,7 @@ test_normalize(
             return test_normalize_double_real(N, matrix_type,
                                               matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_normalize_single_complex(N, matrix_type,
                                                  matrix_precision, M);
@@ -28,6 +29,7 @@ test_normalize(
             return test_normalize_double_complex(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/print_matrix.c
+++ b/tests/C-tests/print_matrix.c
@@ -20,6 +20,7 @@ test_print(
             return test_print_double_real(N, matrix_type, matrix_precision,
                                           M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_print_single_complex(N, matrix_type,
                                              matrix_precision, M);
@@ -28,6 +29,7 @@ test_print(
             return test_print_double_complex(N, matrix_type,
                                              matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/print_matrix_typed.c
+++ b/tests/C-tests/print_matrix_typed.c
@@ -147,6 +147,7 @@ int TYPED_FUNC(
                         printf("Read: %f\n", realp);
                         data[ROWMAJOR(i, j, up, up)] = realp;
                         break;
+#ifdef BML_COMPLEX
                     case single_complex:
                     case double_complex:
                         //read complex number in 3 parts, discarding 'i'
@@ -158,6 +159,7 @@ int TYPED_FUNC(
                         printf("imagp %f\n", IMAGINARY_PART(tmp));
                         data[ROWMAJOR(i, j, up, up)] = tmp;
                         break;
+#endif
                     default:
                         fprintf(stderr, "Unknown precision\n");
                         break;

--- a/tests/C-tests/scale_matrix.c
+++ b/tests/C-tests/scale_matrix.c
@@ -20,6 +20,7 @@ test_scale(
             return test_scale_double_real(N, matrix_type, matrix_precision,
                                           M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_scale_single_complex(N, matrix_type, matrix_precision,
                                              M);
@@ -28,6 +29,7 @@ test_scale(
             return test_scale_double_complex(N, matrix_type, matrix_precision,
                                              M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/set_element.c
+++ b/tests/C-tests/set_element.c
@@ -20,6 +20,7 @@ test_set_element(
             return test_set_element_double_real(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_set_element_single_complex(N, matrix_type,
                                                    matrix_precision, M);
@@ -28,6 +29,7 @@ test_set_element(
             return test_set_element_double_complex(N, matrix_type,
                                                    matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/set_row.c
+++ b/tests/C-tests/set_row.c
@@ -20,6 +20,7 @@ test_set_row(
             return test_set_row_double_real(N, matrix_type, matrix_precision,
                                             M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_set_row_single_complex(N, matrix_type,
                                                matrix_precision, M);
@@ -28,6 +29,7 @@ test_set_row(
             return test_set_row_double_complex(N, matrix_type,
                                                matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/set_row_typed.c
+++ b/tests/C-tests/set_row_typed.c
@@ -37,12 +37,14 @@ int TYPED_FUNC(
         case double_real:
             A_row = calloc(N, sizeof(double));
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             A_row = calloc(N, sizeof(float complex));
             break;
         case double_complex:
             A_row = calloc(N, sizeof(double complex));
             break;
+#endif
         default:
             LOG_DEBUG("matrix_precision is not set");
             break;

--- a/tests/C-tests/submatrix_matrix.c
+++ b/tests/C-tests/submatrix_matrix.c
@@ -20,6 +20,7 @@ test_submatrix(
             return test_submatrix_double_real(N, matrix_type,
                                               matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_submatrix_single_complex(N, matrix_type,
                                                  matrix_precision, M);
@@ -28,6 +29,7 @@ test_submatrix(
             return test_submatrix_double_complex(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/test_template.c
+++ b/tests/C-tests/test_template.c
@@ -20,6 +20,7 @@ test_template(
             return test_template_double_real(N, matrix_type, matrix_precision,
                                              M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_template_single_complex(N, matrix_type,
                                                 matrix_precision, M);
@@ -28,6 +29,7 @@ test_template(
             return test_template_double_complex(N, matrix_type,
                                                 matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/threshold_matrix.c
+++ b/tests/C-tests/threshold_matrix.c
@@ -20,6 +20,7 @@ test_threshold(
             return test_threshold_double_real(N, matrix_type,
                                               matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_threshold_single_complex(N, matrix_type,
                                                  matrix_precision, M);
@@ -28,6 +29,7 @@ test_threshold(
             return test_threshold_double_complex(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/trace_matrix.c
+++ b/tests/C-tests/trace_matrix.c
@@ -20,6 +20,7 @@ test_trace(
             return test_trace_double_real(N, matrix_type, matrix_precision,
                                           M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_trace_single_complex(N, matrix_type, matrix_precision,
                                              M);
@@ -28,6 +29,7 @@ test_trace(
             return test_trace_double_complex(N, matrix_type, matrix_precision,
                                              M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/trace_mult.c
+++ b/tests/C-tests/trace_mult.c
@@ -20,6 +20,7 @@ test_trace_mult(
             return test_trace_mult_double_real(N, matrix_type,
                                                matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_trace_mult_single_complex(N, matrix_type,
                                                   matrix_precision, M);
@@ -28,6 +29,7 @@ test_trace_mult(
             return test_trace_mult_double_complex(N, matrix_type,
                                                   matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;

--- a/tests/C-tests/transpose_matrix.c
+++ b/tests/C-tests/transpose_matrix.c
@@ -20,6 +20,7 @@ test_transpose(
             return test_transpose_double_real(N, matrix_type,
                                               matrix_precision, M);
             break;
+#ifdef BML_COMPLEX
         case single_complex:
             return test_transpose_single_complex(N, matrix_type,
                                                  matrix_precision, M);
@@ -28,6 +29,7 @@ test_transpose(
             return test_transpose_double_complex(N, matrix_type,
                                                  matrix_precision, M);
             break;
+#endif
         default:
             fprintf(stderr, "unknown matrix precision\n");
             return -1;


### PR DESCRIPTION
Until now, BML_COMPLEX off was accomplished by building
complex code with non-complex macros datatypes.