### PR TITLE
Remove check for fabs by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,12 +435,6 @@ include(CheckFunctionExists)
 include(CheckFortranFunctionExists)
 include(${PROJECT_SOURCE_DIR}/cmake/bmlCheckCFortranFunctionExists.cmake)
 
-set(CMAKE_REQUIRED_LIBRARIES ${LINK_LIBRARIES} -lm)
-check_function_exists(fabs HAVE_FABS)
-if(NOT HAVE_FABS)
-  message(FATAL_ERROR "Could not find the fabs() function")
-endif()
-
 if(BLAS_FOUND)
   add_definitions(-DHAVE_BLAS)
 


### PR DESCRIPTION
* was used to setup unused variable
* may fail to be found in lm sometimes