### PR TITLE
Rocsparse add targeting OLCF Frontier

### DIFF
--- a/src/C-interface/ellpack/bml_add_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_add_ellpack_typed.c
@@ -22,7 +22,7 @@
 #include <cusparse.h>
 #endif
 #ifdef BML_USE_ROCSPARSE
-// Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
+// Copy rocsparse headers into src/C-interface/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
 #include "../rocsparse/rocsparse.h"
 /* DEBUG
 #include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()

--- a/src/C-interface/ellpack/bml_add_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_add_ellpack_typed.c
@@ -23,7 +23,6 @@
 #endif
 #ifdef BML_USE_ROCSPARSE
 // Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
-#include "bml_threshold_ellpack.h"
 #include "../rocsparse/rocsparse.h"
 /* DEBUG
 #include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()
@@ -928,7 +927,7 @@ void TYPED_FUNC(
 			   matC_tmp, csrValC_tmp,
 			   csrRowPtrC_tmp, csrColIndC_tmp, &threshold,
 			   matA, csrRowPtrA,
-			   &csrRowPtrA[A_N], dwork));
+			   &nnzA, dwork));
       BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr
 			  (handle, A_N, A_N, nnzC_tmp,
 			   (rocsparse_mat_descr) matC_tmp, csrValC_tmp,
@@ -953,7 +952,7 @@ void TYPED_FUNC(
     // Update ellpack C matrix (on device): copy from csr to ellpack format
     TYPED_FUNC(bml_cucsr2ellpack_ellpack) (A);
 
-    bml_threshold_ellpack(A, threshold);
+    //    bml_threshold_ellpack(A, threshold);
 	
     // Clean up
     BML_CHECK_ROCSPARSE(rocsparse_destroy_mat_descr(matA));

--- a/src/C-interface/ellpack/bml_allocate_ellpack.h
+++ b/src/C-interface/ellpack/bml_allocate_ellpack.h
@@ -2,6 +2,13 @@
 #define __BML_ALLOCATE_ELLPACK_H
 
 #include "bml_types_ellpack.h"
+#ifdef BML_USE_ROCSPARSE
+// Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
+#include "../rocsparse/rocsparse.h"
+/* DEBUG
+#include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()
+*/
+#endif
 
 void bml_deallocate_ellpack(
     bml_matrix_ellpack_t * A);
@@ -194,5 +201,43 @@ void bml_cucsr2ellpack_ellpack_single_complex(
     bml_matrix_ellpack_t * A);
 void bml_cucsr2ellpack_ellpack_double_complex(
     bml_matrix_ellpack_t * A);
