### PR TITLE
Fix progress rocsparse tests

### DIFF
--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -441,7 +441,10 @@ void TYPED_FUNC(
     size_t lworkInBytes = 0;
     char *dwork = NULL;
 
-    nnz = csrRowPtr[N];
+#pragma omp target map(to:N) map(from:nnz)
+    {
+      nnz = csrRowPtr[N];
+    }
     // Temporary array for sorting
     
     csrVal_tmp = (REAL_T *) malloc(sizeof(REAL_T)* nnz);


### PR DESCRIPTION
    Fix rocSPARSE bug causing progress issues
    
    Issues:
    
    o Ellpack progress tests were failing for rocSPARSE build
    o Progress benchmark was also failing for N>=6000
    
    Fix:
    
    o bml_sort_rocsparse_ellpack was obtaining nnz from host array
    o changed this to obtain nnz from device array
