### PR TITLE
Build bml with magma (v2.9) and newer gcc compiler (v 12.4.0)

### DIFF
--- a/src/C-interface/bml_init.c
+++ b/src/C-interface/bml_init.c
@@ -2,7 +2,7 @@
 #include "bml_parallel.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 #ifdef BML_USE_XSMM

--- a/src/C-interface/bml_init.c
+++ b/src/C-interface/bml_init.c
@@ -2,7 +2,8 @@
 #include "bml_parallel.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 #ifdef BML_USE_XSMM

--- a/src/C-interface/bml_init.c
+++ b/src/C-interface/bml_init.c
@@ -2,6 +2,7 @@
 #include "bml_parallel.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 #ifdef BML_USE_XSMM

--- a/src/C-interface/bml_shutdown.c
+++ b/src/C-interface/bml_shutdown.c
@@ -2,7 +2,7 @@
 #include "bml_parallel.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 #ifdef BML_USE_XSMM

--- a/src/C-interface/bml_shutdown.c
+++ b/src/C-interface/bml_shutdown.c
@@ -2,7 +2,8 @@
 #include "bml_parallel.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 #ifdef BML_USE_XSMM

--- a/src/C-interface/bml_shutdown.c
+++ b/src/C-interface/bml_shutdown.c
@@ -2,6 +2,7 @@
 #include "bml_parallel.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 #ifdef BML_USE_XSMM

--- a/src/C-interface/dense/bml_add_dense_typed.c
+++ b/src/C-interface/dense/bml_add_dense_typed.c
@@ -1,5 +1,6 @@
 /* Needs to be included before #include <complex.h>. */
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_add_dense_typed.c
+++ b/src/C-interface/dense/bml_add_dense_typed.c
@@ -1,6 +1,6 @@
 /* Needs to be included before #include <complex.h>. */
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_add_dense_typed.c
+++ b/src/C-interface/dense/bml_add_dense_typed.c
@@ -1,6 +1,7 @@
 /* Needs to be included before #include <complex.h>. */
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -8,7 +8,8 @@
 #include "bml_utilities_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -8,6 +8,7 @@
 #include "bml_utilities_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_allocate_dense_typed.c
+++ b/src/C-interface/dense/bml_allocate_dense_typed.c
@@ -8,7 +8,7 @@
 #include "bml_utilities_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_convert_dense_typed.c
+++ b/src/C-interface/dense/bml_convert_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_convert_dense_typed.c
+++ b/src/C-interface/dense/bml_convert_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_convert_dense_typed.c
+++ b/src/C-interface/dense/bml_convert_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_copy_dense_typed.c
+++ b/src/C-interface/dense/bml_copy_dense_typed.c
@@ -8,7 +8,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_copy_dense_typed.c
+++ b/src/C-interface/dense/bml_copy_dense_typed.c
@@ -8,7 +8,8 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_copy_dense_typed.c
+++ b/src/C-interface/dense/bml_copy_dense_typed.c
@@ -8,6 +8,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_diagonalize_dense.c
+++ b/src/C-interface/dense/bml_diagonalize_dense.c
@@ -10,6 +10,7 @@
 #include <float.h>
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #ifdef BML_USE_CUSOLVER
 #include <cuda_runtime.h>

--- a/src/C-interface/dense/bml_diagonalize_dense.c
+++ b/src/C-interface/dense/bml_diagonalize_dense.c
@@ -10,7 +10,8 @@
 #include <float.h>
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #ifdef BML_USE_CUSOLVER
 #include <cuda_runtime.h>

--- a/src/C-interface/dense/bml_diagonalize_dense.c
+++ b/src/C-interface/dense/bml_diagonalize_dense.c
@@ -10,7 +10,7 @@
 #include <float.h>
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #ifdef BML_USE_CUSOLVER
 #include <cuda_runtime.h>

--- a/src/C-interface/dense/bml_element_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_element_multiply_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_element_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_element_multiply_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_element_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_element_multiply_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_export_dense.c
+++ b/src/C-interface/dense/bml_export_dense.c
@@ -6,7 +6,8 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_export_dense.c
+++ b/src/C-interface/dense/bml_export_dense.c
@@ -6,7 +6,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_export_dense.c
+++ b/src/C-interface/dense/bml_export_dense.c
@@ -6,6 +6,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_export_dense_typed.c
+++ b/src/C-interface/dense/bml_export_dense_typed.c
@@ -8,7 +8,8 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_export_dense_typed.c
+++ b/src/C-interface/dense/bml_export_dense_typed.c
@@ -8,7 +8,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_export_dense_typed.c
+++ b/src/C-interface/dense/bml_export_dense_typed.c
@@ -8,6 +8,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_getters_dense_typed.c
+++ b/src/C-interface/dense/bml_getters_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_getters_dense_typed.c
+++ b/src/C-interface/dense/bml_getters_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_getters_dense_typed.c
+++ b/src/C-interface/dense/bml_getters_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_import_dense_typed.c
+++ b/src/C-interface/dense/bml_import_dense_typed.c
@@ -8,7 +8,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_import_dense_typed.c
+++ b/src/C-interface/dense/bml_import_dense_typed.c
@@ -8,7 +8,8 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_import_dense_typed.c
+++ b/src/C-interface/dense/bml_import_dense_typed.c
@@ -8,6 +8,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_inverse_dense_typed.c
+++ b/src/C-interface/dense/bml_inverse_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 //#elif (MKL_GPU)
 //#include "stdio.h"

