### PR TITLE
Fix random matrix

### DIFF
--- a/src/C-interface/csr/bml_allocate_csr_typed.c
+++ b/src/C-interface/csr/bml_allocate_csr_typed.c
@@ -326,8 +326,9 @@ bml_matrix_csr_t *TYPED_FUNC(
                 /* mark column index position */
                 col_marker[col] = 1;
                 nnz_row++;
-            }
-            col = rand() % (N + 1);
+            }            
+            /* generate random column index 0 >= col < N */
+            col = rand() % N;
         }
         /* update nnz of row */
         row->NNZ_ = nnz_row;
@@ -348,6 +349,10 @@ bml_matrix_csr_t *TYPED_FUNC(
         A->table_ = NULL;
     }
 
+    /* free memory */
+    bml_free_memory(col_marker);
+    bml_free_memory(col_marker_pos);
+    
     return A;
 }
 

--- a/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
@@ -375,7 +375,8 @@ bml_matrix_ellblock_t *TYPED_FUNC(
                 bcol_marker[bcol] = 1;
                 bnnz_row++;
             }
-            bcol = rand() % (NB + 1);
+            /* generate random column index 0 >= bcol < NB */
+            bcol = rand() % NB;
         }
         A_nnzb[ib] = bnnz_row;
         /* reset col_marker */

--- a/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_allocate_ellblock_typed.c
@@ -330,35 +330,64 @@ bml_matrix_ellblock_t *TYPED_FUNC(
     //now fill with random values
     int NB = A->NB;
     int MB = A->MB;
-
     REAL_T **A_ptr_value = (REAL_T **) A->ptr_value;
     int *A_indexb = A->indexb;
     int *A_nnzb = A->nnzb;
 
+    const REAL_T INV_RAND_MAX = 1.0 / (REAL_T) RAND_MAX;
+
+    int *bcol_marker = bml_allocate_memory(sizeof(int) * NB );
+    int *bcol_marker_pos = bml_allocate_memory(sizeof(int) * MB );
+/* initialize bcol_marker */
+    for (int j = 0; j < NB; j++)
+    {
+        bcol_marker[j] = -1;
+    }
+
     for (int ib = 0; ib < NB; ib++)
     {
-        for (int jp = 0; jp < MB; jp++)
+        int bcol = ib;
+        int bnnz_row = 0;
+        for (int jb = 0; jb < MB; jb++)
         {
-            int ind = ROWMAJOR(ib, jp, NB, MB);
-            A_indexb[ind] = jp;
-            int jb = A_indexb[ind];
+            if(bcol_marker[bcol] == -1)
+            {
+                int ind = ROWMAJOR(ib, bnnz_row, NB, MB);
+                A_indexb[ind] = bcol; 
+                //allocate storage
+                int nelements = bsize[ib] * bsize[bcol];
+                A_ptr_value[ind] =
+                    TYPED_FUNC(bml_allocate_block_ellblock) (A, ib, nelements);
 
-            //allocate storage
-            int nelements = bsize[ib] * bsize[jb];
-            A_ptr_value[ind] =
-                TYPED_FUNC(bml_allocate_block_ellblock) (A, ib, nelements);
-
-            REAL_T *A_value = A_ptr_value[ind];
-            assert(A_value != NULL);
-            for (int ii = 0; ii < bsize[ib]; ii++)
-                for (int jj = 0; jj < bsize[jb]; jj++)
-                {
-                    A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[jb])] =
-                        rand() / (REAL_T) RAND_MAX;
+                REAL_T *A_value = A_ptr_value[ind];
+                assert(A_value != NULL);
+                for (int ii = 0; ii < bsize[ib]; ii++)
+                { 
+                    for (int jj = 0; jj < bsize[bcol]; jj++)
+                    {
+                        A_value[ROWMAJOR(ii, jj, bsize[ib], bsize[bcol])] =
+                            rand() / (REAL_T) RAND_MAX;
+                    }
                 }
+                /* save position of col_marker */
+                bcol_marker_pos[bnnz_row] = bcol;
+                /* mark column index position */
+                bcol_marker[bcol] = 1;
+                bnnz_row++;
+            }
+            bcol = rand() % (NB + 1);
         }
-        A_nnzb[ib] = MB;
+        A_nnzb[ib] = bnnz_row;
+        /* reset col_marker */
+        for (int j = 0; j < bnnz_row; j++)
+        {
+            bcol_marker[bcol_marker_pos[j]] = -1; 
+        }        
     }
