### PR TITLE
Use cmake LAPACK function finders for Intel MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ endif()
 
 #check for functions in Lapack
 #(or OpenBLAS since OpenBLAS typically contains Lapack)
-if(LAPACK_FOUND OR (BLAS_VENDOR STREQUAL "OpenBLAS"))
+if(LAPACK_FOUND OR (BLAS_VENDOR STREQUAL "OpenBLAS") OR (BLAS_VENDOR MATCHES "Intel"))
   add_definitions(-DHAVE_LAPACK)
 
   set(CMAKE_REQUIRED_LIBRARIES


### PR DESCRIPTION
o This fixes a build bug seen using MKL for BLAS/LAPACK 
o Some syev functions (e.g. C_SSYEV) are being used without setting macros in CMakeLists.txt
o The fix adds the lines to define these macros