### PR TITLE
Specify magma version to use for CI on Ascent@OLCF

### DIFF
--- a/.ecp-gitlab-ci.yml
+++ b/.ecp-gitlab-ci.yml
@@ -15,7 +15,7 @@ build_gpu:
     - module load gcc/10.2.0
     - module load openblas
     - module load cuda
-    - module load magma
+    - module load magma/2.6.1
     - module load git
     - module load cmake
     - export MAGMA_ROOT=${OLCF_MAGMA_ROOT}


### PR DESCRIPTION
Default (magma2.6.2) not working for BML