--- a/src/C-interface/dense/bml_inverse_dense_typed.c
+++ b/src/C-interface/dense/bml_inverse_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 //#elif (MKL_GPU)
 //#include "stdio.h"

--- a/src/C-interface/dense/bml_inverse_dense_typed.c
+++ b/src/C-interface/dense/bml_inverse_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 //#elif (MKL_GPU)
 //#include "stdio.h"

--- a/src/C-interface/dense/bml_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_multiply_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_multiply_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_multiply_dense_typed.c
+++ b/src/C-interface/dense/bml_multiply_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_norm_dense_typed.c
+++ b/src/C-interface/dense/bml_norm_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #include "../bml_allocate.h"
 #endif

--- a/src/C-interface/dense/bml_norm_dense_typed.c
+++ b/src/C-interface/dense/bml_norm_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #include "../bml_allocate.h"
 #endif

--- a/src/C-interface/dense/bml_norm_dense_typed.c
+++ b/src/C-interface/dense/bml_norm_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #include "../bml_allocate.h"
 #endif

--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -13,7 +13,8 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -13,6 +13,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_normalize_dense_typed.c
+++ b/src/C-interface/dense/bml_normalize_dense_typed.c
@@ -13,7 +13,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -9,6 +9,7 @@
 #include "../bml_logger.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -9,7 +9,7 @@
 #include "../bml_logger.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_parallel_dense_typed.c
+++ b/src/C-interface/dense/bml_parallel_dense_typed.c
@@ -9,7 +9,8 @@
 #include "../bml_logger.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_scale_dense_typed.c
+++ b/src/C-interface/dense/bml_scale_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_scale_dense_typed.c
+++ b/src/C-interface/dense/bml_scale_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_scale_dense_typed.c
+++ b/src/C-interface/dense/bml_scale_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_setters_dense.c
+++ b/src/C-interface/dense/bml_setters_dense.c
@@ -5,7 +5,7 @@
 #include "bml_allocate_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_setters_dense.c
+++ b/src/C-interface/dense/bml_setters_dense.c
@@ -5,6 +5,7 @@
 #include "bml_allocate_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_setters_dense.c
+++ b/src/C-interface/dense/bml_setters_dense.c
@@ -5,7 +5,8 @@
 #include "bml_allocate_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_setters_dense_typed.c
+++ b/src/C-interface/dense/bml_setters_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_setters_dense_typed.c
+++ b/src/C-interface/dense/bml_setters_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_setters_dense_typed.c
+++ b/src/C-interface/dense/bml_setters_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_submatrix_dense_typed.c
+++ b/src/C-interface/dense/bml_submatrix_dense_typed.c
@@ -4,6 +4,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_submatrix_dense_typed.c
+++ b/src/C-interface/dense/bml_submatrix_dense_typed.c
@@ -4,7 +4,8 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_submatrix_dense_typed.c
+++ b/src/C-interface/dense/bml_submatrix_dense_typed.c
@@ -4,7 +4,7 @@
 #include "bml_types_dense.h"
 
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_threshold_dense_typed.c
+++ b/src/C-interface/dense/bml_threshold_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #include "../bml_export.h"
 #include "bml_export_dense.h"

--- a/src/C-interface/dense/bml_threshold_dense_typed.c
+++ b/src/C-interface/dense/bml_threshold_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma
 #include "magma_v2.h"
 #include "../bml_export.h"
 #include "bml_export_dense.h"

--- a/src/C-interface/dense/bml_threshold_dense_typed.c
+++ b/src/C-interface/dense/bml_threshold_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #include "../bml_export.h"
 #include "bml_export_dense.h"

--- a/src/C-interface/dense/bml_trace_dense_typed.c
+++ b/src/C-interface/dense/bml_trace_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_trace_dense_typed.c
+++ b/src/C-interface/dense/bml_trace_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_trace_dense_typed.c
+++ b/src/C-interface/dense/bml_trace_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_transpose_dense_typed.c
+++ b/src/C-interface/dense/bml_transpose_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_transpose_dense_typed.c
+++ b/src/C-interface/dense/bml_transpose_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_transpose_dense_typed.c
+++ b/src/C-interface/dense/bml_transpose_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_utilities_dense_typed.c
+++ b/src/C-interface/dense/bml_utilities_dense_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma 
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_utilities_dense_typed.c
+++ b/src/C-interface/dense/bml_utilities_dense_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma 
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/dense/bml_utilities_dense_typed.c
+++ b/src/C-interface/dense/bml_utilities_dense_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
@@ -1,5 +1,5 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h>
+#include <stdbool.h> //define boolean data type for magma
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
@@ -1,4 +1,5 @@
 #ifdef BML_USE_MAGMA
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 

--- a/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
+++ b/src/C-interface/ellpack/bml_submatrix_ellpack_typed.c
@@ -1,5 +1,6 @@
 #ifdef BML_USE_MAGMA
-#include <stdbool.h> //define boolean data type for magma
+//define boolean data type needed by magma
+#include <stdbool.h>
 #include "magma_v2.h"
 #endif
 


### PR DESCRIPTION
Added include file <stdbool.h> before the <magma_v2.h> include. On my newer gcc compilers, C did not understand what the bool data type meant, which is something that magma uses. Thus, I could not build without concluding this .h file.