### PR TITLE
Add script to install rocsparse headers on OLCF machines

### DIFF
--- a/scripts/install_rocsparse_headers_olcf.sh
+++ b/scripts/install_rocsparse_headers_olcf.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+this_dir=$(pwd)
+if [[ ! -e src/C-interface || $this_dir == *build ]]; then
+	echo "Please run this script in the bml/ root directory"
+	exit 1
+fi
+cp -r $ROCM_PATH/include/rocsparse src/C-interface/.
+sed -i -e 's/\[\[.*//' src/C-interface/rocsparse/rocsparse-functions.h 
+sed -i -e 's/.*\]\] ROCSPARSE_EXPORT/ROCSPARSE_EXPORT/' src/C-interface/rocsparse/rocsparse-functions.h

--- a/scripts/install_rocsparse_headers_olcf.sh
+++ b/scripts/install_rocsparse_headers_olcf.sh
@@ -2,9 +2,9 @@
 #
 this_dir=$(pwd)
 if [[ ! -e src/C-interface || $this_dir == *build ]]; then
-	echo "Please run this script in the bml/ root directory"
-	exit 1
+    echo "Please run this script in the bml/ root directory"
+    exit 1
 fi
 cp -r $ROCM_PATH/include/rocsparse src/C-interface/.
-sed -i -e 's/\[\[.*//' src/C-interface/rocsparse/rocsparse-functions.h 
+sed -i -e 's/\[\[.*//' src/C-interface/rocsparse/rocsparse-functions.h
 sed -i -e 's/.*\]\] ROCSPARSE_EXPORT/ROCSPARSE_EXPORT/' src/C-interface/rocsparse/rocsparse-functions.h


### PR DESCRIPTION
Temporary fix on OLCF machines for rocsparse header bug, until rocm 5.5 is deployed

Run the following from the bml/ root dir:

bash scripts/install_rocsparse_headers_olcf.sh