+#endif
+
+#ifdef BML_USE_ROCSPARSE
+void bml_sort_rocsparse_ellpack(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A);
+void bml_sort_rocsparse_ellpack_single_real(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A);
+void bml_sort_rocsparse_ellpack_double_real(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A);
+void bml_sort_rocsparse_ellpack_single_complex(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A);
+void bml_sort_rocsparse_ellpack_double_complex(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A);
+void bml_prune_rocsparse_ellpack(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A,
+    double threshold);
+void bml_prune_rocsparse_ellpack_single_real(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A,
+    double threshold);
+void bml_prune_rocsparse_ellpack_double_real(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A,
+    double threshold);
+void bml_prune_rocsparse_ellpack_single_complex(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A,
+    double threshold);
+void bml_prune_rocsparse_ellpack_double_complex(
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A,
+    double threshold);
 #endif
 #endif

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef BML_USE_ROCSPARSE
-// Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
+// Copy rocsparse headers into src/C-interface/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
 #include "../rocsparse/rocsparse.h"
 /* DEBUG
 #include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -517,7 +517,7 @@ void TYPED_FUNC(
     bml_prune_rocsparse_ellpack) (
     rocsparse_handle handle,
     bml_matrix_ellpack_t * A,
-    double threshold)
+    double threshold_in)
 {
     int N = A->N;
     int M = A->M;
@@ -537,6 +537,8 @@ void TYPED_FUNC(
       
     size_t lworkInBytes = 0;
     char *dwork = NULL;
+
+    REAL_T threshold = (REAL_T)threshold_in;
 
 #pragma omp target map(from:nnz)
     {
@@ -617,7 +619,7 @@ void TYPED_FUNC(
 }
 #endif
 #if defined(BML_USE_CUSPARSE) || defined(BML_USE_ROCSPARSE)
- /** Ellpack to cuCSR conversion.
+/** Ellpack to cuCSR conversion.
  *
  *  Convert from Ellpack format to cusparse csr format.
  *  Naive implementation for testing. Use thrust library for optimal code.

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -15,6 +15,14 @@
 #include <omp.h>
 #endif
 
+#ifdef BML_USE_ROCSPARSE
+// Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
+#include "../rocsparse/rocsparse.h"
+/* DEBUG
+#include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()
+*/
+#endif
+
 /** Deallocate a matrix.
  *
  * \ingroup allocate_group
@@ -399,8 +407,217 @@ bml_matrix_ellpack_t *TYPED_FUNC(
     return A;
 }
 
+#if defined(BML_USE_ROCSPARSE)
+/** Sort the column indices of a rocsparse CSR matrix
+ *
+ *
+ *  \ingroup
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+void TYPED_FUNC(
+    bml_sort_rocsparse_ellpack) (
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A)
+{
+    int N = A->N;
+    int M = A->M;
+    int *csrColInd = A->csrColInd;
+    int *csrRowPtr = A->csrRowPtr;
+    REAL_T *csrVal = A->csrVal;
+    int nnz;
+
+    int i;
+    
+    REAL_T *csrVal_tmp;
+
+    rocsparse_mat_descr mat;
+      
+    size_t lworkInBytes = 0;
+    char *dwork = NULL;
+
+    nnz = csrRowPtr[N];
+    // Temporary array for sorting
+    
+    csrVal_tmp = (REAL_T *) malloc(sizeof(REAL_T)* nnz);
+
+        // rocSPARSE APIs
+    rocsparse_status status = rocsparse_status_success;
+
+    rocsparse_datatype computeType = BML_ROCSPARSE_T;
+
+    BML_CHECK_ROCSPARSE(rocsparse_create_mat_descr
+			(&mat));
+
+        // Sort the matrix
+#pragma omp target data use_device_ptr(csrRowPtr, csrColInd)
+    {
+      BML_CHECK_ROCSPARSE(rocsparse_csrsort_buffer_size
+			  (handle, N, N,
+			   nnz, csrRowPtr,
+			   csrColInd, &lworkInBytes));
+    }
+    dwork = (char *) malloc(sizeof(char)*lworkInBytes);
+    rocsparse_int *perm;
+    perm = (rocsparse_int *) malloc(nnz * sizeof(rocsparse_int));
+    REAL_T *csrVal_tmp_sorted;
+    csrVal_tmp = (REAL_T *) malloc(nnz * sizeof(REAL_T));
+#pragma omp target enter data map(alloc:dwork[:lworkInBytes],perm[:nnz],csrVal_tmp[:nnz])
+
+#pragma omp target teams distribute parallel for
+    for (i=0; i<nnz; i++) {
+      csrVal_tmp[i] = csrVal[i];
+    }
+#pragma omp target data use_device_ptr(csrRowPtr,	\
+				       csrColInd, perm, dwork,	\
+				       csrVal_tmp, csrVal)
+    {
+      BML_CHECK_ROCSPARSE(rocsparse_create_identity_permutation
+			  (handle, nnz, perm));
+      BML_CHECK_ROCSPARSE(rocsparse_csrsort
+			  (handle, N, N,
+			   nnz,
+			   (rocsparse_mat_descr) mat,
+			   csrRowPtr, csrColInd, perm,
+			   dwork));
+      BML_CHECK_ROCSPARSE(bml_rocsparse_xgthr
+			  (handle, nnz, csrVal_tmp,
+			   csrVal, perm,
+			   rocsparse_index_base_zero));
+      //      BML_CHECK_ROCSPARSE(rocsparse_spmat_set_values
+      //			  ((rocsparse_mat_descr) matC_tmp, csrValC_tmp_sorted));
+    }
+
+#pragma omp target exit data map(delete:csrVal_tmp[:nnz],perm[:nnz],dwork[:lworkInBytes])
+    free(csrVal_tmp);
+    free(perm);
+    free(dwork);
+
+    BML_CHECK_ROCSPARSE(rocsparse_destroy_mat_descr(mat));
+}
+
+/** Prune (threshold) a rocsparse CSR matrix
+ *
+ *
+ *  \ingroup
+ *
+ *  \param matrix_precision The precision of the matrix. The default
+ *  is double precision.
+ *  \param N The matrix size.
+ *  \param M The number of non-zeroes per row.
+ *  \param distrib_mode The distribution mode.
+ *  \return The matrix.
+ */
+void TYPED_FUNC(
+    bml_prune_rocsparse_ellpack) (
+    rocsparse_handle handle,
+    bml_matrix_ellpack_t * A,
+    double threshold)
+{
+    int N = A->N;
+    int M = A->M;
+    int *csrColInd = A->csrColInd;
+    int *csrRowPtr = A->csrRowPtr;
+    REAL_T *csrVal = A->csrVal;
+    int nnz;
+
+    int i;
+    
+    int *csrRowPtr_tmp;
+    int *csrColInd_tmp;
+    REAL_T *csrVal_tmp;
+    int nnz_tmp;
+    
+    rocsparse_mat_descr mat, mat_tmp;
+      
+    size_t lworkInBytes = 0;
+    char *dwork = NULL;
+
+#pragma omp target map(from:nnz)
+    {
+      nnz = csrRowPtr[N];
+    }
+    
+    // Temporary array for sorting
+
+    csrRowPtr_tmp = (int *) malloc(sizeof(int)*(N + 1));
+    csrColInd_tmp = (int *) malloc(sizeof(int)* nnz);
+    csrVal_tmp = (REAL_T *) malloc(sizeof(REAL_T)* nnz);
+    nnz_tmp = nnz;
+
+#pragma omp target enter data map(alloc:csrRowPtr_tmp[:N+1],csrColInd_tmp[:nnz],csrVal_tmp[:nnz])
+    
+#pragma omp target teams distribute parallel for
+    for (i=0; i<=N; i++) {
+      csrRowPtr_tmp[i] = csrRowPtr[i];
+    }
+    
+#pragma omp target teams distribute parallel for
+    for (i=0; i<nnz; i++) {
+      csrColInd_tmp[i] = csrColInd[i];
+      csrVal_tmp[i] = ((REAL_T *)csrVal)[i];
+    }
+        // rocSPARSE APIs
+    rocsparse_status status = rocsparse_status_success;
+
+    rocsparse_datatype computeType = BML_ROCSPARSE_T;
+
+    BML_CHECK_ROCSPARSE(rocsparse_create_mat_descr
+			(&mat));
+    BML_CHECK_ROCSPARSE(rocsparse_create_mat_descr
+			(&mat_tmp));
+
+    // Prune the output matrix and overwrite the A matrix with the result
+    
+    // xprune stage 1 = determine working buffer size
+#pragma omp target data use_device_ptr(csrVal_tmp,csrRowPtr_tmp, csrColInd_tmp,csrVal, csrRowPtr, csrColInd)
+    {
+      BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr_buffer_size
+			  (handle, N, N, nnz_tmp,
+			   mat_tmp, csrVal_tmp,
+			   csrRowPtr_tmp, csrColInd_tmp, &threshold,
+			   mat, csrVal,
+			   csrRowPtr, csrColInd, &lworkInBytes));
+    }
+    // Allocate the working buffer on the host and device
+    dwork = (char *) malloc(sizeof(char) * lworkInBytes);
+#pragma omp target enter data map(alloc:dwork[:lworkInBytes])
+    
+    // xprune stages 2, 3 = determine nnz, perform pruning
+#pragma omp target data use_device_ptr(csrVal_tmp,csrRowPtr_tmp, csrColInd_tmp,dwork,csrVal, csrRowPtr, csrColInd)
+    {
+      BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr_nnz
+			  (handle, N, N, nnz_tmp,
+			   mat_tmp, csrVal_tmp,
+			   csrRowPtr_tmp, csrColInd_tmp, &threshold,
+			   mat, csrRowPtr,
+			   &nnz, dwork));
+      BML_CHECK_ROCSPARSE(bml_rocsparse_xprune_csr2csr
+			  (handle, N, N, nnz_tmp,
+			   (rocsparse_mat_descr) mat_tmp, csrVal_tmp,
+			   csrRowPtr_tmp, csrColInd_tmp, &threshold,
+			   (rocsparse_mat_descr) mat, csrVal,
+			   csrRowPtr, csrColInd, dwork));
+    }
+
+
+#pragma omp target exit data map(delete:csrRowPtr_tmp[:N+1],csrColInd_tmp[:nnz_tmp],csrVal_tmp[:nnz_tmp],dwork[:lworkInBytes])
+    free(csrRowPtr_tmp);
+    free(csrColInd_tmp);
+    free(csrVal_tmp);
+    free(dwork);
+    
+    BML_CHECK_ROCSPARSE(rocsparse_destroy_mat_descr(mat));
+    BML_CHECK_ROCSPARSE(rocsparse_destroy_mat_descr(mat_tmp));
+}
+#endif
 #if defined(BML_USE_CUSPARSE) || defined(BML_USE_ROCSPARSE)