+    /* free memory */
+    bml_free_memory(bcol_marker);
+    bml_free_memory(bcol_marker_pos);
+
     return A;
 }
 

--- a/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
+++ b/src/C-interface/ellblock/bml_multiply_ellblock_typed.c
@@ -234,6 +234,9 @@ void TYPED_FUNC(
  *
  * \f$ X^{2} \leftarrow X \, X \f$
  *
+ * Note: the matrix X2 is overwritten with the result.
+ * Since X2 and X may have different non-zero patterns, we need to clear X2 before overwriting.
+ *
  * \ingroup multiply_group
  *
  * \param X Matrix X
@@ -252,12 +255,14 @@ void *TYPED_FUNC(
     int *X_nnzb = X->nnzb;
     int *bsize = X->bsize;
 
+    REAL_T traceX = 0.0;
+    REAL_T **X_ptr_value = (REAL_T **) X->ptr_value;
+
+    /* clear X2 and set pointers to data */
+    TYPED_FUNC(bml_clear_ellblock) (X2);
     int *X2_indexb = X2->indexb;
     int *X2_nnzb = X2->nnzb;
-
-    REAL_T traceX = 0.0;
     REAL_T traceX2 = 0.0;
-    REAL_T **X_ptr_value = (REAL_T **) X->ptr_value;
     REAL_T **X2_ptr_value = (REAL_T **) X2->ptr_value;
 
     double *trace = bml_allocate_memory(sizeof(double) * 2);
@@ -411,10 +416,9 @@ void *TYPED_FUNC(
                 int nelements = bsize[ib] * bsize[jp];
                 int ind = ROWMAJOR(ib, ll, NB, MB);
                 assert(ind < NB * MB);
-                if (X2_ptr_value[ind] == NULL)
-                    X2_ptr_value[ind] =
-                        TYPED_FUNC(bml_allocate_block_ellblock) (X2, ib,
-                                                                 nelements);
+                /* Allocate memory to hold block */
+                X2_ptr_value[ind] =
+                    TYPED_FUNC(bml_allocate_block_ellblock) (X2, ib, nelements);
                 REAL_T *X2_value = X2_ptr_value[ind];
                 assert(X2_value != NULL);
                 memcpy(X2_value, xtmp, nelements * sizeof(REAL_T));

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -474,7 +474,10 @@ void TYPED_FUNC(
     size_t lworkInBytes = 0;
     char *dwork = NULL;
 
-    nnz = csrRowPtr[N];
+#pragma omp target map(to:N) map(from:nnz)
+    {
+      nnz = csrRowPtr[N];
+    }
     // Temporary array for sorting
     
     csrVal_tmp = (REAL_T *) malloc(sizeof(REAL_T)* nnz);
@@ -573,7 +576,7 @@ void TYPED_FUNC(
 
     REAL_T threshold = (REAL_T)threshold_in;
 
-#pragma omp target map(from:nnz)
+#pragma omp target map(to:N) map(from:nnz)
     {
       nnz = csrRowPtr[N];
     }

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -316,6 +316,12 @@ bml_matrix_ellpack_t *TYPED_FUNC(
  *  Note that the matrix \f$ a \f$ will be newly allocated. If it is
  *  already allocated then the matrix will be deallocated in the
  *  process.
+ * 
+ * NOTE: 
+ *  The resulting nonzero structure is not necessarily uniform since we 
+ *  are sampling between [0, N], N << RAND_MAX. The diagonal entry is 
+ *  stored first.
+ *  
  *
  *  \ingroup allocate_group
  *
@@ -338,21 +344,49 @@ bml_matrix_ellpack_t *TYPED_FUNC(
     bml_matrix_ellpack_t *A =
         TYPED_FUNC(bml_zero_matrix_ellpack) (N, M, distrib_mode);
 
+    int *col_marker = bml_allocate_memory(sizeof(int) * N );
+    int *col_marker_pos = bml_allocate_memory(sizeof(int) * M );
+    
     REAL_T *A_value = A->value;
     int *A_index = A->index;
     int *A_nnz = A->nnz;
     const REAL_T INV_RAND_MAX = 1.0 / (REAL_T) RAND_MAX;
+
+/* initialize col_marker */
+    for (int j = 0; j < N; j++)
+    {
+        col_marker[j] = -1;
+    }
     for (int i = 0; i < N; i++)
     {
-        int jind = 0;
+        int col = i;
+        int nnz_row = 0;
         for (int j = 0; j < M; j++)
         {
-            A_value[ROWMAJOR(i, jind, N, M)] = rand() * INV_RAND_MAX;
-            A_index[ROWMAJOR(i, jind, N, M)] = j;
-            jind++;
+            if(col_marker[col] == -1)
+            {
+                A_value[ROWMAJOR(i, nnz_row, N, M)] = rand() * INV_RAND_MAX;
+                A_index[ROWMAJOR(i, nnz_row, N, M)] = col;
+                /* save position of col_marker */
+                col_marker_pos[nnz_row] = col;
+                /* mark column index position */
+                col_marker[col] = 1;
+                nnz_row++;
+            }
+            col = rand() % (N + 1);
         }
-        A_nnz[i] = jind;
+        /* update nnz of row */
+        A_nnz[i] = nnz_row;
+        /* reset col_marker */
+        for (int j = 0; j < nnz_row; j++)
+        {
+            col_marker[col_marker_pos[j]] = -1; 
+        }
     }
+    /* free memory */
+    bml_free_memory(col_marker);
+    bml_free_memory(col_marker_pos);
+
 #if defined(USE_OMP_OFFLOAD)
 #pragma omp target update to(A_value[:N*M], A_index[:N*M], A_nnz[:N])
 #endif
@@ -439,10 +473,7 @@ void TYPED_FUNC(
     size_t lworkInBytes = 0;
     char *dwork = NULL;
 
-#pragma omp target map(to:N) map(from:nnz)
-    {
-      nnz = csrRowPtr[N];
-    }
+    nnz = csrRowPtr[N];
     // Temporary array for sorting
     
     csrVal_tmp = (REAL_T *) malloc(sizeof(REAL_T)* nnz);
@@ -541,7 +572,7 @@ void TYPED_FUNC(
 
     REAL_T threshold = (REAL_T)threshold_in;
 
-#pragma omp target map(to:N) map(from:nnz)
+#pragma omp target map(from:nnz)
     {
       nnz = csrRowPtr[N];
     }

--- a/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_allocate_ellpack_typed.c
@@ -373,7 +373,8 @@ bml_matrix_ellpack_t *TYPED_FUNC(
                 col_marker[col] = 1;
                 nnz_row++;
             }
-            col = rand() % (N + 1);
+            /* generate random column index 0 >= col < N */
+            col = rand() % N;
         }
         /* update nnz of row */
         A_nnz[i] = nnz_row;


### PR DESCRIPTION
This PR introduces a new strategy for constructing sparse (arbitrary) random matrices. This fixes issues with the previous approach that assumed the column indexes per row are contiguous (as in dense matrices). The PR also corrects potential issues with our test framework due to the above assumption. This PR resolves issue #715. 