### PR TITLE
Pull devcontainer from Docker Hub

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-	"build": {
-		// Sets the run context to one level up instead of the .devcontainer folder.
-		"context": "..",
-		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-		"dockerfile": "../Dockerfile-focal"
-	},
+	"image": "nicolasbock/bml:latest",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},


### PR DESCRIPTION
Which is much faster than building a fresh container image every time.

Signed-off-by: Nicolas Bock <nicolasbock@gmail.com>