-/** Ellpack to cuCSR conversion.
+ /** Ellpack to cuCSR conversion.
  *
  *  Convert from Ellpack format to cusparse csr format.
  *  Naive implementation for testing. Use thrust library for optimal code.

--- a/src/C-interface/ellpack/bml_copy_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_copy_ellpack_typed.c
@@ -101,13 +101,14 @@ void TYPED_FUNC(
     int *B_nnz = B->nnz;
     REAL_T *B_value = B->value;
 
+    size_t NbyM = (size_t)N*(size_t)M;
 #ifdef USE_OMP_OFFLOAD
 #pragma omp target teams distribute parallel for
     for (int i = 0; i < N; i++)
     {
         B_nnz[i] = A_nnz[i];
     }
-
+    /*
 #pragma omp target teams distribute parallel for collapse(2) schedule (static, 1)
     for (int i = 0; i < N; i++)
     {
@@ -116,6 +117,13 @@ void TYPED_FUNC(
             B_index[ROWMAJOR(i, j, N, M)] = A_index[ROWMAJOR(i, j, N, M)];
             B_value[ROWMAJOR(i, j, N, M)] = A_value[ROWMAJOR(i, j, N, M)];
         }
+    }
+    */
+#pragma omp target teams distribute parallel for schedule (static,1)
+    for (int i = 0; i < NbyM; i++)
+    {
+      B_index[i] = A_index[i];
+      B_value[i] = A_value[i];
     }
 #else
     // memcpy(B->index, A->index, sizeof(int) * A->N * A->M);

