### PR TITLE
Fix rocsparse multiply using rocm 5.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,9 @@ set(XL_Fortran_FLAGS_DEBUG -O0 -g)
 set(XL_Fortran_FLAGS_RELEASE -O3 -g)
 set(XL_Fortran_FLAGS_RELWITHDEBINFO -O3 -g -DNDEBUG)
 
-set(Clang_C_FLAGS_DEBUG -O0 -g -save-temps -std=c99)
-set(Clang_C_FLAGS_RELEASE -O2 -g -std=c99 -DNDEBUG)
-set(Clang_C_FLAGS_RELWITHDEBINFO -O2 -g -std=c99 -DNDEBUG)
+set(Clang_C_FLAGS_DEBUG -O0 -g -save-temps -std=gnu99)
+set(Clang_C_FLAGS_RELEASE -O2 -g -DNDEBUG -std=gnu99)
+set(Clang_C_FLAGS_RELWITHDEBINFO -O2 -g -DNDEBUG -std=gnu99)
 
 # If Cray Fortran compiler then assume Cray C compiler
 #  (This is needed as Cray C compiler ID is Clang)

--- a/scripts/build_crusher_rocsparse_cce.sh
+++ b/scripts/build_crusher_rocsparse_cce.sh
@@ -20,7 +20,7 @@ export BUILD_DIR=${BUILD_DIR:="${MY_PATH}/build"}
 export INSTALL_DIR=${INSTALL_DIR:="${MY_PATH}/install"}
 export BML_TESTING=${BML_TESTING:=yes}
 export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}
-
+#export EXTRA_CFLAGS=${EXTRA_CFLAGS:=-craype-verbose}
 ./build.sh configure
 
 pushd ${BUILD_DIR}

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -30,9 +30,7 @@
 #include "bml_trace_ellpack.h"
 // Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
 #include "../rocsparse/rocsparse.h"
-/* DEBUG
-#include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()
-*/
+//#include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()
 #endif
 
 /** Matrix multiply.
@@ -1236,22 +1234,59 @@ void TYPED_FUNC(
                                                  rocsparse_spgemm_alg_default,
                                                  rocsparse_spgemm_stage_compute,
                                                  &bufferSize1, dBuffer1));
-/* DEBUG
-	hipDeviceSynchronize();
-	BML_CHECK_ROCSPARSE(rocsparse_csr_get(matC_tmp, &rows, &cols, &nnz, &csr_row_ptr, &csr_col_ind, &csr_val, &row_ptr_type, &col_ind_type, &idx_base, &data_type));
-	for (int i=0;i<10;i++) printf("C_tmp[%d]=%f ",i,(((REAL_T *)(csr_val))[i])); printf("\n");
-*/
         }
+        // Sort the resulting matrix
+#pragma omp target data use_device_ptr(csrRowPtrC_tmp, csrColIndC_tmp)
+        {
+            BML_CHECK_ROCSPARSE(rocsparse_csrsort_buffer_size
+                                (handle, C_num_rows, C_num_cols,
+                                 C_nnz_tmp, csrRowPtrC_tmp,
+                                 csrColIndC_tmp, &bufferSize1));
+        }
+        dBuffer1 = (char *) realloc(dBuffer1, bufferSize1);
+        rocsparse_int *perm;
+        perm = (rocsparse_int *) malloc(C_nnz_tmp * sizeof(rocsparse_int));
+        REAL_T *csrValC_tmp_sorted;
+        csrValC_tmp_sorted = (REAL_T *) malloc(C_nnz_tmp * sizeof(REAL_T));
 
+#pragma omp target enter data map(alloc:dBuffer1[:bufferSize1],perm[:C_nnz_tmp],csrValC_tmp_sorted[:C_nnz_tmp])
+
+#pragma omp target data use_device_ptr(csrRowPtrC_tmp, \
+			   csrColIndC_tmp, perm, dBuffer1, \
+			   csrValC_tmp_sorted, csrValC_tmp)
+        {
+            BML_CHECK_ROCSPARSE(rocsparse_create_identity_permutation
+                                (handle, C_nnz_tmp, perm));
+            BML_CHECK_ROCSPARSE(rocsparse_csrsort
+                                (handle, C_num_rows, C_num_cols,
+                                 C_nnz_tmp,
+                                 (rocsparse_mat_descr) matC_tmp,
+                                 csrRowPtrC_tmp, csrColIndC_tmp, perm,
+                                 dBuffer1));
+            BML_CHECK_ROCSPARSE(bml_rocsparse_xgthr
+                                (handle, C_nnz_tmp, csrValC_tmp,
+                                 csrValC_tmp_sorted, perm,
+                                 rocsparse_index_base_zero));
+            BML_CHECK_ROCSPARSE(rocsparse_spmat_set_values
+                                (matC_tmp, csrValC_tmp_sorted));
+        }
+        rocsparse_set_mat_storage_mode(matC_tmp,
+                                       rocsparse_storage_mode_sorted);
+        rocsparse_set_mat_storage_mode(matC, rocsparse_storage_mode_sorted);
         // Prune the output matrix and overwrite the C matrix with the result
 
         // xprune stage 1 = determine working buffer size
