### PR TITLE
Move CMake package definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,8 +734,13 @@ string(REPLACE ";" " " LINKLINE "${LINK_LIBRARIES}")
 string(STRIP "${LINKLINE}" LINKLINE)
 message(STATUS "Link flags: '${LINKLINE}'")
 
+add_subdirectory(src)
+
 configure_file(src/bml.pc.in bml.pc)
 install(FILES ${CMAKE_BINARY_DIR}/bml.pc
   DESTINATION ${CMAKE_INSTALL_PKG_CONFIG_DIR})
 
-add_subdirectory(src)
+include(CMakePackageConfigHelpers)
+configure_file(src/BMLConfig.cmakein ${CMAKE_CURRENT_BINARY_DIR}/BMLConfig.cmake @ONLY)
+write_basic_package_version_file("BMLConfigVersion.cmake" VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/BMLConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/BMLConfigVersion.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BML)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,10 +100,7 @@ install(TARGETS bml bml_fortran EXPORT BML_Targets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(EXPORT BML_Targets FILE BML_Targets.cmake NAMESPACE BML:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BML)
-include(CMakePackageConfigHelpers)
-configure_file(BMLConfig.cmakein ${CMAKE_CURRENT_BINARY_DIR}/BMLConfig.cmake @ONLY)
-write_basic_package_version_file("BMLConfigVersion.cmake" VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/BMLConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/BMLConfigVersion.cmake" DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BML)
+
 add_library(BML::bml ALIAS bml)
 add_library(BML::bml_fortran ALIAS bml_fortran)
 


### PR DESCRIPTION
This change moves the CMake package definition (for use in other CMake based projects) to the project's root directory. This puts the definition in the same place as the `pkg-config` based definitions.

Closes: https://github.com/lanl/bml/issues/684
Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>