### PR TITLE
Add script for cray compiler on AMD GPU

### DIFF
--- a/scripts/build_crusher_magma_cce.sh
+++ b/scripts/build_crusher_magma_cce.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Make sure all the paths are correct
+
+rm -r build
+rm -r install
+
+MY_PATH=$(pwd)
+
+export CC=${CC:=cc}
+export FC=${FC:=ftn}
+export CXX=${CXX:=CC}
+
+export BLAS_VENDOR=${BLAS_VENDOR:=OpenBLAS}
+
+export BML_OPENMP=${BML_OPENMP:=yes}
+
+export BML_MAGMA=${BML_MAGMA:=yes}
+export MAGMA_ROOT=${OLCF_MAGMA_ROOT}
+export BML_ROCSOLVER=${BML_ROCSOLVER:=no}
+export BML_TESTING=${BML_TESTING:=yes}
+export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:=Release}
+export INSTALL_DIR="/autofs/nccs-svm1_proj/csc304/bml/crusher/cce"
+export EXTRA_FFLAGS=${EXTRA_FCFLAGS:="-hsystem_alloc"}
+
+export BML_NONMPI_PRECOMMAND=${BML_NONMPI_PRECOMMAND:="srun"}
+export BML_NONMPI_PRECOMMAND_ARGS=${BML_NONMPI_PRECOMMAND_ARGS:="-n1;-c4;--gpus=1"}
+
+./build.sh configure
+
+pushd build
+make -j8
+make install
+popd

--- a/scripts/setenv_crusher_magma_cce.sh
+++ b/scripts/setenv_crusher_magma_cce.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+module load craype-accel-amd-gfx90a
+module load cmake
+module load rocm/5.1.0
+module load magma/2.6.1
+module load cce/15.0.1
+module load openblas


### PR DESCRIPTION
cce/15.0.1 required instead of default to avoid segfaults rocm/5.1.0 required instead of default to avoid diagonalization tests failures (double and double complex)