### PR TITLE
Rename f_c_string to bml_f_c_string to avoid conflict (issue 744)

### DIFF
--- a/src/Fortran-interface/bml_fc_tools_m.F90
+++ b/src/Fortran-interface/bml_fc_tools_m.F90
@@ -5,7 +5,7 @@ module bml_fc_tools_m
   implicit none
   private
 
-  public :: f_c_string
+  public :: bml_f_c_string
 
   integer, parameter :: LEN_C_NULL_CHAR = len(C_NULL_CHAR)
 
@@ -25,13 +25,13 @@ contains
   !!
   !! \param fstr  Fortran string.
   !! \return cstr  The Fortran string terminated with C NULL.
-  pure function f_c_string(fstr) result(cstr)
+  pure function bml_f_c_string(fstr) result(cstr)
 
     character(len=*, kind=C_CHAR), intent(in) :: fstr
     character(len=len_f_c_string(fstr), kind=C_CHAR) :: cstr
 
     cstr = trim(fstr)//C_NULL_CHAR
 
-  end function f_c_string
+  end function bml_f_c_string
 
 end module bml_fc_tools_m

--- a/src/Fortran-interface/bml_utilities_m.F90
+++ b/src/Fortran-interface/bml_utilities_m.F90
@@ -76,7 +76,7 @@ contains
     character(len=*, kind=C_CHAR), intent(in) :: filename
     type(bml_matrix_t), intent(in) :: a
 
-    call bml_read_bml_matrix_C(a%ptr, f_c_string(filename))
+    call bml_read_bml_matrix_C(a%ptr, bml_f_c_string(filename))
 
   end subroutine bml_read_matrix
 
@@ -89,7 +89,7 @@ contains
     character(len=*, kind=C_CHAR), intent(in) :: filename
     type(bml_matrix_t), intent(in) :: a
 
-    call bml_write_bml_matrix_C(a%ptr, f_c_string(filename))
+    call bml_write_bml_matrix_C(a%ptr, bml_f_c_string(filename))
 
   end subroutine bml_write_matrix
 


### PR DESCRIPTION
New compilers have f_c_string built in, renaming our function to avoid conflicts (issue #744)