### PR TITLE
Fix bug in indent.sh script

### DIFF
--- a/scripts/indent.sh
+++ b/scripts/indent.sh
@@ -39,6 +39,7 @@ if (( $# > 0 )); then
                 echo "unknown suffix"
                 ;;
         esac
+        shift
     done
 else
     readarray -t SH_FILES < <(git ls-files -- '*.sh')


### PR DESCRIPTION
o The indent script wasn't parsing the input file list correctly
  - add "shift" statement to fix this