### PR TITLE
Add local user to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		"context": "..",
 		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 		"dockerfile": "../Dockerfile-focal"
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -22,5 +22,5 @@
 	// "customizations": {},
 
 	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "devcontainer"
+	"remoteUser": "ubuntu"
 }

--- a/Dockerfile-focal
+++ b/Dockerfile-focal
@@ -1,6 +1,11 @@
 FROM ubuntu:focal
 LABEL org.opencontainers.image.authors="nicolasbock@gmail.com"
 
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install --yes sudo
+RUN useradd --create-home --user-group --groups sudo ubuntu
+RUN sed --in-place --expression '/^%sudo/ s/ALL$/NOPASSWD: ALL/' /etc/sudoers
+
 COPY scripts/prepare-container-focal.sh /usr/sbin
 
 RUN /usr/sbin/prepare-container-focal.sh install_base


### PR DESCRIPTION
Using root in the container will create files owned by root on the host
which is quite inconvenient. Instead, use a non-root user, ubuntu, which
will be mapped by VSCode to the current UID/PID.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
