### PR TITLE
Store result of failed lint job

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,6 +33,13 @@ jobs:
       - run: bundle install
       - run: bundle exec danger || true
       - run: BML_OPENMP=no EMACS=emacs27 ./build.sh --debug check_indent
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: lint-artifacts
+          path: |
+            **/*.indented
+            build.log
 
   docs:
     name: Build docs


### PR DESCRIPTION
This change stores the output of a failed lint job as an artifact.

Closes: lanl/bml#647
Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>