--- a/src/C-interface/ellpack/bml_copy_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_copy_ellpack_typed.c
@@ -119,7 +119,7 @@ void TYPED_FUNC(
         }
     }
     */
-#pragma omp target teams distribute parallel for schedule (static,1)
+#pragma omp target teams distribute parallel for schedule (static,1) map(to:NbyM)
     for (int i = 0; i < NbyM; i++)
     {
       B_index[i] = A_index[i];

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -28,7 +28,7 @@
 #endif
 #ifdef BML_USE_ROCSPARSE
 #include "bml_trace_ellpack.h"
-// Copy rocsparse headers into src/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
+// Copy rocsparse headers into src/C-insterface/rocsparse/ and edit rocsparse_functions.h to remove '[[...]]' text
 #include "../rocsparse/rocsparse.h"
 //#include <hip/hip_runtime.h> // needed for hipDeviceSynchronize()
 #endif

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -1069,15 +1069,14 @@ void TYPED_FUNC(
     TYPED_FUNC(bml_sort_rocsparse_ellpack) (handle,B);
     TYPED_FUNC(bml_sort_rocsparse_ellpack) (handle,C);
 
-    // Create cusparse matrix A and B in CSR format
-    // Note: The following update is not necessary since the ellpack2cucsr
-    // routine updates the csr rowpointers on host and device
-#pragma omp target update from(csrRowPtrA[:A_N+1])
-#pragma omp target update from(csrRowPtrB[:B_N+1])
-#pragma omp target update from(csrRowPtrC[:C_N+1])
-    int nnzA = csrRowPtrA[A_N];
-    int nnzB = csrRowPtrB[B_N];
-    int nnzC_in = csrRowPtrC[C_N];
+    // Get total number of nonzero elements for rocsparse calls
+    int nnzA, nnzB, nnzC_in;
+#pragma omp target map(from:nnzA,nnzB,nnzC_in)
+    {
+      nnzA = csrRowPtrA[A_N];
+      nnzB = csrRowPtrB[B_N];
+      nnzC_in = csrRowPtrC[C_N];
+    }
 
     // special case not well handled by cusparse
 

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -1232,7 +1232,7 @@ void TYPED_FUNC(
 
 	// Sort the resulting matrix
 	TYPED_FUNC(bml_sort_rocsparse_ellpack) (handle,C);
-	BML_CHECK_ROCSPARSE(rocsparse_set_mat_storage_mode(matC, rocsparse_storage_mode_sorted));
+	BML_CHECK_ROCSPARSE(rocsparse_set_mat_storage_mode((rocsparse_mat_descr)matC, rocsparse_storage_mode_sorted));
 	
 	// Prune (threshold) the resulting matrix
 	TYPED_FUNC(bml_prune_rocsparse_ellpack) (handle,C,threshold);

--- a/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_multiply_ellpack_typed.c
@@ -1233,9 +1233,9 @@ void TYPED_FUNC(
 	// Sort the resulting matrix
 	TYPED_FUNC(bml_sort_rocsparse_ellpack) (handle,C);
 	BML_CHECK_ROCSPARSE(rocsparse_set_mat_storage_mode(matC, rocsparse_storage_mode_sorted));
+	
 	// Prune (threshold) the resulting matrix
 	TYPED_FUNC(bml_prune_rocsparse_ellpack) (handle,C,threshold);
-
 
         // Free the temporary arrays used on the device and host
 #pragma omp target exit data map(delete:csrRowPtrC_tmp[:C_num_rows+1],csrColIndC_tmp[:C_nnz_tmp],csrValC_tmp[:C_nnz_tmp],dBuffer1[:bufferSize1])

--- a/src/typed.h
+++ b/src/typed.h
@@ -48,7 +48,6 @@
 #define bml_cusparsePruneCSR cusparseSpruneCsr2csr
 #elif defined (BML_USE_ROCSPARSE)
 #define BML_ROCSPARSE_T rocsparse_datatype_f32_r
-#define bml_rocsparse_csrgeam_buffer_size rocsparse_scsrgeam_buffer_size
 #define bml_rocsparse_csrgeam rocsparse_scsrgeam
 #define bml_rocsparse_xprune_csr2csr_buffer_size rocsparse_sprune_csr2csr_buffer_size
 #define bml_rocsparse_xprune_csr2csr_nnz rocsparse_sprune_csr2csr_nnz
@@ -86,7 +85,6 @@
 #define bml_cusparsePruneCSR cusparseDpruneCsr2csr
 #elif defined (BML_USE_ROCSPARSE)
 #define BML_ROCSPARSE_T rocsparse_datatype_f64_r
-#define bml_rocsparse_csrgeam_buffer_size rocsparse_dcsrgeam_buffer_size
 #define bml_rocsparse_csrgeam rocsparse_dcsrgeam
 #define bml_rocsparse_xprune_csr2csr_buffer_size rocsparse_dprune_csr2csr_buffer_size
 #define bml_rocsparse_xprune_csr2csr_nnz rocsparse_dprune_csr2csr_nnz
@@ -127,7 +125,6 @@
 #define bml_cusparsePruneCSR cusparseCpruneCsr2csr
 #elif defined (BML_USE_ROCSPARSE)
 #define BML_ROCSPARSE_T rocsparse_datatype_f32_c
-#define bml_rocsparse_csrgeam_buffer_size rocsparse_ccsrgeam_buffer_size
 #define bml_rocsparse_csrgeam rocsparse_ccsrgeam
 #define bml_rocsparse_xprune_csr2csr_buffer_size rocsparse_cprune_csr2csr_buffer_size
 #define bml_rocsparse_xprune_csr2csr_nnz rocsparse_cprune_csr2csr_nnz
@@ -165,7 +162,6 @@
 #define bml_cusparsePruneCSR cusparseZpruneCsr2csr
 #elif defined (BML_USE_ROCSPARSE)
 #define BML_ROCSPARSE_T rocsparse_datatype_f64_c
-#define bml_rocsparse_csrgeam_buffer_size rocsparse_zcsrgeam_buffer_size
 #define bml_rocsparse_csrgeam rocsparse_zcsrgeam
 #define bml_rocsparse_xprune_csr2csr_buffer_size rocsparse_zprune_csr2csr_buffer_size
 #define bml_rocsparse_xprune_csr2csr_nnz rocsparse_zprune_csr2csr_nnz


### PR DESCRIPTION
Working rocsparse add and multiply fix
    
    o New bml_add_ellpack() method using rocsparse
    o New bml_sort_rocsparse_ellpack() method to sort csr column indices
    o New bml_prune_rocsparse_ellpack() method to threshold the csr matrix
    o Modify bml_multiply_ellpack() rocpsarse to use the new sort and prune
       - Addresses issue where unsorted array might be passed, potentially causing errors
    o Progress benchmarks produce correct results using rocsparse