-#pragma omp target data use_device_ptr(csrValC_tmp,csrRowPtrC_tmp, csrColIndC_tmp,csrValC, csrRowPtrC, csrColIndC)
+
+#pragma omp target data use_device_ptr(csrValC_tmp_sorted,csrRowPtrC_tmp, \
+				       csrColIndC_tmp,csrValC, csrRowPtrC, \
+				       csrColIndC)
         {
             BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr_buffer_size
-                                (handle, C_num_rows, C_num_cols, C_nnz_tmp,
-                                 (rocsparse_mat_descr) matC_tmp, csrValC_tmp,
-                                 csrRowPtrC_tmp, csrColIndC_tmp, &threshold,
+                                (handle, C_num_rows, C_num_cols,
+                                 C_nnz_tmp,
+                                 (rocsparse_mat_descr) matC_tmp,
+                                 csrValC_tmp_sorted, csrRowPtrC_tmp,
+                                 csrColIndC_tmp, &threshold,
                                  (rocsparse_mat_descr) matC, csrValC,
                                  csrRowPtrC, csrColIndC, &lworkInBytes));
         }
@@ -1261,18 +1296,22 @@ void TYPED_FUNC(
 #pragma omp target enter data map(alloc:dwork[:lworkInBytes])
 
         // xprune stages 2, 3 = determine nnz, perform pruning
-#pragma omp target data use_device_ptr(csrValC_tmp,csrRowPtrC_tmp, csrColIndC_tmp,dwork,csrValC, csrRowPtrC, csrColIndC)
+#pragma omp target data use_device_ptr(csrValC_tmp_sorted, csrRowPtrC_tmp, csrColIndC_tmp, dwork, csrValC, csrRowPtrC, csrColIndC)
         {
             BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr_nnz
-                                (handle, C_num_rows, C_num_cols, C_nnz_tmp,
-                                 (rocsparse_mat_descr) matC_tmp, csrValC_tmp,
-                                 csrRowPtrC_tmp, csrColIndC_tmp, &threshold,
+                                (handle, C_num_rows, C_num_cols,
+                                 C_nnz_tmp,
+                                 (rocsparse_mat_descr) matC_tmp,
+                                 csrValC_tmp_sorted, csrRowPtrC_tmp,
+                                 csrColIndC_tmp, &threshold,
                                  (rocsparse_mat_descr) matC, csrRowPtrC,
                                  &nnzC, dwork));
             BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr
-                                (handle, C_num_rows, C_num_cols, C_nnz_tmp,
-                                 (rocsparse_mat_descr) matC_tmp, csrValC_tmp,
-                                 csrRowPtrC_tmp, csrColIndC_tmp, &threshold,
+                                (handle, C_num_rows, C_num_cols,
+                                 C_nnz_tmp,
+                                 (rocsparse_mat_descr) matC_tmp,
+                                 csrValC_tmp_sorted, csrRowPtrC_tmp,
+                                 csrColIndC_tmp, &threshold,
                                  (rocsparse_mat_descr) matC, csrValC,
                                  csrRowPtrC, csrColIndC, dwork));
         }
@@ -1283,10 +1322,13 @@ void TYPED_FUNC(
 */
 
         // Free the temporary arrays used on the device and host
-#pragma omp target exit data map(delete:csrRowPtrC_tmp[:C_num_rows+1],csrColIndC_tmp[:C_nnz_tmp],csrValC_tmp[:C_nnz_tmp],dwork[:lworkInBytes],dBuffer1[:bufferSize1])
+#pragma omp target exit data map(delete:csrRowPtrC_tmp[:C_num_rows+1],csrColIndC_tmp[:C_nnz_tmp],csrValC_tmp[:C_nnz_tmp],csrValC_tmp_sorted[:C_nnz_tmp],perm[:C_nnz_tmp],dwork[:lworkInBytes],dBuffer1[:bufferSize1])
+
         free(csrRowPtrC_tmp);
         free(csrColIndC_tmp);
         free(csrValC_tmp);
+        free(csrValC_tmp_sorted);
+        free(perm);
         free(dwork);
         free(dBuffer1);
 

--- a/src/typed.h
+++ b/src/typed.h
@@ -53,6 +53,7 @@
 #define bml_rocsparse_xprune_csr2csr_buffer_size rocsparse_sprune_csr2csr_buffer_size
 #define bml_rocsparse_xprune_csr2csr_nnz rocsparse_sprune_csr2csr_nnz
 #define bml_rocsparse_xprune_csr2csr rocsparse_sprune_csr2csr
+#define bml_rocsparse_xgthr rocsparse_sgthr
 #endif
 #elif defined(DOUBLE_REAL)
 #define REAL_T double
@@ -90,6 +91,7 @@
 #define bml_rocsparse_xprune_csr2csr_buffer_size rocsparse_dprune_csr2csr_buffer_size
 #define bml_rocsparse_xprune_csr2csr_nnz rocsparse_dprune_csr2csr_nnz
 #define bml_rocsparse_xprune_csr2csr rocsparse_dprune_csr2csr
+#define bml_rocsparse_xgthr rocsparse_dgthr
 #endif
 #elif defined(SINGLE_COMPLEX)
 /* Note that we are using `_Complex` here instead of the preferred `complex`


### PR DESCRIPTION
 o rocsparse_xprune does not support unsorted matrices in rocm 5.3
  - sort the matrix after multiplication and before pruning